### PR TITLE
Replace 'parsed URL' with 'URL record'

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -2878,7 +2878,7 @@
 
     For the purposes of the comparisons in the above substeps, the <a spec="url">path</a> and <a spec="url">query</a> components
     can only be the same if the <a spec="url">scheme</a> component of both
-    <a>parsed URLs</a> are <a>relative schemes</a>.
+    <a>resulting parsed URLs</a> are <a>relative schemes</a>.
 
     </li>
 
@@ -3806,7 +3806,7 @@
     being navigated; if all the components of the resulting <a>parsed
     URLs</a>, ignoring any <a>fragment</a> components, are
     identical, and the new resource is to be fetched using <code>GET</code>, and the
-    <a>parsed URL</a> of the new resource has a <a>fragment</a> component that is not null (even if it is empty),
+    <a>URL record</a> of the new resource has a <a>fragment</a> component that is not null (even if it is empty),
     then <a lt="fragment identifier">navigate to that fragment identifier</a> and abort these
     steps.</li>
 
@@ -6081,7 +6081,7 @@
     after this step will both be slashes, the URL path separator character.)</li>
 
     <li>Apply the <a>URL parser</a> steps to the <var>base URL</var>, so that the
-    components from its <a>parsed URL</a> can be used by the subsequent steps of this
+    components from its <a>URL record</a> can be used by the subsequent steps of this
     algorithm.</li>
 
     <li>Let <var>explicit URLs</var> be an initially empty list of <a>absolute URLs</a> for <a>explicit
@@ -6201,7 +6201,7 @@
       If the <a>resulting parsed URL</a> has a different <a spec="url">scheme</a> component than <var>base URL</var> (the
       manifest's URL), then jump back to the step labeled <i>start of line</i>.
 
-      Let <var>new URL</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the resulting <a>parsed
+      Let <var>new URL</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the <a>resulting parsed
       URL</a>, with the <i>exclude fragment flag</i> set.
 
       Add <var>new URL</var> to the <var>explicit URLs</var>.
@@ -6230,11 +6230,11 @@
       If <var>manifest path</var> is not a <a>prefix match</a> for <var>part one
       path</var>, then jump back to the step labeled <i>start of line</i>.
 
-      Let <var>part one</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the first resulting
-      <a>parsed URL</a>, with the <i>exclude fragment flag</i> set.
+      Let <var>part one</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the first <a>resulting
+      parsed URL</a>, with the <i>exclude fragment flag</i> set.
 
-      Let <var>part two</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the second resulting
-      <a>parsed URL</a>, with the <i>exclude fragment flag</i> set.
+      Let <var>part two</var> be the result of applying the <a spec="url">URL serializer</a> algorithm to the second <a>resulting
+      parsed URL</a>, with the <i>exclude fragment flag</i> set.
 
       If <var>part one</var> is already in the <var>fallback URLs</var> mapping
       as a <a>fallback namespace</a>, then jump back to
@@ -6567,11 +6567,11 @@
 
       Otherwise, associate the <code>Document</code> for this entry with <var>cache</var>; store the resource for this entry in <var>cache</var>, if it
       isn't already there, and categorize its entry as a <a>master entry</a>. If applying the <a>URL parser</a>
-      algorithm to the resource's <a for="url">URL</a> results in a <a>parsed URL</a> that has a
+      algorithm to the resource's <a for="url">URL</a> results in a <a>resulting parsed URL</a> that has a
       non-null <a>fragment</a> component, the <a for="url">URL</a>
       used for the entry in <var>cache</var> must instead be the <a>absolute URL</a>
       obtained from applying the <a spec="url">URL serializer</a>
-      algorithm to the <a>parsed URL</a> with the <i>exclude fragment flag</i> set
+      algorithm to the <a>resulting parsed URL</a> with the <i>exclude fragment flag</i> set
       (application caches never include fragment identifiers).
 
       </li>
@@ -7125,7 +7125,7 @@
 
     <li>If the resource is not to be fetched using the GET method, or if applying the <a>URL
     parser</a> algorithm to both its <a for="url">URL</a> and the <a>application cache</a>'s
-    <a>manifest</a>'s URL results in two <a>parsed URLs</a> with different <a spec="url">scheme</a> components,
+    <a>manifest</a>'s URL results in two <a>URL records</a> with different <a spec="url">scheme</a> components,
     then fetch the resource normally and abort these steps.</li>
 
     <li>If the resource's URL is a <a>master entry</a>,

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -636,16 +636,16 @@
         * <a spec="url">path start state</a>
         * <a spec="url">query state</a>
         * <a spec="url">fragment state</a>
-      * <a>Parsed URL</a>
-      * The <a spec="url">scheme</a> component of a <a>parsed URL</a>
-      * The <a spec="url">scheme data</a> component of a <a>parsed URL</a>
-      * The <a spec="url">username</a> component of a <a>parsed URL</a>
-      * The <a spec="url">password</a> component of a <a>parsed URL</a>
-      * The <a spec="url">host</a> component of a <a>parsed URL</a>
-      * The <a spec="url">port</a> component of a <a>parsed URL</a>
-      * The <a spec="url">path</a> component of a <a>parsed URL</a>
-      * The <a spec="url">query</a> component of a <a>parsed URL</a>
-      * The <a for="urlsyntax" spec="url">fragment</a> component of a <a>parsed URL</a>
+      * <a>URL record</a>
+      * The <a spec="url">scheme</a> component of a <a>URL record</a>
+      * The <a spec="url">scheme data</a> component of a <a>URL record</a>
+      * The <a spec="url">username</a> component of a <a>URL record</a>
+      * The <a spec="url">password</a> component of a <a>URL record</a>
+      * The <a spec="url">host</a> component of a <a>URL record</a>
+      * The <a spec="url">port</a> component of a <a>URL record</a>
+      * The <a spec="url">path</a> component of a <a>URL record</a>
+      * The <a spec="url">query</a> component of a <a>URL record</a>
+      * The <a for="urlsyntax" spec="url">fragment</a> component of a <a>URL record</a>
       * <a>non-relative flag</a>
       * <a for="url">Parse errors</a> from the <a>URL parser</a>
       * The <a spec="url">URL serializer</a>

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -13709,7 +13709,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
           <li>
 
           Otherwise, if applying the <a>URL parser</a> algorithm to the <a for="url">URL</a> of
-          the specified resource (after any redirects) results in a <a>parsed URL</a> whose
+          the specified resource (after any redirects) results in a <a>URL record</a> whose
           <a>path</a> component matches a pattern that a
           <a>plugin</a> supports, then the content's type is the type that the plugin can handle.
 
@@ -14285,7 +14285,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
         <li>
 
         If applying the <a>URL parser</a> algorithm to the <a for="url">URL</a> of the
-        specified resource (after any redirects) results in a <a>parsed URL</a> whose <a>path</a> component matches a pattern that a <a>plugin</a>
+        specified resource (after any redirects) results in a <a>URL record</a> whose <a>path</a> component matches a pattern that a <a>plugin</a>
         supports, then let <var>resource type</var> be the type that the plugin can
         handle.
 


### PR DESCRIPTION
Fixed some to resulting parsed URL.

Fixes
 https://www.w3.org/Bugs/Public/show_bug.cgi?id=26400
See also
 https://www.w3.org/Bugs/Public/show_bug.cgi?id=26402
