### PR TITLE
Added clarification wording for input types table

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -1384,10 +1384,12 @@
   The <{input}> element <a>represents</a> a typed data field, usually with a form
   control to allow the user to edit the data.
 
-  The <dfn element-attr for="input"><code>type</code></dfn> attribute controls the data type (and
-  associated control) of the element. It is an <a>enumerated attribute</a>. The following
-  table lists the keywords and states for the attribute — the keywords in the left column map
-  to the states in the cell in the second column on the same row as the keyword.
+  The <dfn element-attr for="input"><code>type</code></dfn> attribute controls the data type of the
+  element. It is an <a>enumerated attribute</a>. The data type is used to select the control to
+  use for the <{input}>. Some data types allow either a text field or combo box control to be used,
+  based on the absence or presence of a <code>list</code> attribute on the element.
+  The following table lists the keywords and states for the attribute — the keywords in the
+  left column map to the state, data type and control(s) in the cells on the same row.
 
   <table id="attr-input-type-keywords">
     <thead>
@@ -1406,27 +1408,27 @@
       <td> <dfn attr-value for="input/type"><code>text</code></dfn>
       </td><td> <a element-state for="input">Text</a>
       </td><td> Text with no line breaks
-      </td><td> A text field
+      </td><td> A text field or combo box
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>search</code></dfn>
       </td><td> <a element-state for="input">Search</a>
       </td><td> Text with no line breaks
-      </td><td> Search field
+      </td><td> Search field or combo box
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>tel</code></dfn>
       </td><td> <a element-state for="input">Telephone</a>
       </td><td> Text with no line breaks
-      </td><td> A text field
+      </td><td> A text field or combo box
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>url</code></dfn>
       </td><td> <a element-state for="input">URL</a>
       </td><td> An absolute URL
-      </td><td> A text field
+      </td><td> A text field or combo box
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>email</code></dfn>
       </td><td> <a element-state for="input">E-mail</a>
       </td><td> An e-mail address or list of e-mail addresses
-      </td><td> A text field
+      </td><td> A text field or combo box
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>password</code></dfn>
       </td><td> <a element-state for="input">Password</a>
@@ -1461,7 +1463,7 @@
       <td> <dfn attr-value for="input/type"><code>number</code></dfn>
       </td><td> <a element-state for="input">Number</a>
       </td><td> A numerical value
-      </td><td> A text field or spinner control
+      </td><td> A text field or combo box or spinner control
     </td></tr><tr>
       <td> <dfn attr-value for="input/type"><code>range</code></dfn>
       </td><td> <a element-state for="input">Range</a>


### PR DESCRIPTION
Attempt to clean up the wording of what's in the input types table. Also explain how the 'list' attribute influences selection of text or combo box controls. See issue #174.
