### PR TITLE
Fix focus navigation

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -4728,7 +4728,7 @@
     <li>Run the <a>focusing steps</a> for that element, with the <code>Document</code>'s
     viewport as the <i>fallback target</i>.</li>
 
-    <li>Optionally, move the <a>sequential focus navigation starting point</a> to
+    <li>Move the <a>sequential focus navigation starting point</a> to
     <var>target</var>.
 
   </ol>


### PR DESCRIPTION
It should not be optional to make the current focus move when following
a link.

Note that there are bugs in browsers about how they handle this with
e.g. embedded SVG.

This is https://www.w3.org/Bugs/Public/show_bug.cgi?id=16186 (and
matches a change the wig finally made for the same bug)
