### PR TITLE
Base accesskeys on preferences, not user keyboard

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -1652,7 +1652,7 @@
   activate it, using the <code>accesskey</code> attribute.
 
   The exact shortcut is determined by the user agent, based on information about the user's
-  keyboard, what keyboard shortcuts already exist on the platform, and what other shortcuts have
+  preferences, what keyboard shortcuts already exist on the platform, and what other shortcuts have
   been specified on the page, using the information provided in the <code>accesskey</code> attribute as a guide.
 
   In order to ensure that a relevant keyboard shortcut is available on a wide variety of input
@@ -1798,8 +1798,8 @@
       <li>If the value is not a string exactly one Unicode code point in length, then skip the
       remainder of these steps for this value.</li>
 
-      <li>If the value does not correspond to a key on the system's keyboard, then skip the
-      remainder of these steps for this value.</li>
+      <li>The user agent may assign a key combination based on stored user preferences as the
+ +      element's <a>assigned access key</a> and then abort these steps.</li>
 
       <li>If the user agent can find a mix of zero or more modifier keys that, combined with the
       key that corresponds to the value given in the attribute, can be used as the access key, then


### PR DESCRIPTION
Because very few browsers (and only old ones nobody has anymore) do
otherwise - see #22 for links to tests. This is to fix #21 again…
