### PR TITLE
Updated figure definition for Issue 177

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1399,7 +1399,7 @@
   </div>
 
   The <{figcaption}> element, if any,
-  represents the caption of the <{figure}> element's contents. If there is no child
+  represents the caption of the <{figure}> element's contents. If there is no descendant
   <{figcaption}> element, then there is no caption.
 
   A <{figure}> element's contents are part of the surrounding flow. If the purpose of the

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1358,9 +1358,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd>Either: One <{figcaption}> element followed by <a>flow content</a>.</dd>
-    <dd>Or: <a>Flow content</a> followed by one <{figcaption}> element.</dd>
-    <dd>Or: <a>Flow content</a>.</dd>
+    <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -1400,7 +1398,7 @@
     meaning.
   </div>
 
-  The <span class="impl">first</span> <{figcaption}> element child of the element, if any,
+  The <{figcaption}> element, if any,
   represents the caption of the <{figure}> element's contents. If there is no child
   <{figcaption}> element, then there is no caption.
 


### PR DESCRIPTION
Update to the `<figure>` definition, based on [Issue 177](https://github.com/w3c/html/issues/177), and in complement to the [`<figcaption>` definition update](https://github.com/w3c/html/pull/179) PR from @travisleithead
