### PR TITLE
Change order of "Tag omission in text/html:" to match WHATWG HTML Standard

### DIFF
--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -5489,9 +5489,7 @@
     <dd>Any <code>aria-*</code> attributes
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
-    <dd>
-    Uses <code>HTMLElement</code>
-    </dd>
+    <dd>Uses <code>HTMLElement</code></dd>
   </dl>
 
   The <{main}> element <a>represents</a> the main content of the body of a document or application.
@@ -7375,9 +7373,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd>None.</dd>
-    <dt>
-      <a>Contexts in which this element can be used</a>:
-      </dt>
+    <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>
       As a child of a <code>ruby</code> or <{rtc}> element, either immediately before or
       immediately after an <code>rt</code> or <{rtc}> element, but not between
@@ -44159,7 +44155,8 @@ fur
           attribute DOMString label;
         };
       </pre>
-  </dd></dl>
+    </dd>
+  </dl>
 
   The <{menu}> element represents a list of commands.
 

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -6168,7 +6168,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd><a>Phrasing content</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dt><a>Tag omission in text/html</a></dt>
+    <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
@@ -14684,7 +14684,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>controls</code> - Show user agent controls</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a></dt>
+    <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>.</dd>
@@ -15020,7 +15020,7 @@ zero or more <{track}> elements, then
     <dd><code>loop</code> - Whether to loop the <a>media resource</a></dd>
     <dd><code>muted</code> - Whether to mute the <a>media resource</a> by default</dd>
     <dd><code>controls</code> - Show user agent controls</dd>
-    <dt><a>Tag omission in text/html</a></dt>
+    <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>.</dd>

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -23,9 +23,6 @@
     <dd>Wherever a subdocument fragment is allowed in a compound document.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>A <{head}> element followed by a <{body}> element.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>manifest</code> — <a>Application cache manifest</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       An <{html}> element's <a>start tag</a> can be omitted if the first thing inside the
@@ -35,6 +32,9 @@
       An <{html}> element's <a>end tag</a> can be omitted if the <{html}> element
       is not immediately followed by a <a>comment</a>.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
+    <dd><code>manifest</code> — <a>Application cache manifest</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -112,8 +112,6 @@
       Otherwise: One or more elements of <a>metadata content</a>, of which exactly one is a
       <a element for="html"><code>title</code></a> element and no more than one is a <{base}> element.
     </dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{head}> element's <a>start tag</a> may be omitted if the element is empty, or if
@@ -123,6 +121,8 @@
       A <{head}> element's <a>end tag</a> may be omitted if the <{head}> element
       is not immediately followed by a <a>space character</a> or a <a>comment</a>.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -186,10 +186,10 @@
     <dd>In a <{head}> element containing no other <a element for="html"><code>title</code></a> elements.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Text</a> that is not <a>inter-element whitespace</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -275,6 +275,8 @@
     <dd>In a <{head}> element containing no other <{base}> elements.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No end tag.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> — <a>Document base URL</a></dd>
