### PR TITLE
longdesc is not obsolete on img

### DIFF
--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -223,9 +223,6 @@
   :: Use <code>img</code> instead of <code>input</code> for image maps.
 
   : <dfn element-attr for="iframe"><code>longdesc</code></dfn> on <{iframe}> elements
-  : <dfn element-attr for="img"><code>longdesc</code></dfn> on <{img}> elements
-  :: Use a regular <{a}> element to link to the description, or (in the case of images) use
-      an <a>image map</a> to provide a link from the image to the image's description.
 
   : <dfn element-attr for="img"><code>lowsrc</code></dfn> on <{img}> elements
   :: Use a progressive JPEG image (given in the <code>src</code> attribute), instead of using two


### PR DESCRIPTION
It's a W3C Recommendation...
