### PR TITLE
Editorial edits from buglist

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -570,6 +570,7 @@
   Peter Beverloo,
   Peter Karlsson,
   Peter Kasting,
+  Peter Lemieux,
   Peter Moulder,
   Peter Occil,
   Peter Stark,

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -4,10 +4,10 @@
   Thanks to Tim Berners-Lee for inventing HTML, without which none of this would exist, Dan Connolly,
   the many who worked to standardise HTML over the last couple of decades or so, and the many more who
   worked on ideas subsequently incorporated into HTML.
-  
+
   For inestimable work, and the drive to keep HTML up to date, particular thanks are due to Ian Hickson,
   and the other editors of the WHATWG: Anne van Kesteren, Domenic Denicola, Philip Jägenstedt,
-  Simon Pieters. 
+  Simon Pieters.
 
   With apologies to people who have undeservedly not been named, thanks to
 
@@ -244,7 +244,7 @@
   Eliot Graff,
   Elisabeth Robson,
   Elizabeth Castro,
-  Elliott Regan, 
+  Elliott Regan,
   Elliott Sprehn,
   Elliotte Harold,
   Eric Carlson,
@@ -663,6 +663,7 @@
   Stefan Håkansson,
   Stefan Haustein,
   Stefan Santesson,
+  Stefan Schumacher,
   Stefan Weiss,
   Steffen Meschkat,
   Stephen Ma,

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -47,8 +47,8 @@
 
   <hr />
 
-  For simplicity, terms such as <dfn>shown</dfn>, <dfn>displayed</dfn>, and <dfn>visible</dfn> might
-  sometimes be used when referring to the way a document is rendered to the user. These terms are
+  For simplicity, terms such as <dfn>shown</dfn>, <dfn>displayed</dfn>, and <dfn>visible</dfn> are
+  used (sometimes) when referring to the way a document is rendered to the user. These terms are
   not meant to imply a visual medium; they must be considered to apply to other media in equivalent
   ways.
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -41,7 +41,7 @@
   <a>XML MIME type</a>.
 
   The term <dfn lt="XHTML document|XHTML documents">XHTML document</dfn> is used to refer to both <a>documents</a> in the
-  <a>XML document</a> mode that contains element nodes in the <a>HTML namespace</a>, and byte
+  <a>XML document</a> mode that contain element nodes in the <a>HTML namespace</a>, and byte
   streams labeled with an <a>XML MIME type</a> that contain elements from the <a>HTML namespace</a>,
   depending on context.
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -254,8 +254,8 @@
     <p class="warning">
       Browsers should take extreme care when interacting with external content intended for
       <a>plugins</a>. When third-party software is run with the same privileges as the user agent
-      itself, vulnerabilities in the third-party software become as dangerous as those in the user
-      agent.
+      itself, vulnerabilities in the third-party software become as dangerous as if they were
+      vulnerabilities of the user agent itself.
     </p>
 
     Since different users having different sets of <a>plugins</a> provides a fingerprinting vector

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -212,10 +212,10 @@
 
 <h4 id="plugin-content-handlers"><code>Plugin</code> Content Handlers</h4>
 
-  The term <dfn lt="plugin|plugins">plugin</dfn> refers to a user-agent defined set of content handlers used by the user
-  agent that can take part in the user agent's rendering of a {{Document}} object, but that
-  neither act as <a>child browsing contexts</a> of the {{Document}} nor introduce any
-  {{Node}} objects to the {{Document}}'s DOM.
+  The term <dfn lt="plugin|plugins">plugin</dfn> refers to a user-agent defined set of content
+  handlers that can be used by the user agent. The content handlers can take part in the user
+  agent's rendering of a {{Document}} object, but that neither act as <a>child browsing contexts</a>
+  of the {{Document}} nor introduce any {{Node}} objects to the {{Document}}'s DOM.
 
   Typically such content handlers are provided by third parties, though a user agent can also
   designate built-in content handlers as <a>plugins</a>.

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -521,9 +521,8 @@
         the author of the document or section. However, since an authoring tool is likely unable to
         determine the difference, an authoring tool is exempt from that requirement. This does not
         mean, though, that authoring tools can use <{address}> elements for any block of
-        italics text (for instance); it just means that the authoring tool doesn't have to verify
-        that when the user uses a tool for inserting contact information for a section, that the
-        user really is doing that and not inserting something else instead.
+        italics text (for instance); it just means that the authoring tool doesn't have to verify,
+        if a user inserts contact information for a section or something else.
       </p>
 
       <p class="note">

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -1045,7 +1045,7 @@
         or an <{h2}> heading:</p>
 
         <pre class="bad" highlight="html">&lt;h2>Contact details&lt;/h1></pre>
-    
+
   : Cases that are likely to be typos
   :: When a user makes a simple typo, it is helpful if the error can be caught early, as this can
       save the author a lot of debugging time. This specification therefore usually considers it
@@ -1062,8 +1062,8 @@
       harmless features are disallowed.
 
       <p class="example">
-        For example, "attributes" in end tags are ignored currently, but they are invalid, in case a
-        future change to the language makes use of that syntax feature without conflicting with
+        For example, "attributes" in end tags are currently invalid and ignored. A future change to
+        the language may make use of this syntax feature and can do so without conflicting with
         already-deployed (and valid!) content.
       </p>
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -476,7 +476,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   must begin with one or more <a>space characters</a>.
 
   If the <code>srcset</code> attribute has any
-  <a>image candidate strings</a> using a <i>width descriptor</i>,
+  <a>image candidate strings</a> using a <a>width descriptor</a>,
   the <dfn element-attr for="source"><code>sizes</code></dfn> content attribute must also be present,
   and the value must be a <a>valid source size list</a>.
 
@@ -626,10 +626,10 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
 
     <ul>
 
-      <li>A <i>width descriptor</i>, consisting of:
+      <li>A <dfn>width descriptor</dfn>, consisting of:
       a <a>space character</a>,
       a <a>valid non-negative integer</a> giving a number greater than zero
-      representing the <i>width descriptor</i> value,
+      representing the <dfn>width descriptor value</dfn>,
       and a U+0077 LATIN SMALL LETTER W character.</li>
 
       <li>A <i>pixel density descriptor</i>, consisting of:
@@ -647,8 +647,8 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   </ol>
 
   There must not be an <a>image candidate string</a> for an element that
-  has the same <i>width descriptor</i> value as another
-  <a>image candidate string</a>'s <i>width descriptor</i> value for the same element.
+  has the same <a>width descriptor value</a> as another
+  <a>image candidate string</a>'s <a>width descriptor value</a> for the same element.
 
   There must not be an <a>image candidate string</a> for an element that
   has the same <i>pixel density descriptor</i> value as another
@@ -660,14 +660,14 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   If a <{source}> element has a <code>sizes</code> attribute present
   or an <{img}> element has a <code>sizes</code> attribute present,
   all <a>image candidate strings</a> for that
-  element must have the <i>width descriptor</i> specified.
+  element must have the <a>width descriptor</a> specified.
 
   If an <a>image candidate string</a> for a <code>source</code> or
-  <{img}> element has the <i>width descriptor</i> specified, all other
+  <{img}> element has the <a>width descriptor</a> specified, all other
   <a>image candidate strings</a> for that element must also
-  have the <i>width descriptor</i> specified.
+  have the <a>width descriptor</a> specified.
 
-  The specified width in an <a>image candidate string</a>'s <i>width descriptor</i>
+  The specified width in an <a>image candidate string</a>'s <a>width descriptor</a>
   must match the <a>intrinsic width</a> in the resource given by the
   <a>image candidate string</a>'s URL, if it has an <a>intrinsic width</a>.
 
@@ -1326,7 +1326,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   and a <a>source size</a>.
 
   An <dfn>image source</dfn> is a <a for="url">URL</a>,
-  and optionally either a density descriptor, or a width descriptor.
+  and optionally either a density descriptor, or a <a>width descriptor</a>.
 
   A <dfn>source size</dfn> is a <code>&lt;source-size-value&gt;</code>.
   When a <a>source size</a> has a unit relative to the viewport,
@@ -1400,7 +1400,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
         whose value is not the empty string
         and <var>source set</var> does not contain an
         <a>image source</a> with a density descriptor value of 1,
-        and no <a>image source</a> with a width descriptor,
+        and no <a>image source</a> with a <a>width descriptor</a>,
         append <var>child</var>'s <code>src</code> attribute value to <var>source set</var>.</li>
 
         <li><a>Normalize the source densities</a> of <var>source set</var>.</li>
@@ -1812,7 +1812,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
   </p>
 
   An <a>image source</a> can have a density descriptor,
-  a width descriptor,
+  a <a>width descriptor</a>,
   or no descriptor at all accompanying its URL.
   Normalizing a <a>source set</a> gives every <a>image source</a> a density descriptor.
 
@@ -1834,9 +1834,9 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
 
       <li>
 
