### PR TITLE
Fix spelling mistake

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1535,7 +1535,7 @@
 
   Comparing two strings in a <dfn>compatibility caseless</dfn> manner means using the Unicode
   <i>compatibility caseless match</i> operation to compare the two strings, with no
-  language-specific tailoirings. [[!UNICODE]]
+  language-specific tailorings. [[!UNICODE]]
 
   Except where otherwise stated, string comparisons must be performed in a <a>case-sensitive</A>
   manner.


### PR DESCRIPTION
`tailoirings` > `tailorings`
