### PR TITLE
Removed references to itemprop / microdata

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -403,36 +403,6 @@
       <td><a>Boolean attribute</a></td>
     </tr>
     <tr>
-      <th><code>itemid</code></th>
-      <td><a>HTML elements</a></td>
-      <td>Global identifier for a microdata item</td>
-      <td><a>Valid URL potentially surrounded by spaces</a></td>
-    </tr>
-    <tr>
-      <th><code>itemprop</code></th>
-      <td><a>HTML elements</a></td>
-      <td>Property names of a microdata item</td>
-      <td><a>Unordered set of unique space-separated tokens</a>, <a>case-sensitive</a>, consisting of <a>resulting absolute URL</a>s, defined property names, or text*</td>
-    </tr>
-    <tr>
-      <th><code>itemref</code></th>
-      <td><a>HTML elements</a></td>
-      <td>Referenced elements</td>
-      <td><a>Unordered set of unique space-separated tokens</a>, <a>case-sensitive</a>, consisting of IDs*</td>
-    </tr>
-    <tr>
-      <th><code>itemscope</code></th>
-      <td><a>HTML elements</a></td>
-      <td>Introduces a microdata item</td>
-      <td><a>Boolean attribute</a></td>
-    </tr>
-    <tr>
-      <th><code>itemtype</code></th>
-      <td><a>HTML elements</a></td>
-      <td>Item types of a microdata item</td>
-      <td><a>Unordered set of unique space-separated tokens</a>, <a>case-sensitive</a>, consisting of <a>resulting absolute URL</a>*</td>
-    </tr>
-    <tr>
       <th><code>keytype</code></th>
       <td><{keygen}></td>
       <td>The type of cryptographic key to generate</td>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1042,13 +1042,11 @@
     <li><{kbd}></li>
     <li><{keygen}></li>
     <li><{label}></li>
-    <li><{link}> (if the <code>itemprop</code> attribute is present)</li>
     <li><{main}></li>
     <li><{map}></li>
     <li><{mark}></li>
     <li><{math}></li>
     <li><{menu}></li>
-    <li><{meta}> (if the <code>itemprop</code> attribute is present)</li>
     <li><{meter}></li>
     <li><{nav}></li>
     <li><{noscript}></li>
@@ -1152,11 +1150,9 @@
     <li><{kbd}></li>
     <li><{keygen}></li>
     <li><{label}></li>
-    <li><{link}> (if the <code>itemprop</code> attribute is present)</li>
     <li><{map}></li>
     <li><{mark}></li>
     <li><{math}></li>
-    <li><{meta}> (if the <code>itemprop</code> attribute is present)</li>
     <li><{meter}></li>
     <li><{noscript}></li>
     <li><{object}></li>
@@ -1593,11 +1589,6 @@
   * <code>dropzone</code>
   * <code>hidden</code>
   * <{global/id}>
-  * <code>itemid</code>
-  * <code>itemprop</code>
-  * <code>itemref</code>
-  * <code>itemscope</code>
-  * <code>itemtype</code>
   * <{global/lang}>
   * <code>spellcheck</code>
   * <code>style</code>

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -116,8 +116,6 @@
      </td>
       <td>
         <{area}> (if it is a descendant of a <{map}> element);
-      <{link}> (if the <code>itemprop</code> attribute is present);
-      <{meta}> (if the <code>itemprop</code> attribute is present);
       <{style}> (if the <{style/scoped}> attribute is present)
 
     </td>
@@ -213,9 +211,6 @@
      </td>
       <td>
         <{area}> (if it is a descendant of a  <{map}> element);
-      <{link}> (if the <code>itemprop</code> attribute is present);
-      <{meta}> (if the <code>itemprop</code> attribute is present)
-
     </td>
     </tr>
     <tr>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -311,14 +311,9 @@
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Metadata content</a>.</dd>
-    <dd>If the <code>itemprop</code> attribute is present: <a>flow content</a>.</dd>
-    <dd>If the <code>itemprop</code> attribute is present: <a>phrasing content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>metadata content</a> is expected.</dd>
     <dd>In a <{noscript}> element that is a child of a <{head}> element.</dd>
-    <dd>
-      If the <code>itemprop</code> attribute is present: where <a>phrasing content</a> is expected.
-    </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
@@ -372,14 +367,11 @@
   <span class="impl">If the <{link/href}> attribute is absent, then the element does not define
   a link.</span>
 
