### PR TITLE
Fix #52: Wrong bike shed tags ([[url#urls|URLs]])

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -2482,7 +2482,7 @@
     <a>State objects</a> are intended to be used for two main purposes:
     first, storing a preparsed description of the state in the <a for="url">URL</a> so that in the simple
     case an author doesn't have to do the parsing (though one would still need the parsing for
-    handling [[url#urls|URLs]] passed around by users, so it's only a minor
+    handling <a for="url">URLs</a> passed around by users, so it's only a minor
     optimization), and second, so that the author can store state that one wouldn't store in the URL
     because it only applies to the current <code>Document</code> instance and it would have to be
     reconstructed if a new <code>Document</code> were opened.
@@ -2862,7 +2862,7 @@
 
       <li>Compare the <a>resulting parsed URL</a> to the result of applying the <a>URL
       parser</a> algorithm to <a>the document's address</a>. If any component of these two
-      [[url#urls|URLs]] differ other than the <a spec="url">path</a>, <a spec="url">query</a>, and <a>fragment</a> components, then throw a
+      <a for="url">URLs</a> differ other than the <a spec="url">path</a>, <a spec="url">query</a>, and <a>fragment</a> components, then throw a
       <code>SecurityError</code> exception and abort these steps.</li>
 
       <li>If the <a spec="fetch">origin</a> of the <a>resulting absolute URL</a> is not the same as

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -110,7 +110,7 @@
   to be correctly processed. Which resources are considered critical or not is defined by the
   specification that defines the resource's format.
 
-  The term <a scheme lt="data:"><code>data:</code> URL</a> refers to [[url#urls|URLs]] that use the <a scheme><code>data:</code></a>
+  The term <a scheme lt="data:"><code>data:</code> URL</a> refers to <a for="url">URLs</a> that use the <a scheme><code>data:</code></a>
   scheme. [[!RFC2397]]
 
 <h4 id="xml">XML</h4>
@@ -3520,7 +3520,7 @@
     <h4 id="encrypted-http-and-related-security-concerns">Encrypted HTTP and related security concerns</h4>
 
     Anything in this specification that refers to HTTP also applies to HTTP-over-TLS, as represented
-    by [[url#urls|URLs]] representing the <code>https</code> scheme. [[!HTTP]]
+    by <a for="url">URLs</a> representing the <code>https</code> scheme. [[!HTTP]]
 
     <p class="warning">
       User agents should report certificate errors to the user and must either refuse to download
@@ -3683,7 +3683,7 @@
     empty string.
 
     If a reflecting IDL attribute is a <code>DOMString</code> attribute whose content attribute is
-    defined to contain one or more [[url#urls|URLs]], then on getting, the IDL attribute must <a lt="split a string on spaces">split the
+    defined to contain one or more <a for="url">URLs</a>, then on getting, the IDL attribute must <a lt="split a string on spaces">split the
     content attribute on spaces</a> and return the concatenation of <a>resolving</a> each token URL
     to an <a>absolute URL</a> relative to the element, with a single U+0020 SPACE character between
     each URL, ignoring any tokens that did not resolve successfully. If the content attribute is

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -32,7 +32,7 @@
   <{a}> elements in the element's <a>home subtree</a>. If this attribute is present and the
   element has an <{global/id}>, then the attribute's value must be equal to the element's <{global/id}>. In
   earlier versions of the language, this attribute was intended as a way to specify possible targets
-  for fragment identifiers in [[url#urls|URLs]]. The <{global/id}> attribute should be used instead.
+  for fragment identifiers in <a for="url">URLs</a>. The <{global/id}> attribute should be used instead.
 
   Authors should not, but may despite requirements to the contrary elsewhere in this specification,
   specify the <{input/maxlength}> and <{input/size}> attributes on <{input}> elements

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -313,7 +313,7 @@
   potentially surrounded by spaces</a>.
 
   A <{base}> element, if it has an <{base/href}> attribute, must come before any other
-  elements in the tree that have attributes defined as taking [[url#urls|URLs]], except the
+  elements in the tree that have attributes defined as taking <a for="url">URLs</a>, except the
   <{html}> element (its <code>manifest</code> attribute isn't affected by
   <code>xml:base</code> attributes or <{base}> elements).
 
@@ -1071,7 +1071,7 @@
     above, with the "proposed" status.
   </div>
 
-  Metadata names whose values are to be [[url#urls|URLs]] must not be proposed or accepted. Links must be
+  Metadata names whose values are to be <a for="url">URLs</a> must not be proposed or accepted. Links must be
   represented using the <{link}> element, not the <{meta}> element.
 
 <h5 id="pragma-directives">Pragma directives</h5>
@@ -9875,7 +9875,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   and the resource selection algorithm is different.
   As well, the <{picture}> element itself does not display anything;
   it merely provides a context for its contained <{img}> element
-  that enables it to choose from multiple [[url#urls|URLs]].
+  that enables it to choose from multiple <a for="url">URLs</a>.
   </p>
 
 <h4 id="the-source-element-when-used-with-the-picture-element">The <dfn element for="picture" lt="picture source"><code>source</code></dfn> element when used with the <{picture}> element</h4>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -470,7 +470,7 @@
   <a>candidate entry settings object</a>. If the stack is empty, or has no entries labeled as
   such, then there is no <a>entry settings object</a>. It is used to obtain, amongst other
   things, the <a>API base URL</a> to <a>resolve</a> relative
-  [[url#urls|URLs]] used in scripts running in that <a>unit of related
+  <a for="url">URLs</a> used in scripts running in that <a>unit of related
   similar-origin browsing contexts</a>.
 
   The <dfn>incumbent settings object</dfn> is the <a>environment settings object</a> in the


### PR DESCRIPTION
This PR makes the term "URLs" link to the definition of URL Standard as well as the term "URL".

Ref. examples of the term "URL" link to the definition of URL Standard.
http://w3c.github.io/html/browsers.html#state-object
