### PR TITLE
Align example dates of time element with WHATWG HTML Standard.

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -1919,7 +1919,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
 
     <dd>
 
-    <pre class="example">&lt;time&gt;2011-11-12&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18&lt;/time&gt;</pre>
 
     </dd>
 
@@ -1945,12 +1945,12 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
 
     <dd>
 
-    <pre class="example">&lt;time&gt;2011-11-12T14:54&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39.929&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39.929&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39.929&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39.929&lt;/time&gt;</pre>
 
     <p class="note">
     Times with dates but without a time zone offset are useful for specifying events
@@ -1989,45 +1989,45 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
 
     <dd>
 
-    <pre class="example">&lt;time&gt;2011-11-12T14:54Z&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39Z&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39.929Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39.929Z&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12T14:54+0000&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39+0000&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39.929+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39.929+0000&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12T14:54+00:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39+00:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T14:54:39.929+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T14:54:39.929+00:00&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12T06:54-0800&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T06:54:39-0800&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T06:54:39.929-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54:39-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54:39.929-0800&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12T06:54-08:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T06:54:39-08:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12T06:54:39.929-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54:39-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18T06:54:39.929-08:00&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12 14:54Z&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39Z&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39.929Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39Z&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39.929Z&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12 14:54+0000&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39+0000&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39.929+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39+0000&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39.929+0000&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12 14:54+00:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39+00:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 14:54:39.929+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39+00:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 14:54:39.929+00:00&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12 06:54-0800&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 06:54:39-0800&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 06:54:39.929-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54:39-0800&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54:39.929-0800&lt;/time&gt;</pre>
 
-    <pre class="example">&lt;time&gt;2011-11-12 06:54-08:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 06:54:39-08:00&lt;/time&gt;</pre>
-    <pre class="example">&lt;time&gt;2011-11-12 06:54:39.929-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54:39-08:00&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-11-18 06:54:39.929-08:00&lt;/time&gt;</pre>
 
     <p class="note">
     Times with dates and a time zone offset are useful for specifying specific
@@ -2045,7 +2045,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
 
     <dd>
 
-    <pre class="example">&lt;time&gt;2011-W46&lt;/time&gt;</pre>
+    <pre class="example">&lt;time&gt;2011-W47&lt;/time&gt;</pre>
 
     </dd>
 
@@ -2208,11 +2208,11 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
   </div>
 
   <div class="example">
-    For example, this element conveys the string "Tuesday" with the additional semantic that the
-    15th of November 2011 is the meaning that corresponds to "Tuesday":
+    For example, this element conveys the string "Friday" with the additional semantic that the
+    18th of November 2011 is the meaning that corresponds to "Friday":
 
     <pre highlight="html">
-Today is &lt;time datetime="2011-11-15"&gt;Tuesday&lt;/time&gt;.
+Today is &lt;time datetime="2011-11-18"&gt;Friday&lt;/time&gt;.
     </pre>
 
   </div>
@@ -2221,7 +2221,7 @@ Today is &lt;time datetime="2011-11-15"&gt;Tuesday&lt;/time&gt;.
     In this example, a specific time in the Pacific Standard Time timezone is specified:
 
     <pre highlight="html">
-Your next meeting is at &lt;time datetime="2011-11-12T15:00-08:00"&gt;3pm&lt;/time&gt;.
+Your next meeting is at &lt;time datetime="2011-11-18T15:00-08:00"&gt;3pm&lt;/time&gt;.
     </pre>
 
   </div>
@@ -3339,7 +3339,7 @@ document.body.appendChild(wbr);
     </td></tr><tr>
       <td><{time}>
       </td><td>Machine-readable equivalent of date- or time-related data
-      </td><td><pre class="example">Available starting on <strong>&lt;time datetime="2011-11-12"&gt;November 12th&lt;/time&gt;</strong>!</pre>
+      </td><td><pre class="example">Available starting on <strong>&lt;time datetime="2011-11-18"&gt;November 18th&lt;/time&gt;</strong>!</pre>
 
     </td></tr><tr>
       <td><{code}>


### PR DESCRIPTION
Currently W3C HTML 5.1 uses two similar dates in time element examples. Most of examples use 2011-11-12 (November 12th, 2011) while one example uses 2011-11-15 (November 15th, 2011).
On the other hand, WHATWG HTML Standard only uses 2011-11-18 (November 18th, 2011).

This PR makes all of examples use 2011-11-18.