-  A <{link}> element must have either a <code>rel</code> attribute or an
-  <code>itemprop</code> attribute, but not both.
+  A <{link}> element must a <code>rel</code> attribute.
 
   <p class="note">
     If the <code>rel</code> attribute is used, the element is restricted to the <code>head</code>
-    element. When used with the <code>itemprop</code> attribute, the element can be used both in the
-    <{head}> element and in the <code>body</code> of the page, subject to the constraints
-    of the microdata model.
+    element.
   </p>
 
   The types of link indicated (the relationships) are given by the value of the
@@ -684,8 +676,6 @@
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Metadata content</a>.</dd>
-    <dd>If the <code>itemprop</code> attribute is present: <a>flow content</a>.</dd>
-    <dd>If the <code>itemprop</code> attribute is present: <a>phrasing content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>
       If the <code>charset</code> attribute is present, or if the element's <code>http-equiv</code>
@@ -702,12 +692,6 @@
     </dd>
     <dd>
       If the <code>name</code> attribute is present: where <a>metadata content</a> is expected.
-    </dd>
-    <dd>
-      If the <code>itemprop</code> attribute is present: where <a>metadata content</a> is expected.
-    </dd>
-    <dd>
-      If the <code>itemprop</code> attribute is present: where <a>phrasing content</a> is expected.
     </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Nothing</a>.</dd>
@@ -744,10 +728,10 @@
   <a>character encoding declaration</a> when an HTML document is serialized to string form (e.g., for
   transmission over the network or for disk storage) with the <code>charset</code> attribute.
 
-  Exactly one of the <code>name</code>, <code>http-equiv</code>, <code>charset</code>,
-  and <code>itemprop</code> attributes must be specified.
+  Exactly one of the <code>name</code>, <code>http-equiv</code>, and <code>charset</code>
+  attributes must be specified.
 
-  If either <code>name</code>, <code>http-equiv</code>, or <code>itemprop</code> is
+  If either <code>name</code> or <code>http-equiv</code> is
   specified, then the <code>content</code> attribute must also be
   specified. Otherwise, it must be omitted.
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3447,8 +3447,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
 
   The <dfn element-attr for="iframe"><code>src</code></dfn> attribute gives the address of a page
   that the <a>nested browsing context</a> is to contain. The attribute, if present, must be a
-  <a>valid non-empty URL potentially surrounded by spaces</a>. If the <code>itemprop</code> is specified on an <{iframe}> element, then the
-  <code>src</code> attribute must also be specified.
+  <a>valid non-empty URL potentially surrounded by spaces</a>. 
 
   The <dfn element-attr for="iframe"><code>srcdoc</code></dfn> attribute gives the content of
   the page that the <a>nested browsing context</a> is to contain. The value of the attribute
@@ -4161,10 +4160,6 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   resource being embedded. The attribute, if present, must contain a <a>valid non-empty URL
   potentially surrounded by spaces</a>.
 
-  If the <code>itemprop</code> attribute is specified on an
-  <{embed}> element, then the <code>src</code> attribute must also
-  be specified.
-
   The <dfn element-attr for="embed"><code>type</code></dfn> attribute, if present, gives the
   <a>MIME type</a> by which the plugin to instantiate is selected. The value must be a
   <a>valid mime type</a>. If both the <code>type</code> attribute and
@@ -4543,9 +4538,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   type of the resource. If present, the attribute must be a <a>valid mime type</a>.
 
   At least one of either the <code>data</code> attribute or the <code>type</code> attribute must be present.
-
-  If the <code>itemprop</code> attribute is specified on an <code>object</code>
-  element, then the <code>data</code> attribute must also be specified.
 
   The <dfn element-attr for="object"><code>typemustmatch</code></dfn> attribute is a
   <a>boolean attribute</a> whose presence indicates that the resource specified by the <code>data</code> attribute is only to be used if the value of the <code>type</code> attribute and the <a>Content-Type</a> of the
@@ -6259,9 +6251,6 @@ zero or more <{track}> elements, then
   The <dfn element-attr for="media"><code>src</code></dfn> content attribute on <a href="#media-elements">media elements</a> gives the address of the media resource (video, audio) to show. The
   attribute, if present, must contain a <a>valid non-empty URL potentially surrounded by
   spaces</a>.