-      Otherwise, if the <a>image source</a> has a width descriptor,
-      replace the width descriptor with a density descriptor
-      with a value of the width descriptor divided by the <a>source size</a>
+      Otherwise, if the <a>image source</a> has a <a>width descriptor</a>,
+      replace the <a>width descriptor</a> with a density descriptor
+      with a value of the <a>width descriptor</a> divided by the <a>source size</a>
       and a unit of <code>x</code>.
 
       <p class="note">
@@ -13589,8 +13589,8 @@ red:89
 
 <h4 id="sec-dimension-attributes"><dfn>Dimension attributes</dfn></h4>
 
-  <span class="impl"><strong>Author requirements</strong>:</span> The 
-  <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>width</code></dfn> and 
+  <span class="impl"><strong>Author requirements</strong>:</span> The
+  <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>width</code></dfn> and
   <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>height</code></dfn> attributes on <{img}>, <{iframe}>,
   <{embed}>, <{object}>, <{video}>, and, when their <code>type</code> attribute is in the <a element-state for="input">image button</a> state, <{input}> elements may be
   specified to give the dimensions of the visual content of the element (the width and height

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5927,7 +5927,7 @@ zero or more <{track}> elements, then
 
   </div>
 
-  <div class="example">
+  <div class="note">
   If the element's <a>track URL</a> identifies a <a>WebVTT</a> resource, and the
   element's <code>kind</code> attribute is not in the <a state for="track">Metadata</a> state, then the <a>WebVTT</a> file must be
   a <a>WebVTT file using cue text</a>. [[WEBVTT]]

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5927,6 +5927,7 @@ zero or more <{track}> elements, then
 
   </div>
 
+  <div class="example">
   If the element's <a>track URL</a> identifies a <a>WebVTT</a> resource, and the
   element's <code>kind</code> attribute is not in the <a state for="track">Metadata</a> state, then the <a>WebVTT</a> file must be
   a <a>WebVTT file using cue text</a>. [[WEBVTT]]
@@ -5935,6 +5936,7 @@ zero or more <{track}> elements, then
   and the element's <code>kind</code> attribute is in the <a>chapters</a> state, then the <a>WebVTT</a> file must be
   both a <a>WebVTT file using chapter title text</a> and a <a>WebVTT file using only nested
   cues</a>. [[WEBVTT]]
+  </div>
 
   The <dfn element-attr for="track"><code>srclang</code></dfn> attribute gives the language of
   the text track data. The value must be a valid BCP 47 language tag. This attribute must be present

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -310,7 +310,7 @@ was an English &lt;a href="/wiki/Music_hall"&gt;music hall&lt;/a&gt; singer, ...
       To specify dimensions that the user agent can use before having downloaded the image,
       CSS can be used.
 
-      <pre class="css">
+      <pre highlight="css">
         img { width: 300px; height: 300px }
         @media (min-width: 32em) { img { width: 500px; height:300px } }
         @media (min-width: 45em) { img { width: 700px; height:400px } }
@@ -3090,26 +3090,27 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   Use an empty <code>alt</code> attribute when an icon is supplemental to
   text conveying the same meaning.
 
-    <div class="example">
-  In this example, we have a link pointing to a site's home page, the link contains a
-  house icon image and the text "home". The image has an empty <code>alt</code> text.
-  Where images are used in this way, it would also be appropriate to add the image using CSS
+  <div class="example">
+    In this example, we have a link pointing to a site's home page, the link contains a
+    house icon image and the text "home". The image has an empty <code>alt</code> text.
 
-  <img src="images/home.png" alt="A house icon next to the word 'home'." width="100" height="38" />
+    <img src="images/home.png" alt="A house icon next to the word 'home'." width="100" height="38" />
 
-  <pre highlight="html">
-  &lt;a href="home.html"&gt;&lt;img src="home.gif" width="15" height="15" alt=""&gt;Home&lt;/a&gt;
+    <pre highlight="html">
+      &lt;a href="home.html"&gt;&lt;img src="home.gif" width="15" height="15" alt=""&gt;Home&lt;/a&gt;
     </pre>
 
-  <pre highlight="css">
-  #home:before
-  {
-  content: url(home.png);
-  }
+    Where images are used in this way, it would also be appropriate to add the image using CSS.
 
-  &lt;a href="home.html" id="home"&gt;Home&lt;/a&gt;
+    <pre highlight="css">
+      #home:before
+      {
+      content: url(home.png);
+      }
+
+      &lt;a href="home.html" id="home"&gt;Home&lt;/a&gt;
     </pre>
-    </div>
+  </div>
 
     <div class="example">
   In this example, there is a warning message, with a warning icon. The word "Warning!" is in emphasized

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -10682,13 +10682,8 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   in the <{form}> element's <code>elements</code> object. If the attribute is specified, its value
   must not be the empty string.
 
-  Any non-empty value for <{formelements/name}> is allowed, but the names
-  "<code>_charset_</code>" and "<code>isindex</code>" are special:
-
-  : <dfn attr-value for="formelements/name"><code>isindex</code></dfn>
-  :: This value, if used as the name of a <a>Text</a> control that is the first control in a form
-     that is submitted using the <code>application/x-www-form-urlencoded</code> mechanism, causes
-     the submission to only include the value of this control, with no name.
+  Any non-empty value for <{formelements/name}> is allowed, but the name
+  "<code>_charset_</code>" is special:
 
   : <dfn attr-value for="formelements/name"><code>_charset_</code></dfn>
   :: This value, if used as the name of a <a element-state for="input">Hidden</a>
@@ -14633,13 +14628,7 @@ fur
 
       </li>
 
-      <li>If the entry's name is "<code>isindex</code>", its type is
-      "<code>text</code>", and this is the first entry in the <var>form data
-      set</var>, then append the value to <var>result</var> and skip the rest of the
-      substeps for this entry, moving on to the next entry, if any, or the next step in the overall
-      algorithm otherwise.</li>
-
-      <li>If this is not the first entry, append a single U+0026 AMPERSAND character (&amp;) to
+      <li>Append a single U+0026 AMPERSAND character (&amp;) to
       <var>result</var>.</li>
 
       <li>Append the entry's name to <var>result</var>.</li>
@@ -14662,27 +14651,18 @@ fur
   To <dfn lt="decoding algorithm">decode <code>application/x-www-form-urlencoded</code> payloads</dfn>, the following algorithm should be
   used. This algorithm uses as inputs the payload itself, <var>payload</var>, consisting of
   a Unicode string using only characters in the range U+0000 to U+007F; a default character encoding
-  <var>encoding</var>; and optionally an <var>isindex</var> flag indicating that
-  the payload is to be processed as if it had been generated for a form containing an <code>isindex</code> control. The output of this algorithm is a sorted list
-  of name-value pairs. If the <var>isindex</var> flag is set and the first control really
-  was an <code>isindex</code> control, then the first name-value pair
-  will have as its name the empty string.
+  <var>encoding</var>. The output of this algorithm is a sorted list
+  of name-value pairs.
 
   Which default character encoding to use can only be determined on a case-by-case basis, but
   generally the best character encoding to use as a default is the one that was used to encode the
   page on which the form used to create the payload was itself found. In the absence of a better
   default, UTF-8 is suggested.
 
-  The <var>isindex</var> flag is for legacy use only. Forms in conforming HTML documents
-  will not generate payloads that need to be decoded with this flag set.
-
   <ol>
 
     <li>Let <var>strings</var> be the result of <a>strictly splitting the string</a> <var>payload</var> on U+0026 AMPERSAND
     characters (&amp;).</li>
-
-    <li>If the <var>isindex</var> flag is set and the first string in <var>strings</var> does not contain a U+003D EQUALS SIGN character (=), insert a U+003D
-    EQUALS SIGN character (=) at the start of the first string in <var>strings</var>.</li>
 
     <li>Let <var>pairs</var> be an empty list of name-value pairs.</li>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -209,7 +209,7 @@
   : <code>size</code>
   :: The pizza size, either <code>small</code>, <code>medium</code>, or <code>large</code>
   : <code>topping</code>
-  :: A topping, specified once for each selected topping, with the allowed values being 
+  :: A topping, specified once for each selected topping, with the allowed values being
      <code>bacon</code>, <code>cheese</code>, <code>onion</code>, and <code>mushroom</code>
   : <code>delivery</code>
   :: The requested delivery time
@@ -1091,7 +1091,7 @@
 
   The <{label}> element <a>represents</a> a caption in a user interface. The
   caption can be associated with a specific form control<span class="impl">, known as the
-  <{label}> element's <dfn>labeled control</dfn></span>, either using the <{label/for}> attribute, 
+  <{label}> element's <dfn>labeled control</dfn></span>, either using the <{label/for}> attribute,
   or by putting the form control inside the <{label}> element itself.
 
   <div class="impl">
@@ -1111,10 +1111,10 @@
   element's <a>labeled control</a>.</span>
 
 <div class="example">
-  
-  The following example shows the use of a <{label/for}> attribute, to associate <{label}>s 
+
+  The following example shows the use of a <{label/for}> attribute, to associate <{label}>s
   which do not contain the element they label.
-  
+
   <pre highlight="html">
 &lt;form&gt;
   &lt;table&gt;
@@ -1126,8 +1126,8 @@
   &lt;/table&gt;
 &lt;/form&gt;
     </pre>
-<p>Note that the <code>id</code> attribute is required to associate the <{label/for}> attribute, 
-while the <{label/name}> attribute is required so the value of the input will be submitted as 
+<p>Note that the <code>id</code> attribute is required to associate the <{label/for}> attribute,
+while the <{label/name}> attribute is required so the value of the input will be submitted as
 part of the form.</p>
 </div>
   <div class="impl">
@@ -1138,15 +1138,15 @@ part of the form.</p>
   <a>labeled control</a>.
 
   The <{label}> element's <a>activation behavior</a> should match the platform's label
-  behavior. Similarly, any additional presentation hints should match the platform's 
+  behavior. Similarly, any additional presentation hints should match the platform's
   label presentation.
 
   <div class="example">
-    On many platforms activating a checkbox label checks the checkbox, while activating a 
-    text input's label focuses the input. Clicking the <{label}> "Lost" in the following 
-    snippet could trigger the user agent to <a>run synthetic click activation steps</a> 
-    on the checkbox, as if the element itself had been triggered by the user, while clicking 
-    the <{label}> "Where?" would <a>queue a task</a> that runs the <a>focusing steps</a> 
+    On many platforms activating a checkbox label checks the checkbox, while activating a
+    text input's label focuses the input. Clicking the <{label}> "Lost" in the following
+    snippet could trigger the user agent to <a>run synthetic click activation steps</a>
+    on the checkbox, as if the element itself had been triggered by the user, while clicking
+    the <{label}> "Where?" would <a>queue a task</a> that runs the <a>focusing steps</a>
     for the element to the text input:
 
     <pre highlight="html">
@@ -1243,7 +1243,7 @@ part of the form.</p>
 
   <a>Labelable elements</a> have a <code>NodeList</code> object
   associated with them that represents the list of <{label}> elements, in <a>tree
-  order</a>, whose <a>labeled control</a> is the element in question. The 
+  order</a>, whose <a>labeled control</a> is the element in question. The
   <dfn attribute for="HTMLLabelElement,HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLProgressElement,HTMLMeterElement"><code>labels</code></dfn>
   IDL attribute of <a>labelable elements</a>, on getting, must return that
   <code>NodeList</code> object.
@@ -2626,72 +2626,72 @@ part of the form.</p>
   initially be set to false. On getting, it must return the last value it was set to. On setting, it
   must be set to the new value. It has no effect except for changing the appearance of <a element-state for="input">checkbox</a> controls.
 
-  The <dfn attribute for="HTMLInputElement"><code>accept</code></dfn>, 
-  <dfn attribute for="HTMLInputElement"><code>alt</code></dfn>, 
+  The <dfn attribute for="HTMLInputElement"><code>accept</code></dfn>,
+  <dfn attribute for="HTMLInputElement"><code>alt</code></dfn>,
   <dfn attribute for="HTMLInputElement"><code>max</code></dfn>,
-  <dfn attribute for="HTMLInputElement"><code>min</code></dfn>, 
-  <dfn attribute for="HTMLInputElement"><code>multiple</code></dfn>, 
-  <dfn attribute for="HTMLInputElement"><code>pattern</code></dfn>, 
+  <dfn attribute for="HTMLInputElement"><code>min</code></dfn>,
+  <dfn attribute for="HTMLInputElement"><code>multiple</code></dfn>,
+  <dfn attribute for="HTMLInputElement"><code>pattern</code></dfn>,
   <dfn attribute for="HTMLInputElement"><code>placeholder</code></dfn>,
-  <dfn attribute for="HTMLInputElement"><code>required</code></dfn>, 
-  <dfn attribute for="HTMLInputElement"><code>size</code></dfn>, 
-  <dfn attribute for="HTMLInputElement"><code>src</code></dfn>, and 
-  <dfn attribute for="HTMLInputElement"><code>step</code></dfn> 
+  <dfn attribute for="HTMLInputElement"><code>required</code></dfn>,
+  <dfn attribute for="HTMLInputElement"><code>size</code></dfn>,
+  <dfn attribute for="HTMLInputElement"><code>src</code></dfn>, and
+  <dfn attribute for="HTMLInputElement"><code>step</code></dfn>
   IDL attributes must <a>reflect</a> the respective content attributes of the same name.
-  The <dfn attribute for="HTMLInputElement"><code>dirName</code></dfn> IDL attribute must 
-  <a>reflect</a> the <{input/dirname}> content attribute. 
-  The <dfn attribute for="HTMLInputElement"><code>readOnly</code></dfn> IDL attribute must 
-  <a>reflect</a> the <{input/readonly}> content attribute. 
+  The <dfn attribute for="HTMLInputElement"><code>dirName</code></dfn> IDL attribute must
+  <a>reflect</a> the <{input/dirname}> content attribute.
+  The <dfn attribute for="HTMLInputElement"><code>readOnly</code></dfn> IDL attribute must
+  <a>reflect</a> the <{input/readonly}> content attribute.
   The <dfn attribute for="HTMLInputElement"><code>defaultChecked</code></dfn> IDL attribute must
-  <a>reflect</a> the <{input/checked}> content attribute. 
+  <a>reflect</a> the <{input/checked}> content attribute.
   The <dfn attribute for="HTMLInputElement"><code>defaultValue</code></dfn> IDL attribute must
   <a>reflect</a> the <{input/value}> content attribute.
 
-  The <dfn attribute for="HTMLInputElement"><code>type</code></dfn> IDL attribute must 
-  <a>reflect</a> the respective content attribute of the same name, 
-  <a>limited to only known values</a>. 
+  The <dfn attribute for="HTMLInputElement"><code>type</code></dfn> IDL attribute must
+  <a>reflect</a> the respective content attribute of the same name,
+  <a>limited to only known values</a>.
   The <dfn attribute for="HTMLInputElement"><code>inputMode</code></dfn> IDL attribute must
   <a>reflect</a> the <{input/inputmode}> content attribute,
-  <a>limited to only known values</a>. 
-  The <dfn attribute for="HTMLInputElement"><code>maxLength</code></dfn> IDL attribute must 
-  <a>reflect</a> the <{input/maxlength}> content attribute, 
+  <a>limited to only known values</a>.
+  The <dfn attribute for="HTMLInputElement"><code>maxLength</code></dfn> IDL attribute must
+  <a>reflect</a> the <{input/maxlength}> content attribute,
   <a>limited to only non-negative numbers</a>.
-  The <dfn attribute for="HTMLInputElement"><code>minLength</code></dfn> IDL attribute must 
-  <a>reflect</a> the <{input/minlength}> content attribute, 
+  The <dfn attribute for="HTMLInputElement"><code>minLength</code></dfn> IDL attribute must
+  <a>reflect</a> the <{input/minlength}> content attribute,
   <a>limited to only non-negative numbers</a>.
 
-  The IDL attributes 
-  <dfn attribute for="HTMLInputElement"><code>width</code></dfn> and 
-  <dfn attribute for="HTMLInputElement"><code>height</code></dfn> must return the rendered 
-  width and height of the image, in CSS pixels, if an image is <a>being rendered</a>, and is 
-  being rendered to a visual medium; or else the <a>intrinsic width and height</a> of the image, 
-  in CSS pixels, if an image is <i>available</i> but not being rendered to a visual medium; 
+  The IDL attributes
+  <dfn attribute for="HTMLInputElement"><code>width</code></dfn> and
+  <dfn attribute for="HTMLInputElement"><code>height</code></dfn> must return the rendered
+  width and height of the image, in CSS pixels, if an image is <a>being rendered</a>, and is
+  being rendered to a visual medium; or else the <a>intrinsic width and height</a> of the image,
+  in CSS pixels, if an image is <i>available</i> but not being rendered to a visual medium;
   or else 0, if no image is <i>available</i>. When the <{input}> element's
-  <{input/type}> attribute is not in the <a element-state for="input">image button</a> state, 
+  <{input/type}> attribute is not in the <a element-state for="input">image button</a> state,
   then no image is <i>available</i>. [[!CSS-2015]]
 
   On setting, they must act as if they <a>reflected</a> the respective
   content attributes of the same name.
 
-  The {{HTMLInputElement/willValidate}}, 
-  {{HTMLInputElement/validity}}, and 
-  {{HTMLInputElement/validationMessage}} IDL attributes, and 
-  the {{HTMLInputElement/checkValidity()}}, 
-  {{HTMLInputElement/reportValidity()}}, and 
-  {{HTMLInputElement/setCustomValidity()}} methods, are part of 
+  The {{HTMLInputElement/willValidate}},
+  {{HTMLInputElement/validity}}, and
+  {{HTMLInputElement/validationMessage}} IDL attributes, and
+  the {{HTMLInputElement/checkValidity()}},
+  {{HTMLInputElement/reportValidity()}}, and
+  {{HTMLInputElement/setCustomValidity()}} methods, are part of
   the <a>constraint validation API</a>.
-  The {{HTMLInputElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-  The {{HTMLInputElement/select()}}, 
-  {{HTMLInputElement/selectionStart}}, 
-  {{HTMLInputElement/selectionEnd}}, 
-  {{HTMLInputElement/selectionDirection}}, 
-  {{HTMLInputElement/setRangeText()}}, and 
-  {{HTMLInputElement/setSelectionRange()}} methods and IDL 
-  attributes expose the element's text selection. 
-  The {{HTMLInputElement/autofocus}}, 
-  {{HTMLInputElement/disabled}}, 
-  {{HTMLInputElement/form}}, and 
-  {{HTMLInputElement/name}} IDL attributes are part of the 
+  The {{HTMLInputElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+  The {{HTMLInputElement/select()}},
+  {{HTMLInputElement/selectionStart}},
+  {{HTMLInputElement/selectionEnd}},
+  {{HTMLInputElement/selectionDirection}},
+  {{HTMLInputElement/setRangeText()}}, and
+  {{HTMLInputElement/setSelectionRange()}} methods and IDL
+  attributes expose the element's text selection.
+  The {{HTMLInputElement/autofocus}},
+  {{HTMLInputElement/disabled}},
+  {{HTMLInputElement/form}}, and
+  {{HTMLInputElement/name}} IDL attributes are part of the
   element's forms API.
 
   </div>
@@ -6565,7 +6565,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
   When an <{input}> element has a <code>pattern</code>
   attribute specified, authors should provide a description of the pattern in text near the
-  control. Authors may also include a 
+  control. Authors may also include a
   <dfn element-attr for="input"><code>title</code></dfn>
   attribute to give a description of the pattern. User agents may use
   the contents of this attribute, if it is present, when informing the
@@ -7382,9 +7382,9 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   <hr />
 
-  The 
-  <dfn method for="HTMLInputElement"><code>stepDown(<var>n</var>)</code></dfn> and 
-  <dfn method for="HTMLInputElement"><code>stepUp(<var>n</var>)</code></dfn> 
+  The
+  <dfn method for="HTMLInputElement"><code>stepDown(<var>n</var>)</code></dfn> and
+  <dfn method for="HTMLInputElement"><code>stepUp(<var>n</var>)</code></dfn>
   methods, when invoked, must run the following algorithm:
 
   <ol>
@@ -7775,24 +7775,24 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   <hr />
 
-  The <dfn attribute for="HTMLButtonElement"><code>value</code></dfn> and 
-  <dfn attribute for="HTMLButtonElement"><code>menu</code></dfn> IDL attributes must <a>reflect</a> 
+  The <dfn attribute for="HTMLButtonElement"><code>value</code></dfn> and
+  <dfn attribute for="HTMLButtonElement"><code>menu</code></dfn> IDL attributes must <a>reflect</a>
   the content attributes of the same name.
 
   The <dfn attribute for="HTMLButtonElement"><code>type</code></dfn> IDL attribute must
   <a>reflect</a> the content attribute of the same name, <a>limited to only known values</a>.
 
-  The {{HTMLButtonElement/willValidate}}, 
-  {{HTMLButtonElement/validity}}, and 
-  {{HTMLButtonElement/validationMessage}} IDL attributes, and 
-  the {{HTMLButtonElement/checkValidity()}}, 
-  {{HTMLButtonElement/reportValidity()}}, and 
-  {{HTMLButtonElement/setCustomValidity()}} methods, are part of 
-  the <a>constraint validation API</a>. 
-  The {{HTMLButtonElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-  The {{HTMLButtonElement/autofocus}}, 
-  {{HTMLButtonElement/disabled}}, 
-  {{HTMLButtonElement/form}}, and 
+  The {{HTMLButtonElement/willValidate}},
+  {{HTMLButtonElement/validity}}, and
+  {{HTMLButtonElement/validationMessage}} IDL attributes, and
+  the {{HTMLButtonElement/checkValidity()}},
+  {{HTMLButtonElement/reportValidity()}}, and
+  {{HTMLButtonElement/setCustomValidity()}} methods, are part of
+  the <a>constraint validation API</a>.
+  The {{HTMLButtonElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+  The {{HTMLButtonElement/autofocus}},
+  {{HTMLButtonElement/disabled}},
+  {{HTMLButtonElement/form}}, and
   {{HTMLButtonElement/name}} IDL attributes are
   part of the element's forms API.
 
@@ -8220,18 +8220,18 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   attribute.
   </p>
 
-  The {{HTMLSelectElement/willValidate}}, 
-  {{HTMLSelectElement/validity}}, and 
-  {{HTMLSelectElement/validationMessage}} IDL attributes, and 
-  the {{HTMLSelectElement/checkValidity()}}, 
-  {{HTMLSelectElement/reportValidity()}}, and 
-  {{HTMLSelectElement/setCustomValidity()}} methods, are part of 
-  the <a>constraint validation API</a>. 
-  The {{HTMLSelectElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-  The {{HTMLSelectElement/autofocus}}, 
-  {{HTMLSelectElement/disabled}}, 
-  {{HTMLSelectElement/form}}, and 
-  {{HTMLSelectElement/name}} IDL attributes are part of the 
+  The {{HTMLSelectElement/willValidate}},
+  {{HTMLSelectElement/validity}}, and
+  {{HTMLSelectElement/validationMessage}} IDL attributes, and
+  the {{HTMLSelectElement/checkValidity()}},
+  {{HTMLSelectElement/reportValidity()}}, and
+  {{HTMLSelectElement/setCustomValidity()}} methods, are part of
+  the <a>constraint validation API</a>.
+  The {{HTMLSelectElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+  The {{HTMLSelectElement/autofocus}},
+  {{HTMLSelectElement/disabled}},
+  {{HTMLSelectElement/form}}, and
+  {{HTMLSelectElement/name}} IDL attributes are part of the
   element's forms API.
 
   </div>
@@ -9079,7 +9079,7 @@ Filename: &lt;code&gt;/etc/bash.bashrc&lt;/code&gt;
 
   The <{textarea/name}> attribute represents the element's name.
   The <{textarea/dirname}> attribute controls how the element's <a>directionality</a> is submitted.
-  The <{textarea/disabled}> attribute is used to make the control non-interactive and to prevent its 
+  The <{textarea/disabled}> attribute is used to make the control non-interactive and to prevent its
   value from being submitted.
   The <{textarea/form}> attribute is used to explicitly associate the
   <{textarea}> element with its <a>form owner</a>.
@@ -9140,22 +9140,22 @@ Filename: &lt;code&gt;/etc/bash.bashrc&lt;/code&gt;
     The <dfn attribute for="HTMLTextAreaElement"><code>textLength</code></dfn> IDL attribute must return the <a>code-unit length</a> of
     the element's <a>API value</a>.
 
-    The {{HTMLTextAreaElement/willValidate}}, {{HTMLTextAreaElement/validity}}, and 
-    {{HTMLTextAreaElement/validationMessage}} IDL attributes, 
+    The {{HTMLTextAreaElement/willValidate}}, {{HTMLTextAreaElement/validity}}, and
+    {{HTMLTextAreaElement/validationMessage}} IDL attributes,
     and the {{HTMLTextAreaElement/checkValidity()}}, {{HTMLTextAreaElement/reportValidity()}}, and
-    {{HTMLTextAreaElement/setCustomValidity()}} methods, are part of the 
+    {{HTMLTextAreaElement/setCustomValidity()}} methods, are part of the
     <a>constraint validation API</a>.
-    The {{HTMLTextAreaElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-    The {{HTMLTextAreaElement/select()}}, 
-    {{HTMLTextAreaElement/selectionStart}}, 
+    The {{HTMLTextAreaElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+    The {{HTMLTextAreaElement/select()}},
+    {{HTMLTextAreaElement/selectionStart}},
     {{HTMLTextAreaElement/selectionEnd}},
-    {{HTMLTextAreaElement/selectionDirection}}, 
+    {{HTMLTextAreaElement/selectionDirection}},
     {{HTMLTextAreaElement/setRangeText()}}, and
-    {{HTMLTextAreaElement/setSelectionRange()}} methods and IDL 
+    {{HTMLTextAreaElement/setSelectionRange()}} methods and IDL
     attributes expose the element's text selection.
-    The {{HTMLTextAreaElement/autofocus}}, 
-    {{HTMLTextAreaElement/disabled}}, 
-    {{HTMLTextAreaElement/form}}, and 
+    The {{HTMLTextAreaElement/autofocus}},
+    {{HTMLTextAreaElement/disabled}},
+    {{HTMLTextAreaElement/form}}, and
     {{HTMLTextAreaElement/name}} IDL attributes are part of the element's forms API.
   </div>
 
@@ -9463,16 +9463,16 @@ Daddy"&gt;&lt;/textarea&gt;
   The <dfn attribute for="HTMLKeygenElement"><code>type</code></dfn> IDL attribute must return the value
   "<code>keygen</code>".
 
-  The {{HTMLKeygenElement/willValidate}}, {{HTMLKeygenElement/validity}}, and 
-  {{HTMLKeygenElement/validationMessage}} IDL attributes, and 
-  the {{HTMLKeygenElement/checkValidity()}}, 
-  {{HTMLKeygenElement/reportValidity()}}, and 
-  {{HTMLKeygenElement/setCustomValidity()}} methods, are part of 
-  the <a>constraint validation API</a>. 
-  The {{HTMLKeygenElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-  The {{HTMLKeygenElement/autofocus}}, 
-  {{HTMLKeygenElement/disabled}}, 
-  {{HTMLKeygenElement/form}}, and 
+  The {{HTMLKeygenElement/willValidate}}, {{HTMLKeygenElement/validity}}, and
+  {{HTMLKeygenElement/validationMessage}} IDL attributes, and
+  the {{HTMLKeygenElement/checkValidity()}},
+  {{HTMLKeygenElement/reportValidity()}}, and
+  {{HTMLKeygenElement/setCustomValidity()}} methods, are part of
+  the <a>constraint validation API</a>.
+  The {{HTMLKeygenElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+  The {{HTMLKeygenElement/autofocus}},
+  {{HTMLKeygenElement/disabled}},
+  {{HTMLKeygenElement/form}}, and
   {{HTMLKeygenElement/name}} IDL attributes are
   part of the element's forms API.
 
@@ -9649,15 +9649,15 @@ Daddy"&gt;&lt;/textarea&gt;
   The <dfn attribute for="HTMLOutputElement"><code>htmlFor</code></dfn> IDL attribute must
   <a>reflect</a> the <{output/for}> content attribute.
 
-  The {{HTMLOutputElement/willValidate}}, 
-  {{HTMLOutputElement/validity}}, and 
-  {{HTMLOutputElement/validationMessage}} IDL attributes, and 
-  the {{HTMLOutputElement/checkValidity()}}, 
-  {{HTMLOutputElement/reportValidity()}}, and 
-  {{HTMLOutputElement/setCustomValidity()}} methods, are part of 
-  the <a>constraint validation API</a>. 
-  The {{HTMLOutputElement/labels}} IDL attribute provides a list of the element's <{label}>s. 
-  The {{HTMLOutputElement/form}} and 
+  The {{HTMLOutputElement/willValidate}},
+  {{HTMLOutputElement/validity}}, and
+  {{HTMLOutputElement/validationMessage}} IDL attributes, and
+  the {{HTMLOutputElement/checkValidity()}},
+  {{HTMLOutputElement/reportValidity()}}, and
+  {{HTMLOutputElement/setCustomValidity()}} methods, are part of
+  the <a>constraint validation API</a>.
+  The {{HTMLOutputElement/labels}} IDL attribute provides a list of the element's <{label}>s.
+  The {{HTMLOutputElement/form}} and
   {{HTMLOutputElement/name}} IDL attributes are
   part of the element's forms API.
 
@@ -10666,7 +10666,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   </dl>
 
   <div class="impl">
-    <a>Reassociateable</a> <a>form-associated elements</a> have a 
+    <a>Reassociateable</a> <a>form-associated elements</a> have a
     <dfn attribute for="FormIDLAttribute,HTMLObjectElement,HTMLLabelElement,HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLOptionElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement,HTMLLegendElement"><code>form</code></dfn>
     IDL attribute, which, on getting, must return the element's <a>form owner</a>, or null if there
     isn't one.
@@ -10676,20 +10676,20 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
 <h5 id="naming-form-controls-the-name-attribute">Naming form controls: the <code>name</code> attribute</h5>
 
-  The 
+  The
   <dfn element-attr for="formelements,label,input,button,select,textarea,keygen,output,fieldset"><code>name</code></dfn>
-  content attribute gives the name of the form control, as used in [[#forms-form-submission]] and 
-  in the <{form}> element's <code>elements</code> object. If the attribute is specified, its value 
+  content attribute gives the name of the form control, as used in [[#forms-form-submission]] and
+  in the <{form}> element's <code>elements</code> object. If the attribute is specified, its value
   must not be the empty string.
 
   Any non-empty value for <{formelements/name}> is allowed, but the names
   "<code>_charset_</code>" and "<code>isindex</code>" are special:
 
   : <dfn attr-value for="formelements/name"><code>isindex</code></dfn>
-  :: This value, if used as the name of a <a>Text</a> control that is the first control in a form 
+  :: This value, if used as the name of a <a>Text</a> control that is the first control in a form
      that is submitted using the <code>application/x-www-form-urlencoded</code> mechanism, causes
      the submission to only include the value of this control, with no name.
-     
+
   : <dfn attr-value for="formelements/name"><code>_charset_</code></dfn>
   :: This value, if used as the name of a <a element-state for="input">Hidden</a>
      control with no <code>value</code> attribute, is automatically given a
@@ -10697,7 +10697,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <div class="impl">
 
-  The 
+  The
   <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>name</code></dfn>
   IDL attribute must <a>reflect</a> the <{formelements/name}> content attribute.
 
@@ -10846,8 +10846,8 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   <strong>Constraint validation</strong>: If an element is disabled, it is <a>barred from constraint
   validation</a>.
 
-  The 
-  <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement"><code>disabled</code></dfn> 
+  The
+  <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement"><code>disabled</code></dfn>
   IDL attribute must
   <a>reflect</a> the <{disabledformelements/disabled}> content attribute.
 
@@ -10859,7 +10859,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   and on <a>submit buttons</a> (elements that represent buttons
   that submit forms, e.g., an <{input}> element whose <{input/type}> attribute is in the <a element-state for="input">submit button</a> state).
 
-  The <a>attributes for form submission</a> that may be specified on <{form}> elements are 
+  The <a>attributes for form submission</a> that may be specified on <{form}> elements are
   <{form/action}>, <{form/enctype}>, <{form/method}>, <{form/novalidate}>, and <{form/target}>.
 
   The corresponding <a>attributes for form submission</a> that may be specified on <a>submit buttons</a> are <{submitbuttonelements/formaction}>, <{submitbuttonelements/formenctype}>, <{submitbuttonelements/formmethod}>, <{submitbuttonelements/formnovalidate}>, and <{submitbuttonelements/formtarget}>. When omitted, they default to the values given on
@@ -10867,7 +10867,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn element-attr for="form"><code>action</code></dfn> and 
+  The <dfn element-attr for="form"><code>action</code></dfn> and
   <dfn element-attr for="submitbuttonelements,input,button"><code>formaction</code></dfn> content attributes, if specified, must
   have a value that is a <a>valid non-empty URL potentially surrounded by spaces</a>.
 
@@ -10878,7 +10878,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn element-attr for="form"><code>method</code></dfn> and 
+  The <dfn element-attr for="form"><code>method</code></dfn> and
   <dfn element-attr for="submitbuttonelements,input,button"><code>formmethod</code></dfn> content attributes are <a>enumerated attributes</a> with the following keywords and
   states:
 
@@ -10959,7 +10959,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn element-attr for="form"><code>enctype</code></dfn> and 
+  The <dfn element-attr for="form"><code>enctype</code></dfn> and
   <dfn element-attr for="submitbuttonelements,input,button"><code>formenctype</code></dfn> content attributes are <a>enumerated attributes</a> with the following keywords and
   states:
 
@@ -10979,7 +10979,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn element-attr for="form"><code>target</code></dfn> and 
+  The <dfn element-attr for="form"><code>target</code></dfn> and
   <dfn element-attr for="submitbuttonelements,input,button"><code>formtarget</code></dfn> content attributes, if specified, must
   have values that are <a>valid browsing context
   names or keywords</a>.
@@ -10993,7 +10993,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn element-attr for="form"><code>novalidate</code></dfn> and 
+  The <dfn element-attr for="form"><code>novalidate</code></dfn> and
   <dfn element-attr for="submitbuttonelements,input,button"><code>formnovalidate</code></dfn> content attributes are <a>boolean attributes</a>. If present, they indicate that the form is
   not to be validated during submission.
 
@@ -11025,37 +11025,37 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <hr />
 
-  The <dfn attribute for="HTMLFormElement"><code>action</code></dfn> IDL attribute must <a>reflect</a> the 
-  content attribute of the same name, except that on getting, when the content attribute is missing 
-  or its value is the empty string, <a>the document's address</a> must be returned instead. 
-  
-  The <dfn attribute for="HTMLFormElement"><code>target</code></dfn> IDL attribute must <a>reflect</a> the 
-  content attribute of the same name. 
-  
-  The <dfn attribute for="HTMLFormElement"><code>method</code></dfn> and 
+  The <dfn attribute for="HTMLFormElement"><code>action</code></dfn> IDL attribute must <a>reflect</a> the
+  content attribute of the same name, except that on getting, when the content attribute is missing
+  or its value is the empty string, <a>the document's address</a> must be returned instead.
+
+  The <dfn attribute for="HTMLFormElement"><code>target</code></dfn> IDL attribute must <a>reflect</a> the
+  content attribute of the same name.
+
+  The <dfn attribute for="HTMLFormElement"><code>method</code></dfn> and
   <dfn attribute for="HTMLFormElement"><code>enctype</code></dfn> IDL attributes must <a>reflect</a> the
-  respective content attributes of the same name, <a>limited to only known values</a>. 
-  
-  The <dfn attribute for="HTMLFormElement"><code>encoding</code></dfn> IDL attribute must <a>reflect</a> the 
-  <{form/enctype}> content attribute, <a>limited to only known values</a>. 
-  
-  The <dfn attribute for="HTMLFormElement"><code>noValidate</code></dfn> IDL attribute must <a>reflect</a> the 
+  respective content attributes of the same name, <a>limited to only known values</a>.
+
+  The <dfn attribute for="HTMLFormElement"><code>encoding</code></dfn> IDL attribute must <a>reflect</a> the
+  <{form/enctype}> content attribute, <a>limited to only known values</a>.
+
+  The <dfn attribute for="HTMLFormElement"><code>noValidate</code></dfn> IDL attribute must <a>reflect</a> the
   <{form/novalidate}> content attribute.
-  
-  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formAction</code></dfn> IDL attribute must <a>reflect</a> the 
-  <{input/formaction}> content attribute, except that on getting, when the content attribute is 
-  missing or its value is the empty string, <a>the document's address</a> must be returned instead. 
-  
-  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formEnctype</code></dfn> IDL attribute must <a>reflect</a> the 
-  <{input/formenctype}> content attribute, <a>limited to only known values</a>. 
-  
-  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formMethod</code></dfn> IDL attribute must <a>reflect</a> the 
-  <{input/formmethod}> content attribute, <a>limited to only known values</a>. 
-  
-  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formNoValidate</code></dfn> IDL attribute must <a>reflect</a> 
-  the <{input/formnovalidate}> content attribute. 
-  
-  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formTarget</code></dfn> IDL attribute must <a>reflect</a> the 
+
+  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formAction</code></dfn> IDL attribute must <a>reflect</a> the
+  <{input/formaction}> content attribute, except that on getting, when the content attribute is
+  missing or its value is the empty string, <a>the document's address</a> must be returned instead.
+
+  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formEnctype</code></dfn> IDL attribute must <a>reflect</a> the
+  <{input/formenctype}> content attribute, <a>limited to only known values</a>.
+
+  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formMethod</code></dfn> IDL attribute must <a>reflect</a> the
+  <{input/formmethod}> content attribute, <a>limited to only known values</a>.
+
+  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formNoValidate</code></dfn> IDL attribute must <a>reflect</a>
+  the <{input/formnovalidate}> content attribute.
+
+  The <dfn attribute for="HTMLInputElement,HTMLButtonElement"><code>formTarget</code></dfn> IDL attribute must <a>reflect</a> the
   <{input/formtarget}> content attribute.
 
   </div>
@@ -11302,8 +11302,8 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 <h6 id="autofilling-form-controls-the-autocomplete-attribute">Autofilling form controls: the <code>autocomplete</code> attribute</h6>
 
   User agents sometimes have features for helping users fill forms in, for example prefilling the
-  user's address based on earlier user input. The 
-  <dfn element-attr for="autocompleteelements,form,input,select,textarea"><code>autocomplete</code></dfn> 
+  user's address based on earlier user input. The
+  <dfn element-attr for="autocompleteelements,form,input,select,textarea"><code>autocomplete</code></dfn>
   content attribute can be used to hint
   to the user agent how to, or indeed whether to, provide such a feature.
 
@@ -12784,7 +12784,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   </td></tr></tbody></table>
 
-  The 
+  The
   <dfn attribute for="HTMLInputElement,HTMLSelectElement,HTMLTextAreaElement"><code>autocomplete</code></dfn>
   IDL attribute, on getting,
   must return the element's <a>IDL-exposed autofill value</a>, and on setting, must
@@ -13205,7 +13205,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   adjusting the selection, based on which directional arrow key was used.
   </p>
 
-  The 
+  The
   <dfn method for="selectionapielements,HTMLInputElement,HTMLTextAreaElement"><code>select()</code></dfn>
   method must cause the
   contents of the text field to be fully selected, with the selection direction being none, if the
@@ -13221,7 +13221,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   picker, as opposed to a text field accepting a hexadecimal color code, there would be no text
   field, and thus nothing to select, and thus calls to the method are ignored.</p>
 
-  The 
+  The
   <dfn attribute for="selectionapielements,HTMLInputElement,HTMLTextAreaElement"><code>selectionStart</code></dfn>
   attribute
   must, on getting, return the offset (in logical order) to the character that immediately follows
@@ -13235,7 +13235,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   current value of the {{selectionapielements/selectionDirection}}
   as the third argument.
 
-  The 
+  The
   <dfn attribute for="selectionapielements,HTMLInputElement,HTMLTextAreaElement"><code>selectionEnd</code></dfn>
   attribute
   must, on getting, return the offset (in logical order) to the character that immediately follows
@@ -13246,7 +13246,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   with the current value of the {{selectionapielements/selectionStart}} attribute as the first argument,
   the new value as the second argument, and the current value of the {{selectionapielements/selectionDirection}} as the third argument.
 
-  The 
+  The
   <dfn attribute for="selectionapielements,HTMLInputElement,HTMLTextAreaElement"><code>selectionDirection</code></dfn>
   attribute must, on getting, return the string corresponding to the current selection direction: if
   the direction is <i>forward</i>, "<code>forward</code>"; if the direction is
@@ -13257,7 +13257,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   the current value of the {{selectionapielements/selectionEnd}} IDL
   attribute as the second argument, and the new value as the third argument.
 
-  The 
+  The
   <dfn method for="selectionapielements,HTMLInputElement,HTMLTextAreaElement"><code>setSelectionRange(<var>start</var>, <var>end</var>, <var>direction</var>)</code></dfn>
   method
   must set the selection of the text field to the sequence of characters starting with the character
@@ -13275,7 +13275,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   then <a>queue a task</a> to <a>fire a simple event</a> that bubbles named <code>select</code> at the element, using the <a>user interaction task
   source</a> as the task source.
 
-  The 
+  The
   <dfn method for="selectionapielements,HTMLInputElement,HTMLTextAreaElement" lt="setRangeText()|setRangeText(replacement)|setRangeText(replacement, start, end)|setRangeText(replacement, start, end, selectionMode)"><code>setRangeText(<var>replacement</var>, <var>start</var>, <var>end</var>, <var>selectMode</var>)</code></dfn>
   method must run the following steps:
 
@@ -13469,46 +13469,46 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
   define more precisely when each state applies or does not.)
 
   : <dfn lt="suffer from being missing|suffering from being missing">Suffering from being missing</dfn>
-  :: When a control has no <a for="forms">value</a> but has a <code>required</code> attribute 
-     (<{input}> <{input/required}>, <{textarea}> <{textarea/required}>); or, in the case of an 
+  :: When a control has no <a for="forms">value</a> but has a <code>required</code> attribute
+     (<{input}> <{input/required}>, <{textarea}> <{textarea/required}>); or, in the case of an
      element in a <i>radio button group</i>, any of the other elements in the group has a
-     <code>required</code> attribute; or, for <{select}> elements, none of the <{option}> 
-     elements have their <a state for="option">selectedness</a> set (<{select}> 
+     <code>required</code> attribute; or, for <{select}> elements, none of the <{option}>
+     elements have their <a state for="option">selectedness</a> set (<{select}>
      <{select/required}>).
-     
+
   : <dfn lt="suffer from a type mismatch|suffering from a type mismatch">Suffering from a type mismatch</dfn>
-  :: When a control that allows arbitrary user input has a <a for="forms">value</a> that is not in 
-     the correct syntax (<a element-state for="input">E-mail</a>, 
+  :: When a control that allows arbitrary user input has a <a for="forms">value</a> that is not in
+     the correct syntax (<a element-state for="input">E-mail</a>,
      <a element-state for="input">URL</a>).
 
   : <dfn lt="suffer from a pattern mismatch|suffering from a pattern mismatch">Suffering from a pattern mismatch</dfn>
-  :: When a control has a <a for="forms">value</a> that doesn't satisfy the <code>pattern</code> 
+  :: When a control has a <a for="forms">value</a> that doesn't satisfy the <code>pattern</code>
      attribute.
 
   : <dfn lt="suffer from being too long|suffering from being too long">Suffering from being too long</dfn>
-  :: When a control has a <a for="forms">value</a> that is too long for the 
-     <a>form control <code>maxlength</code> attribute</a> (<{input}> <{input/maxlength}>, 
+  :: When a control has a <a for="forms">value</a> that is too long for the
+     <a>form control <code>maxlength</code> attribute</a> (<{input}> <{input/maxlength}>,
      <{textarea}> <{textarea/maxlength}>).
 
   : <dfn lt="suffer from being too short|suffering from being too short">Suffering from being too short</dfn>
   :: When a control has a <a for="forms">value</a> that is too short for the
-     <a>form control <code>minlength</code> attribute</a> (<{input}> <{input/minlength}>, 
+     <a>form control <code>minlength</code> attribute</a> (<{input}> <{input/minlength}>,
      <{textarea}> <{textarea/minlength}>).
 
   : <dfn lt="suffer from an underflow|suffering from an underflow">Suffering from an underflow</dfn>
-  :: When a control has a <a for="forms">value</a> that is not the empty string and is too low for 
+  :: When a control has a <a for="forms">value</a> that is not the empty string and is too low for
      the <code>min</code> attribute.
 
   : <dfn lt="suffer from an overflow|suffering from an overflow">Suffering from an overflow</dfn>
-  :: When a control has a <a for="forms">value</a> that is not the empty string and is too high for 
+  :: When a control has a <a for="forms">value</a> that is not the empty string and is too high for
      the <code>max</code> attribute.
 
   : <dfn lt="suffer from a step mismatch|suffering from a step mismatch">Suffering from a step mismatch</dfn>
-  :: When a control has a <a for="forms">value</a> that doesn't fit the rules given by the 
+  :: When a control has a <a for="forms">value</a> that doesn't fit the rules given by the
      <code>step</code> attribute.
 
   : <dfn lt="suffer from bad input|suffering from bad input">Suffering from bad input</dfn>
-  :: When a control has incomplete input and the user agent does not think the user ought to be 
+  :: When a control has incomplete input and the user agent does not think the user ought to be
      able to submit the form in its current state.
 
   : <dfn lt="suffer from a custom error|suffering from a custom error">Suffering from a custom error</dfn>
@@ -13760,16 +13760,16 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
 
   <div class="impl">
 
-  The 
+  The
   <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>willValidate</code></dfn>
   IDL attribute must return
   true if an element is a <a>candidate for constraint validation</a>, and false otherwise
   (i.e., false if any conditions are <a>barring it from
   constraint validation</a>).
 
-  The 
+  The
   <dfn method for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement" lt="setCustomValidity()|setCustomValidity(error)"><code>setCustomValidity(<var>message</var>)</code></dfn>,
-  when invoked, must set the <a>custom validity error message</a> to the value of the given 
+  when invoked, must set the <a>custom validity error message</a> to the value of the given
   <var>message</var> argument.
 
   </div>
@@ -13799,9 +13799,9 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
 
   <div class="impl">
 
-  The 
+  The
   <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>validity</code></dfn>
-  IDL attribute must return a <code>ValidityState</code> object that represents 
+  IDL attribute must return a <code>ValidityState</code> object that represents
   the <a>validity states</a> of the element.
   This object is <a>live</a>.
 
@@ -13847,16 +13847,16 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
   : <dfn attribute for="ValidityState"><code>valid</code></dfn>
   :: None of the other conditions are true.
 
-  When the 
-  <dfn method for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>checkValidity()</code></dfn> 
+  When the
+  <dfn method for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>checkValidity()</code></dfn>
   method is
   invoked, if the element is a <a>candidate for constraint validation</a> and does not <a>satisfy its constraints</a>, the user agent must <a>fire a simple
   event</a> named <code>invalid</code> that is cancelable (but in this case
   has no default action) at the element and return false. Otherwise, it must only return true
   without doing anything else.
 
-  When the 
-  <dfn method for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>reportValidity()</code></dfn> 
+  When the
+  <dfn method for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>reportValidity()</code></dfn>
   method is
   invoked, if the element is a <a>candidate for constraint validation</a> and does not <a>satisfy its constraints</a>, the user agent must: <a>fire a simple
   event</a> named <code>invalid</code> that is cancelable at the element,
@@ -13869,8 +13869,8 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
   element is not <a>being rendered</a>, then the user agent may, instead of notifying the
   user, report a script error.
 
-  The 
-  <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>validationMessage</code></dfn> 
+  The
+  <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement,HTMLKeygenElement,HTMLOutputElement,HTMLFieldSetElement"><code>validationMessage</code></dfn>
   attribute must
   return the empty string if the element is not a <a>candidate for constraint validation</a>
   or if it is one but it <a>satisfies its constraints</a>; otherwise,
@@ -14155,8 +14155,8 @@ fur
     The behaviors are as follows:
 
     : <dfn>Mutate action URL</dfn>
-    :: Let <var>query</var> be the result of encoding the <var>form data set</var> using the 
-        <a><code>application/x-www-form-urlencoded</code> encoding algorithm</a>, interpreted as 
+    :: Let <var>query</var> be the result of encoding the <var>form data set</var> using the
+        <a><code>application/x-www-form-urlencoded</code> encoding algorithm</a>, interpreted as
         a US-ASCII string.
 
         Set <var>parsed action</var>'s <a for="urlsyntax">query</a> component to <var>query</var>.
@@ -14167,7 +14167,7 @@ fur
         <a>Plan to navigate</a> to <var>destination</var>.
 
     : <dfn>Submit as entity body</dfn>
-    :: Let <var>entity body</var> be the result of encoding the <var>form data set</var> using 
+    :: Let <var>entity body</var> be the result of encoding the <var>form data set</var> using
         the <a>appropriate form encoding algorithm</a>.
 
         Let <var>MIME type</var> be determined as follows:
@@ -14176,17 +14176,17 @@ fur
         :: Let <var>MIME type</var> be "<code>application/x-www-form-urlencoded</code>".
 
         : If <var>enctype</var> is <code>multipart/form-data</code>
-        :: Let <var>MIME type</var> be the concatenation of the string 
-            "<code>multipart/form-data;</code>", a U+0020 SPACE character, 
-            the string "<code>boundary=</code>", 
-            and the <a><code>multipart/form-data</code> boundary string</a> generated by the 
+        :: Let <var>MIME type</var> be the concatenation of the string
+            "<code>multipart/form-data;</code>", a U+0020 SPACE character,
+            the string "<code>boundary=</code>",
+            and the <a><code>multipart/form-data</code> boundary string</a> generated by the
             <a><code>multipart/form-data</code> encoding algorithm</a>.
 
         : If <var>enctype</var> is <code>text/plain</code>
         :: Let <var>MIME type</var> be "<code>text/plain</code>".
 
         Otherwise, <a>plan to navigate</a> to a new <a>request</a> whose <a for="url">URL</a> is
-        <var>action</var>, <a>method</a> is <var>method</var>, <a>header list</a> consists of 
+        <var>action</var>, <a>method</a> is <var>method</var>, <a>header list</a> consists of
         <code>Content-Type</code>/<var>MIME type</var>, and <a>body</a> is <var>entity body</var>.
 
     : <dfn>Get action URL</dfn>
@@ -14198,27 +14198,27 @@ fur
     :: Let <var>data</var> be the result of encoding the <var>form data
         set</var> using the <a>appropriate form encoding algorithm</a>.
 
-        If <var>action</var> contains the string "<code>%%%%</code>" 
-        (four U+0025 PERCENT SIGN characters), then <a>percent encode</a> all bytes in 
+        If <var>action</var> contains the string "<code>%%%%</code>"
+        (four U+0025 PERCENT SIGN characters), then <a>percent encode</a> all bytes in
         <var>data</var> that, if interpreted as US-ASCII, are not characters in the URL
         <a>default encode set</a>, and then, treating the result as a US-ASCII string,
         <a>UTF-8 percent encode</a> all the U+0025 PERCENT SIGN characters in the resulting
-        string and replace the first occurrence of "<code>%%%%</code>" in <var>action</var> 
+        string and replace the first occurrence of "<code>%%%%</code>" in <var>action</var>
         with the resulting doubly-escaped string. [[!URL]]
 
         Otherwise, if <var>action</var> contains the string "<code>%%</code>"
         (two U+0025 PERCENT SIGN characters in a row, but not four), then <a>UTF-8 percent
         encode</a> all characters in <var>data</var> that, if interpreted as US-ASCII, are
         not characters in the URL <a>default encode set</a>, and then, treating the result as a
-        US-ASCII string, replace the first occurrence of "<code>%%</code>" in <var>action</var> 
+        US-ASCII string, replace the first occurrence of "<code>%%</code>" in <var>action</var>
         with the resulting escaped string. [[!URL]]
 
         <a>Plan to navigate</a> to the potentially modified <var>action</var> (which
         will be a <a scheme lt="data:"><code>data:</code> URL</a>).
 
     : <dfn>Mail with headers</dfn>
-    :: Let <var>headers</var> be the resulting encoding the <var>form data set</var> using the 
-        <a><code>application/x-www-form-urlencoded</code> encoding algorithm</a>, interpreted as 
+    :: Let <var>headers</var> be the resulting encoding the <var>form data set</var> using the
+        <a><code>application/x-www-form-urlencoded</code> encoding algorithm</a>, interpreted as
         a US-ASCII string.
 
         Replace occurrences of U+002B PLUS SIGN characters (+) in <var>headers</var> with
@@ -14235,8 +14235,8 @@ fur
         <a>Plan to navigate</a> to <var>destination</var>.
 
     : <dfn>Mail as body</dfn>
-    :: Let <var>body</var> be the resulting of encoding the <var>form data set</var> using the 
-        <a>appropriate form encoding algorithm</a> and then 
+    :: Let <var>body</var> be the resulting of encoding the <var>form data set</var> using the
+        <a>appropriate form encoding algorithm</a> and then
         <a lt="percent encode">percent encoding</a> all the bytes in the resulting byte string
         that, when interpreted as US-ASCII, are not characters in the URL <a>default encode
         set</a>. [[!URL]]
@@ -14259,26 +14259,26 @@ fur
         If there isn't one, or if it does not have an <code>open</code>
         attribute, do nothing. Otherwise, proceed as follows:
 
-        If <var>submitter</var> is an <{input}> element whose <{input/type}> attribute is in 
+        If <var>submitter</var> is an <{input}> element whose <{input/type}> attribute is in
         the <a element-state for="input">image button</a> state, then let <var>result</var>
-        be the string formed by concatenating the <a>selected coordinate</a>'s 
+        be the string formed by concatenating the <a>selected coordinate</a>'s
         <var>x</var>-component, expressed as a base-ten number using <a>ASCII digits</a>, a
-        U+002C COMMA character (,), and the <a>selected coordinate</a>'s <var>y</var>-component, 
+        U+002C COMMA character (,), and the <a>selected coordinate</a>'s <var>y</var>-component,
         expressed in the same way as the <var>x</var>-component.
 
-        Otherwise, if <var>submitter</var> has a <a for="forms">value</a>, then let 
+        Otherwise, if <var>submitter</var> has a <a for="forms">value</a>, then let
         <var>result</var> be that <a for="forms">value</a>.
 
         Otherwise, there is no <var>result</var>.
 
-        Then, <a>close the dialog</a> <var>subject</var>. If there is a <var>result</var>, 
+        Then, <a>close the dialog</a> <var>subject</var>. If there is a <var>result</var>,
         let that be the return value.
 
     The <dfn>appropriate form encoding algorithm</dfn> is determined as follows:
 
     : If <var>enctype</var> is <code>application/x-www-form-urlencoded</code>
     :: Use the <a><code>application/x-www-form-urlencoded</code> encoding algorithm</a>.
-    
+
     : If <var>enctype</var> is <code>multipart/form-data</code>
     :: Use the <a><code>multipart/form-data</code> encoding algorithm</a>.
 

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1700,7 +1700,7 @@
               &lt;/ul&gt;
             &lt;/nav&gt;
 
-            &lt;H2 id="ceremony"&gt;Ceremony&lt;/H2&gt;
+            &lt;h2 id="ceremony"&gt;Ceremony&lt;/h2&gt;
             &lt;p&gt;Opening Procession&lt;/p&gt;
             &lt;p&gt;Speech by Valedictorian&lt;/p&gt;
             &lt;p&gt;Speech by Class President&lt;/p&gt;

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -534,7 +534,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
   </dl>
 
   The <{cite}> element <a>represents</a> a reference to a creative work. It must include
-  the title of the work or the name of the author(person, people or organization) or an URL
+  the title of the work or the name of the author (person, people or organization) or an URL
   reference, or a reference in abbreviated form as per the conventions used for the addition of
   citation metadata.
 

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -2169,7 +2169,7 @@
     <{frameset}>, <{h1}>, <{h2}>, <{h3}>, <{h4}>,
     <{h5}>, <{h6}>, <{head}>, <{header}>,
     <{hr}>, <{html}>, <{iframe}>,
-    <{img}>, <{input}>, <{isindex}>, <{li}>, <{link}>,
+    <{img}>, <{input}>, <{li}>, <{link}>,
     <{listing}>, <{main}>, <{marquee}>, <{menu}>,
     <{menuitem}>, <{meta}>, <{nav}>, <{noembed}>,
     <{noframes}>, <{noscript}>, <{object}>, <{ol}>,
@@ -6565,69 +6565,6 @@
 
     <a for="parser">parse error</a>. Change the token's tag name to "img" and reprocess it. (Don't
     ask.)
-    </dd>
-
-    <dt>A start tag whose tag name is "isindex"</dt>
-    <dd>
-
-    <a for="parser">parse error</a>.
-
-    If there is no <{template}> element on the <a>stack of open elements</a> and
-    the <a><code>form</code> element pointer</a> is not null, then ignore the
-    token.
-
-    Otherwise:
-
-    <a>Acknowledge the token's <i>self-closing
-    flag</i></a>, if it is set.
-
-    Set the <a>frameset-ok flag</a> to "not ok".
-
-    If the <a>stack of open elements</a> <a>has a
-    <code>p</code> element in button scope</a>, then <a>close a <code>p</code>
-    element</a>.
-
-    <a>Insert an HTML element</a> for a "form" start tag token with no attributes, and, if
-    there is no <{template}> element on the <a>stack of open elements</a>, set the
-    <a><code>form</code> element pointer</a> to point to the element
-    created.
-
-    If the token has an attribute called "action", set the <code>action</code> attribute on the resulting <{form}> element to the
-    value of the "action" attribute of the token.
-
-    <a>Insert an HTML element</a> for an "hr" start tag token with no attributes.
-    Immediately pop the <a>current node</a> off the <a>stack of open elements</a>.
-
-    <a>reconstruct the active formatting elements</a>, if any.
-
-    <a>Insert an HTML element</a> for a "label" start tag token with no attributes.
-
-    <a>Insert characters</a> (see below for <a lt="prompt">what they should say</a>).
-
-    <a>Insert an HTML element</a> for an "input" start tag token with all the attributes
-    from the "isindex" token except "name", "action", and "prompt", and with an attribute named
-    "name" with the value "isindex". (This creates an <{input}> element with the <code>name</code> attribute set to the magic value "<code>isindex</code>".) Immediately pop the <a>current node</a> off
-    the <a>stack of open elements</a>.
-
-    <a lt="insert a character">Insert more characters</a> (see below for <a lt="prompt">what they should say</a>).
-
-    Pop the <a>current node</a> (which will be the <{label}> element created
-    earlier) off the <a>stack of open elements</a>.
-
-    <a>Insert an HTML element</a> for an "hr" start tag token with no attributes.
-    Immediately pop the <a>current node</a> off the <a>stack of open elements</a>.
-
-    Pop the <a>current node</a> (which will be the <{form}> element created
-    earlier) off the <a>stack of open elements</a>, and, if there is no <code>template</code>
-    element on the <a>stack of open elements</a>, set the <a><code>form</code> element pointer</a> back to null.
-
-    <dfn lt="prompt"><strong>Prompt</strong></dfn>: If the token has an attribute
-    with the name "prompt", then the first stream of characters must be the same string as given in
-    that attribute, and the second stream of characters must be empty. Otherwise, the two streams of
-    character tokens together should, together with the <{input}> element, express the
-    equivalent of "This is a searchable index. Enter search keywords: (input field)" in the user's
-    preferred language.
-
     </dd>
 
     <dt>A start tag whose tag name is "textarea"</dt>


### PR DESCRIPTION
- Adding space for grammar mistake (https://www.w3.org/Bugs/Public/show_bug.cgi?id=29107)
- Remove isindex special handling (https://www.w3.org/Bugs/Public/show_bug.cgi?id=28326)
- Cleaned up extra trailing white space
- Corrected capitalization of tag name (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27628)
- Rephrased sentence
  - (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27423)
  - (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27407)
  - (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27385)
  - (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27365)
  - (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27290)
- Make "width descriptor" link properly (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27393)
- Correct spelling/grammar (https://www.w3.org/Bugs/Public/show_bug.cgi?id=27362)
- Make WebVTT usage a note (https://www.w3.org/Bugs/Public/show_bug.cgi?id=22368)
