### PR TITLE
Add missing be

### DIFF
--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -1886,7 +1886,7 @@ path: includes/cldr.include
   element is wider than it is tall, the element is expected to be depicted as a horizontal progress
   bar, with the start on the right and the end on the left if the 'direction' property on this
   element has a computed value of ''rtl'', and with the start on the left and the end on the right
-  otherwise. When the element is taller than it is wide, it is expected to depicted as a vertical
+  otherwise. When the element is taller than it is wide, it is expected to be depicted as a vertical
   progress bar, with the lowest value on the bottom. When the element is square, it is expected to
   be depicted as a direction-independent progress widget (e.g. a circular progress ring).
 


### PR DESCRIPTION
Missing `be` in a sentence