@@ -282,8 +284,6 @@
       <code>target</code> — Default <a>browsing context</a> for <a>hyperlink</a> <a>navigation</a>
       and [[#forms-form-submission]]
     </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No end tag.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -413,6 +413,8 @@
     </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> — Address of the <a>hyperlink</a></dd>
@@ -429,8 +431,6 @@
       Also, the <code>title</code> attribute has special semantics on this element:  Title of the
       link; alternative style sheet set name.
     </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a><code>link</code></a> (default - <a><em>do not set</em></a>).</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -803,14 +803,14 @@
     </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>name</code> — Metadata name</dd>
     <dd><code>http-equiv</code> — Pragma directive</dd>
     <dd><code>content</code> — Value of the element</dd>
     <dd><code>charset</code> — <a>Character encoding declaration</a></dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -1483,6 +1483,8 @@
       Depends on the value of the <code>type</code> attribute, but must match requirements described
       in prose below.
     </dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>media</code> — Applicable media</dd>
@@ -1495,8 +1497,6 @@
       Also, the <code>title</code> attribute has special semantics on this element: Alternative
       style sheet set name.
     </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -1760,6 +1760,17 @@
     <dd>As the second element in an <{html}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>
+      A <{body}> element's <a>start tag</a> may be omitted if the element is empty, or if
+      the first thing inside the <{body}> element is not a <a>space character</a> or a
+      <a>comment</a>, except if the first thing inside the <{body}> element is a
+      <{meta}>, <{link}>, <{script}>, <{style}>, or
+      <{template}> element.</dd>
+    <dd>
+      A <{body}> element's <a>end tag</a> may be omitted if the <{body}> element
+      is not immediately followed by a <a>comment</a>.
+    </dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>onafterprint</code></dd>
@@ -1777,17 +1788,6 @@
     <dd><code>onstorage</code></dd>
     <dd><code>onunhandledrejection</code></dd>
     <dd><code>onunload</code></dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>
-      A <{body}> element's <a>start tag</a> may be omitted if the element is empty, or if
-      the first thing inside the <{body}> element is not a <a>space character</a> or a
-      <a>comment</a>, except if the first thing inside the <{body}> element is a
-      <{meta}>, <{link}>, <{script}>, <{style}>, or
-      <{template}> element.</dd>
-    <dd>
-      A <{body}> element's <a>end tag</a> may be omitted if the <{body}> element
-      is not immediately followed by a <a>comment</a>.
-    </dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>document</code></a> role (default - <a><em>do not set</em></a>),
@@ -1876,10 +1876,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>article</code></a> (default - <a><em>do not set</em></a>),
@@ -2000,10 +2000,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>region</code></a> role (default - <a><em>do not set</em></a>),
@@ -2179,10 +2179,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no <{main}> element descendants.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>navigation</code></a> role (default - <a><em>do not set</em></a>) or
@@ -2378,10 +2378,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no <{main}> element descendants.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>complementary</code></a> role (default - <a><em>do not set</em></a>),
@@ -2539,10 +2539,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>heading</code></a> role (default - <a><em>do not set</em></a>),
@@ -2651,10 +2651,10 @@
       <a>Flow content</a>, but with no <{header}>, <{footer}>, or
       <{main}> element descendants.
     </dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>banner</code></a> role (default - <a><em>do not set</em></a>) or
@@ -2765,10 +2765,10 @@
       <a>Flow content</a>, but with no <{header}>, <{footer}>, or
       <{main}> element descendants.
     </dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>contentinfo</code></a> role (default - <a><em>do not set</em></a>) or
@@ -2923,10 +2923,10 @@
     content</a> descendants, no <a>sectioning content</a>
     descendants, and no <{header}>, <{footer}>, or
     <{address}> element descendants.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>contentinfo</code></a> role.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -3894,8 +3894,6 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{p}> element's <a>end tag</a> may be omitted if the <{p}> element is
@@ -3907,6 +3905,8 @@
       <a>HTML element</a> that is not an <{a}>, <{audio}>, <{del}>, <{ins}>, <{map}>, <{noscript}>,
       or <{video}> element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -4058,10 +4058,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>No <a>end tag</a>.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>separator</code></a> (default - <a><em>do not set</em></a>) or
@@ -4167,10 +4167,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -4281,11 +4281,11 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>cite</code> - Link to the source of the quotation.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -4571,13 +4571,13 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>li</code> and <a>script-supporting elements</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>reversed</code> - Number the list backwards.</dd>
     <dd><code>start</code> - <a>Ordinal value</a> of the first item </dd>
     <dd><code>type</code> - Kind of list marker.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>list</code></a> role (default - <a><em>do not set</em></a>),
@@ -4787,10 +4787,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>li</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>list</code></a> role (default - <a><em>do not set</em></a>),
@@ -4860,17 +4860,17 @@
     </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd>
-      If the element is a child of an <{ol}> element: <code>value</code> -  Ordinal value
-      of the list item
-    </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       An <{li}> element's <a>end tag</a> may be omitted if the <{li}> element is
       immediately followed by another <{li}> element or if there is no more content in the
       parent element.
+    </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
+    <dd>
+      If the element is a child of an <{ol}> element: <code>value</code> -  Ordinal value
+      of the list item
     </dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
@@ -4978,10 +4978,10 @@
       Zero or more groups each consisting of one or more <{dt}> elements followed by one or
       more <{dd}> elements, optionally intermixed with <a>script-supporting elements</a>.
     </dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5136,13 +5136,13 @@
       <a>Flow content</a>, but with no <{header}>, <{footer}>,
       <a>sectioning content</a>, or <a>heading content</a> descendants.
     </dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{dt}> element's <a>end tag</a> may be omitted if the <{dt}> element is
       immediately followed by another <{dt}> element or a <{dd}> element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5190,14 +5190,14 @@
     <dd>After <code>dt</code> or <{dd}> elements inside <{dl}> elements.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{dd}> element's <a>end tag</a> may be omitted if the <{dd}> element is
       immediately followed by another <{dd}> element or a <{dt}> element, or if
       there is no more content in the parent element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5244,10 +5244,10 @@
     <dd>Either: One <{figcaption}> element followed by <a>flow content</a>.</dd>
     <dd>Or: <a>Flow content</a> followed by one <{figcaption}> element.</dd>
     <dd>Or: <a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5448,10 +5448,10 @@
     <dd>As the first or last child of a <{figure}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5475,10 +5475,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>main</code></a> role (default - <a><em>do not set</em></a>) or
@@ -5626,10 +5626,10 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5699,6 +5699,8 @@
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>, but there must be no <a>interactive content</a> or <{a}> element descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> - Address of the <a>hyperlink</a></dd>
@@ -5716,8 +5718,6 @@
     </dd>
     <dd><code>hreflang</code> - Language of the linked resource</dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>
       <a value for="role" spec="aria"><code>link</code></a> (default - <a><em>do not set</em></a>), <a value for="role" spec="aria"><code>button</code></a>,
@@ -5895,10 +5895,10 @@
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -5975,10 +5975,10 @@
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6072,10 +6072,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6164,10 +6164,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6207,10 +6207,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6360,13 +6360,13 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>
       <code>cite</code> - Link to the source of the quotation or more information about the edit
     </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6464,11 +6464,11 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, but there must be no <{dfn}> element descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>Also, the <code>title</code> attribute has special semantics on this element.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6536,11 +6536,11 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>Also, the <code>title</code> attribute has special semantics on this element.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -6667,10 +6667,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>See prose.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7197,14 +7197,14 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>As a child of a <{ruby}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       An <{rb}> element's <a>end tag</a> may be omitted if the <{rb}> element is
       immediately followed by an <{rb}>, <{rt}>, <code>rtc</code> or
       <{rp}> element, or if there is no more content in the parent element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7233,14 +7233,14 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>As a child of a <code>ruby</code> or of an <{rtc}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       An <{rt}> element's <a>end tag</a> may be omitted if the <{rt}> element is
       immediately followed by an <{rb}>, <{rt}>, <code>rtc</code> or
       <{rp}> element, or if there is no more content in the parent element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7271,14 +7271,14 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>As a child of a <{ruby}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, <{rt}>, or <{rp}> elements.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       An <{rtc}> element's <a>end tag</a> may be omitted if the <{rtc}> element is
       immediately followed by an <code>rb</code> or <{rtc}> element, or if there is no more
       content in the parent element.
     </dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7381,13 +7381,13 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>An <{rp}> element's <a>end tag</a> may be omitted
     if the <{rp}> element is immediately followed by an <{rb}>, <{rt}>,
     <code>rtc</code> or <{rp}> element, or if there is no more content in the parent
     element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7468,11 +7468,11 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>value</code> - Machine-readable value </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7550,11 +7550,11 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <dt><a>Content model</a>:</dt>
     <dd>If the element has a <code>datetime</code> attribute: <a>Text</a>.</dd>
     <dd>Otherwise: <a>phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>datetime</code> - Machine-readable value</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7922,10 +7922,10 @@ Your next meeting is at &lt;time datetime="2011-11-12T15:00-08:00"&gt;3pm&lt;/ti
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -7994,10 +7994,10 @@ end.&lt;/code&gt;&lt;/pre&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8075,10 +8075,10 @@ looked pleased.&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8138,10 +8138,10 @@ Linux demo 2.6.10-grsec+gg3+e+fhs6b+nfs+gr0501+++p3+c4a+gr2b-reslog-v6.189 #1 SM
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8202,10 +8202,10 @@ Linux demo 2.6.10-grsec+gg3+e+fhs6b+nfs+gr0501+++p3+c4a+gr2b-reslog-v6.189 #1 SM
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8275,10 +8275,10 @@ f(&lt;var&gt;x&lt;/var&gt;, &lt;var&gt;n&lt;/var&gt;) = log&lt;sub&gt;4&lt;/sub&
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8344,10 +8344,10 @@ her—&lt;/i&gt;&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8439,10 +8439,10 @@ brighter. A &lt;b&gt;rat&lt;/b&gt; scurries past the corner wall.&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8482,10 +8482,10 @@ brighter. A &lt;b&gt;rat&lt;/b&gt; scurries past the corner wall.&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8641,11 +8641,11 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>Also, the <code>dir</code> global attribute has special semantics on this element.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8712,11 +8712,11 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>Also, the <code>dir</code> global attribute has special semantics on this element.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8754,10 +8754,10 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8803,10 +8803,10 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>No <a>end tag</a></dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -8898,10 +8898,10 @@ Sydney&lt;/p&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>No <a>end tag</a></dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -9118,12 +9118,12 @@ document.body.appendChild(wbr);
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>cite</code> - Link to the source of the quotation or more information about the edit </dd>
     <dd><code>datetime</code> - Date and (optionally) time of the change </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -9211,12 +9211,12 @@ document.body.appendChild(wbr);
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>cite</code> - Link to the source of the quotation or more information about the edit </dd>
     <dd><code>datetime</code> - Date and (optionally) time of the change </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -9845,10 +9845,10 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <{source}> elements, followed by one <{img}> element, optionally intermixed with <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -9887,6 +9887,8 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
     <dd>As a child of a <{picture}> element, before the <{img}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Same as for the <{source}> element.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>srcset</code> - Images to use in different situations
@@ -9894,8 +9896,6 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
     <dd><code>sizes</code> - Image sizes between breakpoints</dd>
     <dd><code>media</code> - Applicable media</dd>
     <dd><code>type</code> - Type of embedded resource</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -9988,6 +9988,8 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Nothing</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>alt</code> - Replacement text for use when images are not available </dd>
@@ -10000,8 +10002,6 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
     <dd><code>ismap</code> - Whether the image is a server-side image map</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>presentation</code></a> role only, for an
     <{img}> element whose <code>alt</code> attribute's value is empty (<code>alt=""</code>), otherwise
@@ -12837,6 +12837,8 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Text that conforms to the requirements given in the prose.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
@@ -12848,8 +12850,6 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     contents to use <code>requestFullscreen()</code></dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>,
     <a value for="role" spec="aria"><code>document</code></a>, <a value for="role" spec="aria"><code>img</code></a> or
@@ -13551,6 +13551,8 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
@@ -13558,8 +13560,6 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code>- Vertical dimension</dd>
     <dd>Any other attribute that has no namespace (see prose).</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>,
     <a value for="role" spec="aria"><code>document</code></a> or
@@ -13907,6 +13907,8 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <{param}> elements, then, <a>transparent</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>data</code> - Address of the resource</dd>
@@ -13918,8 +13920,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>, <a value for="role" spec="aria"><code>document</code></a> or <a value for="role" spec="aria"><code>img</code></a> or
     <a value for="role" spec="aria"><code>presentation</code></a>.</dd>
@@ -14565,12 +14565,12 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd>As a child of an <{object}> element, before any <a>flow content</a>.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>name</code> - Name of parameter</dd>
     <dd><code>value</code> - Value of parameter</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -14664,6 +14664,8 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd>If the element does not have a <code>src</code> attribute: zero or
     more <{source}> elements, then zero or more <{track}> elements, then
   <a>transparent</a>, but with no <a href="#media-elements">media element</a> descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
@@ -14680,8 +14682,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>controls</code> - Show user agent controls</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -15003,6 +15003,8 @@ zero or more <{track}> elements, then
     <dd>If the element does not have a <code>src</code> attribute: zero or more <{source}> elements, then
   zero or more <{track}> elements, then
   <a>transparent</a>, but with no <a href="#media-elements">media element</a> descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
@@ -15016,8 +15018,6 @@ zero or more <{track}> elements, then
     <dd><code>loop</code> - Whether to loop the <a>media resource</a></dd>
     <dd><code>muted</code> - Whether to mute the <a>media resource</a> by default</dd>
     <dd><code>controls</code> - Show user agent controls</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>application</code></a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -15107,12 +15107,12 @@ zero or more <{track}> elements, then
   or <{track}> elements.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
     <dd><code>type</code> - Type of embedded resource</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -15272,6 +15272,8 @@ zero or more <{track}> elements, then
     <dd>As a child of a <a href="#media-elements">media element</a>, before any <a>flow content</a>.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>kind</code> - The type of text track</dd>
@@ -15279,8 +15281,6 @@ zero or more <{track}> elements, then
     <dd><code>srclang</code> - Language of the text track</dd>
     <dd><code>label</code> - User-visible label</dd>
     <dd><code>default</code> - Enable the track if no other <a>text track</a> is more suitable</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -22318,11 +22318,11 @@ red:89
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>name</code> - Name of <a>image map</a> to reference from the <code>usemap</code> attribute</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -22429,6 +22429,8 @@ red:89
     <dd>Where <a>phrasing content</a> is expected, but only if there is a <{map}> element ancestor or a <{template}> element ancestor.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>alt</code> - Replacement text for use when images are not available</dd>
@@ -22440,8 +22442,6 @@ red:89
     <dd><code>shape</code> - The kind of shape to be created in an <a>image map</a></dd>
     <dd><code>target</code> - <a>browsing context</a> for <a>hyperlink</a> <a>navigation</a></dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>link</code></a> role (default - <a><em>do not set</em></a>).</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -24956,12 +24956,12 @@ red:89
     either zero or more <{tbody}> elements or one or more <{tr}> elements, followed
     optionally by a <{tfoot}> element, optionally intermixed with one or more
     <a>script-supporting elements</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>border</code></dd>
     <dd><code>sortable</code> - Enables a sorting interface for the table</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -25671,10 +25671,10 @@ side in the right column.&lt;/p&gt;
     <dd>As the first element child of a <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no descendant <{table}> elements.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -25764,15 +25764,15 @@ the cell that corresponds to the values of the two dice.
     <dt><a>Content model</a>:</dt>
     <dd>If the <code>span</code> attribute is present: <a>Nothing</a>.</dd>
     <dd>If the <code>span</code> attribute is absent: Zero or more <code>col</code> and <{template}> elements.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>span</code> - Number of columns spanned by the element</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{colgroup}> element's <a>end tag</a> may be omitted if
     the <{colgroup}> element is not immediately followed by a <a>space character</a> or
     a <a>comment</a>. A <{colgroup}> element's
     <a>end tag</a> may be omitted if the <{colgroup}> element is not
     immediately followed by a <a>space character</a> or a <a>comment</a>.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
+    <dd><code>span</code> - Number of columns spanned by the element</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -25815,12 +25815,12 @@ the cell that corresponds to the values of the two dice.
     a <code>span</code> attribute.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>span</code></dd>
 
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -25864,8 +25864,6 @@ the cell that corresponds to the values of the two dice.
     <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>tr</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{tbody}> element's <a>start tag</a> may be omitted
   if the first thing inside the <{tbody}> element is a <{tr}> element, and if the
@@ -25875,6 +25873,8 @@ the cell that corresponds to the values of the two dice.
   <a>end tag</a> may be omitted if
   the <{tbody}> element is immediately followed by a <code>tbody</code> or
   <{tfoot}> element, or if there is no more content in the parent element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -25994,12 +25994,12 @@ the cell that corresponds to the values of the two dice.
     <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>tr</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{thead}> element's <a>end tag</a> may be omitted if
   the <{thead}> element is immediately followed by a <code>tbody</code> or
   <{tfoot}> element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -26072,12 +26072,12 @@ the cell that corresponds to the values of the two dice.
     <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>tr</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{tfoot}> element's <a>end tag</a> may be omitted if
   the <{tfoot}> element is immediately followed by a <{tbody}> element, or if
   there is no more content in the parent element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -26114,12 +26114,12 @@ the cell that corresponds to the values of the two dice.
     are children of the <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <{td}>, <{th}>, and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{tr}> element's <a>end tag</a> may be omitted if the
   <{tr}> element is immediately followed by another <{tr}> element, or if there is
   no more content in the parent element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -26268,15 +26268,15 @@ the cell that corresponds to the values of the two dice.
     <dd>As a child of a <{tr}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>A <{td}> element's <a>end tag</a> may be omitted if the
+  <{td}> element is immediately followed by a <code>td</code> or <{th}> element,
+  or if there is no more content in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>colspan</code> - Number of columns that the cell is to span</dd>
     <dd><code>rowspan</code> - Number of rows that the cell is to span</dd>
     <dd><code>headers</code> - The header cells for this cell</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>A <{td}> element's <a>end tag</a> may be omitted if the
-  <{td}> element is immediately followed by a <code>td</code> or <{th}> element,
-  or if there is no more content in the parent element.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -26320,6 +26320,10 @@ the cell that corresponds to the values of the two dice.
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no <{header}>, <{footer}>, <a>sectioning content</a>, or <a>heading content</a> descendants, and if the <{th}> element is a <a>sorting interface <code>th</code> element</a>, no <a>interactive content</a> descendants.</dd>
 
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>A <{th}> element's <a>end tag</a> may be omitted if the
+  <{th}> element is immediately followed by a <code>td</code> or <{th}> element,
+  or if there is no more content in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>colspan</code> - Number of columns that the cell is to span</dd>
@@ -26330,10 +26334,6 @@ the cell that corresponds to the values of the two dice.
     referencing the cell in other contexts</dd>
     <dd><code>sorted</code> - <a>Column sort direction</a> and
     <a>ordinality</a></dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>A <{th}> element's <a>end tag</a> may be omitted if the
-  <{th}> element is immediately followed by a <code>td</code> or <{th}> element,
-  or if there is no more content in the parent element.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -29732,6 +29732,8 @@ the cell that corresponds to the values of the two dice.
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no <{form}> element descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>accept-charset</code> - Character encodings to use for [[#forms-form-submission]]</dd>
@@ -29742,8 +29744,6 @@ the cell that corresponds to the values of the two dice.
     <dd><code>name</code> -  Name of form to use in the <code>document.forms</code> API</dd>
     <dd><code>novalidate</code> - Bypass form control validation for [[#forms-form-submission]]</dd>
     <dd><code>target</code> - <a>browsing context</a> for [[#forms-form-submission]]</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -30114,12 +30114,12 @@ the cell that corresponds to the values of the two dice.
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, but with no descendant <a>labelable elements</a> unless it is the element's <a>labeled control</a>, and no descendant <{label}> elements.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissable</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>for</code> - Associate the label with form control</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissable</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -30290,6 +30290,8 @@ the cell that corresponds to the values of the two dice.
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>accept</code> - Hint for expected file type in <a element-state for="input">file upload controls</a></dd>
@@ -30326,8 +30328,6 @@ the cell that corresponds to the values of the two dice.
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd>Also, the <code>title</code> attribute has special semantics on this element
     when used in conjunction with the <code>pattern</code> attribute.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>Depends upon <a>state of the <code>type</code> attribute</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -36568,6 +36568,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, but there must be no <a>interactive content</a> descendant.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>autofocus</code> - Automatically focus the form control when the page is loaded</dd>
@@ -36582,8 +36584,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><code>name</code> - Name of form control to use for [[#forms-form-submission]] and in the <code>form.elements</code> API </dd>
     <dd><code>type</code> - Type of button</dd>
     <dd><code>value</code> - Value to be used for [[#forms-form-submission]]</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>button</code></a>
     (default - <a><em>do not set</em></a>),
@@ -36805,6 +36805,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <{option}>, <{optgroup}>, and <a>script-supporting elements</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>autofocus</code> - Automatically focus the form control when the page is loaded</dd>
@@ -36814,8 +36816,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><code>name</code> - Name of form control to use for [[#forms-form-submission]] and in the <code>form.elements</code> API </dd>
     <dd><code>required</code> - Whether the control is required for [[#forms-form-submission]]</dd>
     <dd><code>size</code> - Size of the control</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>listbox</code></a>
     (default - <a><em>do not set</em></a>) or
@@ -37294,10 +37294,10 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt><a>Content model</a>:</dt>
     <dd>Either: <a>phrasing content</a>.</dd>
     <dd>Or: Zero or more <code>option</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>listbox</code></a>
     (default - <a><em>do not set</em></a>).</dd>
@@ -37399,15 +37399,15 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>As a child of a <{select}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>option</code> and <a>script-supporting elements</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>disabled</code> - Whether the form control is disabled</dd>
-    <dd><code>label</code> - User-visible label</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>An <{optgroup}> element's <a>end tag</a> may be omitted
     if the <{optgroup}> element  is
     immediately followed by another <{optgroup}> element, or if  there is no more content in
     the parent element.</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
+    <dd><code>disabled</code> - Whether the form control is disabled</dd>
+    <dd><code>label</code> - User-visible label</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -37501,17 +37501,17 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>If the element has a <code>label</code> attribute and a <code>value</code> attribute: <a>Nothing</a>.</dd>
     <dd>If the element has a <code>label</code> attribute but no <code>value</code> attribute: <a>Text</a>.</dd>
     <dd>If the element has no <code>label</code> attribute: <a>Text</a> that is not <a>inter-element whitespace</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>An <{option}> element's <a>end tag</a> may be omitted if
+    the <{option}> element is immediately followed by another <{option}> element, or
+    if it is immediately followed by an <{optgroup}> element, or if there is no more content
+    in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>disabled</code> - Whether the form control is disabled</dd>
     <dd><code>label</code> - User-visible label</dd>
     <dd><code>selected</code> - Whether the option is selected by default</dd>
     <dd><code>value</code> - Value to be used for [[#forms-form-submission]]</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>An <{option}> element's <a>end tag</a> may be omitted if
-    the <{option}> element is immediately followed by another <{option}> element, or
-    if it is immediately followed by an <{optgroup}> element, or if there is no more content
-    in the parent element.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>option</code></a>
     (default - <a><em>do not set</em></a>),
@@ -37744,6 +37744,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Text</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>autocomplete</code> - - Hint for form autofill feature</dd>
@@ -37761,8 +37763,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><code>required</code> - Whether the control is required for [[#forms-form-submission]]</dd>
     <dd><code>rows</code> - Number of lines to show</dd>
     <dd><code>wrap</code> - How the value of the form control is to be wrapped for [[#forms-form-submission]]</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>textbox</code></a>
     (default - <a><em>do not set</em></a>).</dd>
@@ -38198,6 +38198,8 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>autofocus</code> - Automatically focus the form control when the page is loaded</dd>
@@ -38206,8 +38208,6 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>keytype</code> - The type of cryptographic key to generate</dd>
     <dd><code>name</code> - Name of form control to use for [[#forms-form-submission]] and in the <code>form.elements</code> API </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -38475,13 +38475,13 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>for</code> - Specifies controls from which the output was calculated</dd>
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>name</code> - Name of form control to use for [[#forms-form-submission]] and in the <code>form.elements</code> API   </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>status</code></a>
     (default - <a><em>do not set</em></a>), <a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
@@ -38656,12 +38656,12 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, but there must be no <{progress}> element descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>value</code> - Current value of the element</dd>
     <dd><code>max</code> - Upper bound of range</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>progressbar</code></a>
     (default - <a><em>do not set</em></a>).</dd>
@@ -38820,6 +38820,8 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>, but there must be no <{meter}> element descendants.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>value</code> - Current value of the element</dd>
@@ -38828,8 +38830,6 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd><code>low</code> - High limit of low range</dd>
     <dd><code>high</code> - Low limit of high range</dd>
     <dd><code>optimum</code> - Optimum value in gauge</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -39212,13 +39212,13 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>Optionally a <{legend}> element, followed by <a>flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>disabled</code> - Whether the form control is disabled</dd>
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>name</code> - Name of form control to use for [[#forms-form-submission]] and in the <code>form.elements</code> API  </dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>group</code></a>
     (default - <a><em>do not set</em></a>)
@@ -39404,10 +39404,10 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <dd>As the first child of a <{fieldset}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Phrasing content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -43936,11 +43936,11 @@ fur
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>One <{summary}> element followed by <a>flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>open</code> - Whether the details are visible</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role</a> that supports
     <code>aria-expanded</code>.</dd>
@@ -44097,10 +44097,10 @@ fur
     <dt><a>Content model</a>:</dt>
     <dd>Either: <a>phrasing content</a>.</dd>
     <dd>Or: one element of <a>heading content</a>.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>button</code></a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -44127,12 +44127,12 @@ fur
     <dt><a>Content model</a>:</dt>
     <dd>If the element's <code>type</code> attribute is in the <a state for="menu">toolbar</a> state: either zero or more <code>li</code> and <a>script-supporting elements</a>, or, <a>flow content</a>.</dd>
     <dd>If the element's <code>type</code> attribute is in the <a state for="menu">popup menu</a> state: in any order, zero or more <{menuitem}> elements, zero or more <{hr}> elements, zero or more <{menu}> elements whose <code>type</code> attributes are in the <a state for="menu">popup menu</a> state, and zero or more <a>script-supporting elements</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>type</code> - Type of menu</dd>
     <dd><code>label</code> - User-visible label</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>menu</code></a>
     (default - <a><em>do not set</em></a>),
@@ -44354,6 +44354,8 @@ fur
     <dd>As a child of a <{menu}> element whose <code>type</code> attribute is in the <a state for="menu">popup menu</a> state.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>No <a>end tag</a>.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>type</code> - Type of command</dd>
@@ -44364,8 +44366,6 @@ fur
     <dd><code>radiogroup</code> Name of group of commands to treat as a radio button group</dd>
     <dd><code>default</code> - Mark the command as being a default command</dd>
     <dd>Also, the <code>title</code> attribute has special semantics on this element.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a>.</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>menuitem</code></a>
     (default - <a><em>do not set</em></a>).</dd>
@@ -44991,11 +44991,11 @@ fur
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>open</code> - Whether the dialog box is showing</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role" spec="aria"><code>dialog</code></a>
     (default - <a><em>do not set</em></a>),
@@ -45574,6 +45574,8 @@ Canonical Order: per grammar
     attribute, the element must be either empty or contain only
     <a>script documentation</a> that also matches <a>script
     content restrictions</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>src</code> - Address of the resource</dd>
@@ -45582,8 +45584,6 @@ Canonical Order: per grammar
     <dd><code>async</code> - Execute script <a>in parallel</a></dd>
     <dd><code>defer</code> - Defer script execution</dd>
     <dd><code>crossorigin</code> - How the element handles crossorigin requests</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -46723,10 +46723,10 @@ o............A....e
     <dd>When <a>scripting is disabled</a>, in a <{head}> element: in any order, zero or more <{link}> elements, zero or more <{style}> elements, and zero or more <{meta}> elements.</dd>
     <dd>When <a>scripting is disabled</a>, not in a <{head}> element: <a>transparent</a>, but there must be no <{noscript}> element descendants.</dd>
     <dd>Otherwise: text that conforms to the requirements given in the prose.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -46920,10 +46920,10 @@ o............A....e
     <dd>Or: The content model of <{select}> elements.</dd>
     <dd>Or: The content model of <{details}> elements.</dd>
     <dd>Or: The content model of <{menu}> elements whose <code>type</code> attribute is in the <a state for="menu">popup menu</a> state.</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
+    <dt><a>Content attributes</a>:</dt>
+    <dd><a>Global attributes</a></dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
@@ -47182,12 +47182,12 @@ o............A....e
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
+    <dt><a>Tag omission in text/html</a>:</dt>
+    <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>


### PR DESCRIPTION
I would like to know the non-editorial differences between two specifications. However the editorial differences make comparison of the two specifications more difficult (at least for me). To reduce editorial differences between two specifications, I would like to change order of "Tag omission in text/html".

Currently, the order of "Tag omission in text/html:" is different between W3C HTML 5.1 and WHATWG HTML Standard. W3C HTML 5.1 places it after "Content attributes:" while WHATWG HTML Standard places it immediately after "Content model:" (before "Content attributes:"). 

Example:
- [The html element in W3C HTML 5.1](http://w3c.github.io/html/single-page.html#the-html-element)
- [The html element in WHATWG HTML Standard](https://html.spec.whatwg.org/multipage/semantics.html#the-html-element)

I think that WHATWG HTML Standard's order makes sense for W3C HTML 5.1 because the information of HTML attributes will be followed by information of ARIA attributes.

---

In this PR, I moved "Tag omission in text/html: " immediately after "Content model:" (before "Content attributes:") using [a script](https://gist.github.com/takenspc/dcdf0825b089176ea7ea).

In the 1st and 2nd commits, I did minor editorial cleanup to prepare reordering.
In the 3rd commit, I changed order of  "Tag omission in text/html:".
In the 4th commit, I regenerated "single-page.html".

---

In the 4th commit, `bikeshed spec` (without -f ) didn't generate single-page.html because HTML 5.1 references [DOMSettableTokenList which was recently removed from the DOM Standard](https://github.com/whatwg/dom/commit/07e9fc014ba54a185cb8c62016f088fd9181be6f). The error message from bikeshed is following:

> FATAL ERROR: No 'idl' refs found for 'DOMSettableTokenList'.

Thus I ran `bikeshed -f spec` to generated single-page.html. Although bikeshed generates unintended diffs (syntax highlighting and references), I confirmed that reordering was applied to single-page.html
