### PR TITLE
Fix wrong nesting of div.impl.

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3492,8 +3492,6 @@ ldh-str       = &lt; as defined in <a>RFC 1034 section 3.5</a> &gt;
 
   <div class="impl">
 
-  <div class="impl">
-
   When an <{input}> element's <code>type</code> attribute is in
   the <a element-state for="input">Date and Time</a> state, the rules in this section
   apply.

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -583,6 +583,8 @@
    <li><a>Update <code>href</code></a>.</li>
   </ol>
 
+  </div>
+
   <div class="impl">
 
 <h4 id="sec-following-hyperlinks">Following hyperlinks</h4>


### PR DESCRIPTION
The div.impl should not contain usual contents because contents of div.impl can be hidden once the developer view is revived.
