### PR TITLE
Align http-equiv="refresh" with WHATWG HTML Standard

### DIFF
--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -1165,8 +1165,8 @@
         24. If <var>quote</var> is not the empty string, and there is a character in <var>url</var>
             equal to <var>quote</var>, then truncate <var>url</var> at that character, so that it
             and all subsequent characters are removed.
-        25. Strip any trailing <a>space characters</a> from the end of <var>url</var>.
-        26. <i>Trim</i>: Strip any trailing <a>space characters</a> from the end of <var>url</var>.
+        25. <i>Trim</i>: Strip any trailing <a>space characters</a> from the end of <var>url</var>.
+        26. Strip any U+0009 CHARACTER TABULATION (tab), U+000A LINE FEED (LF), and U+000D CARRIAGE RETURN (CR) characters from <var>url</var>.
         27. <a>Resolve</a> the <var>url</var> value, relative to the <{meta}> element. If this
             fails, abort these steps.
         28. Otherwise, let <var>parsed url</var> be the <a>resulting parsed URL</a>.


### PR DESCRIPTION
Currently the step 25 and 26 are duplicated.
https://w3c.github.io/html/document-metadata.html#statedef-http-equiv-refresh

On the other hand, the step 25 and 26 of WHATWG HTML Standard seem reasonable.
https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh

This PR changes step 25 and step 26 align with WHATWG HTML Standard.