-
-  If the <code>itemprop</code> attribute is specified on the <a href="#media-elements">media element</a>, then the <code>src</code> attribute must also be
-  specified.
 
   The <dfn element-attr for="media"><code>crossorigin</code></dfn> content attribute on
   <a href="#media-elements">media elements</a> is a <a>CORS settings attribute</a>.
@@ -13133,10 +13122,6 @@ red:89
 
   The <code>target</code>, <code>download</code>, <code>rel</code>, <code>hreflang</code>, and
   <code>type</code> attributes must be omitted if the <code>href</code> attribute is not present.
-
-  If the <code>itemprop</code> attribute is specified on an
-  <{area}> element, then the <code>href</code> attribute must
-  also be specified.
 
   <div class="impl">
 

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -531,8 +531,7 @@
 
   <div class="example">
     Here the attribution is given in a <code>footer</code> after the quoted text, and metadata about
-    the reference has been added using the microdata syntax (note it could have equally been
-    marked up using <a>RDFA Lite</a>). [[rdfa-lite]]
+    the reference has been added using the <a>RDFA Lite</a> syntax.  [[rdfa-lite]]
 
     <pre highlight="html">
       &lt;blockquote&gt;
@@ -541,10 +540,10 @@
         and one of the reasons she had separated from her husband was that he had never been
         amorous but had consistently made advances.&lt;/p&gt;
 
-        &lt;footer itemscope itemtype="http://schema.org/Book"&gt;
-          &lt;span itemprop="author"&gt;Heinrich Böll&lt;/span&gt;,
-          &lt;span itemprop="name"&gt;The Lost Honor of Katharina Blum&lt;/span&gt;,
-          &lt;span itemprop="datePublished"&gt;January 1, 1974&lt;/span&gt;
+        &lt;footer typeof="schema:Book"&gt;
+          &lt;span property="schema:author"&gt;Heinrich Böll&lt;/span&gt;,
+          &lt;span property="schema:name"&gt;The Lost Honor of Katharina Blum&lt;/span&gt;,
+          &lt;span property="schema:datePublished"&gt;January 1, 1974&lt;/span&gt;
         &lt;/footer&gt;
       &lt;/blockquote&gt;
     </pre>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -179,17 +179,17 @@
     annotations:
 
     <pre highlight="html">
-      &lt;article itemscope itemtype="http://schema.org/BlogPosting"&gt;
+      &lt;article typeof="schema:BlogPosting"&gt;
         &lt;header&gt;
-          &lt;h2 itemprop="headline"&gt;The Very First Rule of Life&lt;/h2&gt;
-          &lt;p&gt;&lt;time itemprop="datePublished" datetime="2009-10-09"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
-          &lt;link itemprop="url" href="?comments=0"&gt;
+          &lt;h2 property="schema:headline"&gt;The Very First Rule of Life&lt;/h2&gt;
+          &lt;p&gt;&lt;time property="schema:datePublished" datetime="2009-10-09"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
+          &lt;link property="schema:url" href="?comments=0"&gt;
         &lt;/header&gt;
         &lt;p&gt;If there's a microphone anywhere near you, assume it's hot and
         sending whatever you're saying to the world. Seriously.&lt;/p&gt;
         &lt;p&gt;<em>...</em>&lt;/p&gt;
         &lt;footer&gt;
-          &lt;a itemprop="discussionUrl" href="?comments=1"&gt;Show comments...&lt;/a&gt;
+          &lt;a property="schema:discussionUrl" href="?comments=1"&gt;Show comments...&lt;/a&gt;
         &lt;/footer&gt;
       &lt;/article&gt;
     </pre>
@@ -197,34 +197,34 @@
     Here is that same blog post, but showing some of the comments:
 
     <pre highlight="html">
-      &lt;article itemscope itemtype="http://schema.org/BlogPosting"&gt;
+      &lt;article typeof="schema:BlogPosting"&gt;
         &lt;header&gt;
