### PR TITLE
Fix build errors for automatic building

### DIFF
--- a/sections/dom.include
+++ b/sections/dom.include
@@ -773,7 +773,7 @@
       attribute DOMString accessKey;
       readonly attribute DOMString accessKeyLabel;
       attribute boolean draggable;
-      [PutForwards=value] readonly attribute DOMSettableTokenList dropzone;
+      [PutForwards=value] readonly attribute DOMTokenList dropzone;
       attribute HTMLMenuElement? contextMenu;
       attribute boolean spellcheck;
       void forceSpellCheck();

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -870,10 +870,7 @@
       * {{NodeList/item()}} method
       * The terms <a spec="dom" lt="collection">collections</a> and <a spec="dom">represented by the collection</a>
       * {{DOMTokenList}} interface
-      * {{DOMSettableTokenList}} interface
       * {{DOMTokenList}} interface
-      * {{DOMSettableTokenList}} interface
-      * {{DOMSettableTokenList/value|DOMSettableTokenList.value}} attribute
       * {{createDocument()}} method
       * {{createHTMLDocument()}} method
       * {{createElement()}} method
@@ -3791,12 +3788,10 @@
       the Web IDL specification. [[!WEBIDL]]
     </p>
 
-    If a reflecting IDL attribute has the type {{DOMTokenList}} or
-    {{DOMSettableTokenList}}, then on getting it must return a {{DOMTokenList}} or
-    {{DOMSettableTokenList}} object (as appropriate) whose associated element is the
-    element in question and whose associated attribute's local name is the name of the attribute in
-    question. The same {{DOMTokenList}} or {{DOMSettableTokenList}} object must be
-    returned every time for each attribute.
+    If a reflecting IDL attribute has the type {{DOMTokenList}}, then on getting it must return a
+    {{DOMTokenList}} object whose associated element is the element in question and whose associated
+    attribute's local name is the name of the attribute in question. The same {{DOMTokenList}}
+    object must be returned every time for each attribute.
 
     If a reflecting IDL attribute has the type {{HTMLElement}}, or an interface that
     descends from {{HTMLElement}}, then, on getting, it must run the following algorithm

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -450,7 +450,7 @@
           attribute DOMString media;
           attribute DOMString hreflang;
           attribute DOMString type;
-          [PutForwards=value] readonly attribute DOMSettableTokenList sizes;
+          [PutForwards=value] readonly attribute DOMTokenList sizes;
         };
         HTMLLinkElement implements LinkStyle;
       </pre>
@@ -12869,7 +12869,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
           attribute DOMString src;
           attribute DOMString srcdoc;
           attribute DOMString name;
-          [PutForwards=value] readonly attribute DOMSettableTokenList sandbox;
+          [PutForwards=value] readonly attribute DOMTokenList sandbox;
           attribute boolean seamless;
           attribute boolean allowFullscreen;
           attribute DOMString width;
@@ -13513,7 +13513,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   The IDL attributes <dfn attribute for="HTMLIFrameElement"><code>src</code></dfn>, <dfn attribute for="HTMLIFrameElement"><code>srcdoc</code></dfn>, <dfn attribute for="HTMLIFrameElement"><code>name</code></dfn>, <dfn attribute for="HTMLIFrameElement"><code>sandbox</code></dfn>, and <dfn attribute for="HTMLIFrameElement"><code>seamless</code></dfn> must <a>reflect</a> the respective
   content attributes of the same name.
 
-  The <a>supported tokens</a> for <code>sandbox</code>'s <code>DOMSettableTokenList</code> are the
+  The <a>supported tokens</a> for <code>sandbox</code>'s <code>DOMTokenList</code> are the
   allowed values defined in the <code>sandbox</code> attribute and supported by the user agent.
 
   The <dfn attribute for="HTMLIFrameElement"><code>allowFullscreen</code></dfn> IDL attribute
@@ -26534,7 +26534,7 @@ the cell that corresponds to the values of the two dice.
     interface HTMLTableCellElement : HTMLElement {
       attribute unsigned long colSpan;
       attribute unsigned long rowSpan;
-      [PutForwards=value] readonly attribute DOMSettableTokenList headers;
+      [PutForwards=value] readonly attribute DOMTokenList headers;
       readonly attribute long cellIndex;
     };
   </pre>
@@ -38497,7 +38497,7 @@ Daddy"&gt;&lt;/textarea&gt;
     <dd>
       <pre class="idl" data-highlight="webidl" dfn-for="HTMLOutputElement">
         interface HTMLOutputElement : HTMLElement {
-          [PutForwards=value] readonly attribute DOMSettableTokenList htmlFor;
+          [PutForwards=value] readonly attribute DOMTokenList htmlFor;
           readonly attribute HTMLFormElement? form;
           attribute DOMString name;
 

--- a/single-page.bs
+++ b/single-page.bs
@@ -558,6 +558,10 @@ spec:svg; type:interface;
     text:SVGMatrix
 spec:dom-ls; type:interface;
     text: element
+spec:css21; type:property;
+    text:border-collapse
+spec:css21; type:property;
+    text:border-spacing
 </pre>
 
 <pre class="biblio">


### PR DESCRIPTION
- Fixed #61 DOMSettableTokenList to DOMTokenList
- Fixed build warnings after bikeshed update caused duplicate references
