### PR TITLE
Fix syntax highlighting of 10.3.6. Quotes (#47)

### DIFF
--- a/includes/cldr.include
+++ b/includes/cldr.include
@@ -1,4 +1,6 @@
-﻿@namespace url(http://www.w3.org/1999/xhtml);
+﻿<!-- upstream version: https://github.com/whatwg/html-build/blob/master/quotes/out/cldr.inc -->
+<pre highlight="css">
+@namespace url(http://www.w3.org/1999/xhtml);
 
 :root                                                         { quotes: '\201c' '\201d' '\2018' '\2019' } /* “ ” ‘ ’ */
 :root:lang(af),       :not(:lang(af)) &gt; :lang(af)             { quotes: '\201c' '\201d' '\2018' '\2019' } /* “ ” ‘ ’ */
@@ -148,3 +150,4 @@
 :root:lang(zh),       :not(:lang(zh)) &gt; :lang(zh)             { quotes: '\201c' '\201d' '\2018' '\2019' } /* “ ” ‘ ’ */
 :root:lang(zh-Hant),  :not(:lang(zh-Hant)) &gt; :lang(zh-Hant)   { quotes: '\300c' '\300d' '\300e' '\300f' } /* 「 」 『 』 */
 :root:lang(zu),       :not(:lang(zu)) &gt; :lang(zu)             { quotes: '\201c' '\201d' '\2018' '\2019' } /* “ ” ‘ ’ */
+</pre>

--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -584,7 +584,7 @@
   derived from the CLDR file names. The quotes are derived from the <code>delimiter</code>
   blocks, with fallback handled as specified in the CLDR documentation.
 
-<pre highlight="css" class="include">
+<pre class="include">
 path: includes/cldr.include
 </pre>
 


### PR DESCRIPTION
Make syntax highlighting work.
Also, add a comment that points to the upstream version