-          &lt;h2 itemprop="headline"&gt;The Very First Rule of Life&lt;/h2&gt;
-          &lt;p&gt;&lt;time itemprop="datePublished" datetime="2009-10-09"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
-          &lt;link itemprop="url" href="?comments=0"&gt;
+          &lt;h2 property="schema:headline"&gt;The Very First Rule of Life&lt;/h2&gt;
+          &lt;p&gt;&lt;time property="schema:datePublished" datetime="2009-10-09"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
+          &lt;link property="schema:url" href="?comments=0"&gt;
         &lt;/header&gt;
         &lt;p&gt;If there's a microphone anywhere near you, assume it's hot and
         sending whatever you're saying to the world. Seriously.&lt;/p&gt;
         &lt;p&gt;<em>...</em>&lt;/p&gt;
         &lt;section&gt;
           &lt;h2&gt;Comments&lt;/h2&gt;
-          &lt;article itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c1"&gt;
-            &lt;link itemprop="url" href="#c1"&gt;
+          &lt;article property="schema:comment" typeof="schema:UserComments" id="c1"&gt;
+            &lt;link property="schema:url" href="#c1"&gt;
             &lt;footer&gt;
-              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
-              &lt;span itemprop="name"&gt;George Washington&lt;/span&gt;
+              &lt;p&gt;Posted by: &lt;span property="schema:creator" typeof="schema:Person"&gt;
+              &lt;span property="schema:name"&gt;George Washington&lt;/span&gt;
               &lt;/span&gt;&lt;/p&gt;
-              &lt;p&gt;&lt;time itemprop="commentTime" datetime="2009-10-10"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
+              &lt;p&gt;&lt;time property="schema:commentTime" datetime="2009-10-10"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
             &lt;/footer&gt;
             &lt;p&gt;Yeah! Especially when talking about your lobbyist friends!&lt;/p&gt;
           &lt;/article&gt;
-          &lt;article itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c2"&gt;
-            &lt;link itemprop="url" href="#c2"&gt;
+          &lt;article property="schema:comment" typeof="schema:UserComments" id="c2"&gt;
+            &lt;link property="schema:url" href="#c2"&gt;
             &lt;footer&gt;
-              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
-              &lt;span itemprop="name"&gt;George Hammond&lt;/span&gt;
+              &lt;p&gt;Posted by: &lt;span property="schema:creator" typeof="schema:Person"&gt;
+              &lt;span property="schema:name"&gt;George Hammond&lt;/span&gt;
               &lt;/span&gt;&lt;/p&gt;
-              &lt;p&gt;&lt;time itemprop="commentTime" datetime="2009-10-10"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;
+              &lt;p&gt;&lt;time property="schema:commentTime" datetime="2009-10-10"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;
             &lt;/footer&gt;
             &lt;p&gt;Hey, you have the same first name as me.&lt;/p&gt;
           &lt;/article&gt;
@@ -522,13 +522,13 @@
     those places is considered a navigation section.
 
     <pre highlight="html">
-      &lt;body itemscope itemtype="http://schema.org/Blog"&gt;
+      &lt;body typeof="schema:Blog"&gt;
         &lt;header&gt;
           &lt;h1&gt;Wake up sheeple!&lt;/h1&gt;
           &lt;p&gt;&lt;a href="news.html"&gt;News&lt;/a&gt; -
           &lt;a href="blog.html"&gt;Blog&lt;/a&gt; -
           &lt;a href="forums.html"&gt;Forums&lt;/a&gt;&lt;/p&gt;
-          &lt;p&gt;Last Modified: &lt;span itemprop="dateModified"&gt;2009-04-01&lt;/span&gt;&lt;/p&gt;
+          &lt;p&gt;Last Modified: &lt;span property="schema:dateModified"&gt;2009-04-01&lt;/span&gt;&lt;/p&gt;
           &lt;nav&gt;
             &lt;h2&gt;Navigation&lt;/h2&gt;
             &lt;ul&gt;
@@ -539,24 +539,24 @@
           &lt;/nav&gt;
         &lt;/header&gt;
         &lt;main&gt;
-          &lt;article itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting"&gt;
+          &lt;article property="schema:blogPosts" typeof="schema:BlogPosting"&gt;
             &lt;header&gt;
-              &lt;h2 itemprop="headline"&gt;My Day at the Beach&lt;/h2&gt;
+              &lt;h2 property="schema:headline"&gt;My Day at the Beach&lt;/h2&gt;
             &lt;/header&gt;
-            &lt;main itemprop="articleBody"&gt;
+            &lt;main property="schema:articleBody"&gt;
               &lt;p&gt;Today I went to the beach and had a lot of fun.&lt;/p&gt;
               <em>...more content...</em>
             &lt;/main&gt;
             &lt;footer&gt;
-              &lt;p&gt;Posted &lt;time itemprop="datePublished" datetime="2009-10-10"&gt;Thursday&lt;/time&gt;.&lt;/p&gt;
+              &lt;p&gt;Posted &lt;time property="schema:datePublished" datetime="2009-10-10"&gt;Thursday&lt;/time&gt;.&lt;/p&gt;
             &lt;/footer&gt;
           &lt;/article&gt;
           <em>...more blog posts...</em>
         &lt;/main&gt;
         &lt;footer&gt;
           &lt;p&gt;Copyright ©
-            &lt;span itemprop="copyrightYear"&gt;2010&lt;/span&gt;
-            &lt;span itemprop="copyrightHolder"&gt;The Example Company&lt;/span&gt;
+            &lt;span property="schema:copyrightYear"&gt;2010&lt;/span&gt;
+            &lt;span property="schema:copyrightHolder"&gt;The Example Company&lt;/span&gt;
           &lt;/p&gt;
           &lt;p&gt;&lt;a href="about.html"&gt;About&lt;/a&gt; -
             &lt;a href="policy.html"&gt;Privacy Policy&lt;/a&gt; -

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -74,9 +74,6 @@
   The <code>target</code>, <code>download</code>, <code>rel</code>, <code>hreflang</code>, and
   <code>type</code> attributes must be omitted if the <{links/href}> attribute is not present.
 
-  If the <code>itemprop</code> attribute is specified on an <{a}> element, then the
-  <{links/href}> attribute must also be specified.
-
   <div class="example">
 
     If a site uses a consistent navigation toolbar on every page, then the link that would
@@ -2164,10 +2161,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <{time}> element to mark up a blog post's publication date.
 
     <pre highlight="html">
-&lt;article itemscope itemtype="http://n.example.org/rfc4287"&gt;
-  &lt;h1 itemprop="title"&gt;Big tasks&lt;/h1&gt;
-  &lt;footer&gt;Published &lt;time itemprop="published" datetime="2009-08-29"&gt;two days ago&lt;/time&gt;.&lt;/footer&gt;
-  &lt;p itemprop="content"&gt;Today, I went out and bought a bike for my kid.&lt;/p&gt;
+&lt;article vocab="http://n.example.org/" typeof="rfc4287"&gt;
+  &lt;h1 property="title"&gt;Big tasks&lt;/h1&gt;
+  &lt;footer&gt;Published &lt;time property="published" datetime="2009-08-29"&gt;two days ago&lt;/time&gt;.&lt;/footer&gt;
+  &lt;p property="content"&gt;Today, I went out and bought a bike for my kid.&lt;/p&gt;
 &lt;/article&gt;
     </pre>
 
@@ -2178,10 +2175,10 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     time using the schema.org microdata vocabulary:
 
     <pre highlight="html">
-&lt;article itemscope itemtype="http://schema.org/BlogPosting"&gt;
-  &lt;h1 itemprop="headline"&gt;Small tasks&lt;/h1&gt;
-  &lt;footer&gt;Published &lt;time itemprop="datePublished" datetime="2009-08-30"&gt;yesterday&lt;/time&gt;.&lt;/footer&gt;
-  &lt;p itemprop="articleBody"&gt;I put a bike bell on his bike.&lt;/p&gt;
+&lt;article typeof="schema:BlogPosting"&gt;
+  &lt;h1 property="schema:headline"&gt;Small tasks&lt;/h1&gt;
+  &lt;footer&gt;Published &lt;time property="schema:datePublished" datetime="2009-08-30"&gt;yesterday&lt;/time&gt;.&lt;/footer&gt;
+  &lt;p property="schema:articleBody"&gt;I put a bike bell on his bike.&lt;/p&gt;
 &lt;/article&gt;
     </pre>
 


### PR DESCRIPTION
Microdata was removed from HTML development in 2013.  The microdata
related attributes were still embedded in the spec.  This pull request
removes those.  It also changes the examples that use microdata to
examples that use RDFa Lite.  RDFa Lite is a W3C Recommendation, so is
more appropriate to use for examples.
