### PR TITLE
Restore the rev attribute to <a> and <link>

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -171,6 +171,7 @@
   Csaba Gabor,
   Csaba Marton,
   Cynthia Shelly,
+  Dan Brickley,
   Dan Yoder,
   Daniel Barclay,
   Daniel Bratell,

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -634,7 +634,7 @@
       <th><{links/rev}></th>
       <td><{a}>; <{link}></td>
       <td>Describes a <a>reverse link</a> from the resource to the containing document</td>
-      <td><a>Set of space-separated tokens</a>*</td>
+      <td><a>Set of space-separated tokens</a></td>
     </tr>
     <tr>
       <th><code>reversed</code></th>

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -619,7 +619,7 @@
       <td><a>Boolean attribute</a></td>
     </tr>
     <tr>
-      <th><code>rel</code></th>
+      <th><{links/rel}></th>
       <td><{a}>; <{area}>; <{link}></td>
       <td>Relationship between the document containing the hyperlink and the destination resource</td>
       <td><a>Set of space-separated tokens</a>*</td>
@@ -707,7 +707,7 @@
     <tr>
       <th><code>sizes</code></th>
       <td><{link}></td>
-      <td>Sizes of the icons (for <code>rel</code>="<code>icon</code>")</td>
+      <td>Sizes of the icons (for <{link/rel}>="<code>icon</code>")</td>
       <td><a>Unordered set of unique space-separated tokens</a>, <a>ASCII case-insensitive</a>, consisting of sizes*</td>
     </tr>
     <tr>

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -631,6 +631,12 @@
       <td><a>Boolean attribute</a></td>
     </tr>
     <tr>
+      <th><{links/rev}></th>
+      <td><{a}>; <{link}></td>
+      <td>Describes a <a>reverse link</a> from the resource to the containing document</td>
+      <td><a>Set of space-separated tokens</a>*</td>
+    </tr>
+    <tr>
       <th><code>reversed</code></th>
       <td><{ol}></td>
       <td>Number the list backwards</td>

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -621,7 +621,7 @@
     <tr>
       <th><{links/rel}></th>
       <td><{a}>; <{area}>; <{link}></td>
-      <td>Relationship between the document containing the hyperlink and the destination resource</td>
+      <td>Relationship of this document (or subsection/topic) to the destination resource</td>
       <td><a>Set of space-separated tokens</a>*</td>
     </tr>
     <tr>
@@ -633,7 +633,7 @@
     <tr>
       <th><{links/rev}></th>
       <td><{a}>; <{link}></td>
-      <td>Describes a <a>reverse link</a> from the resource to the containing document</td>
+      <td><a>Reverse link</a> relationship of the destination resource to this document (or subsection/topic)</td>
       <td><a>Set of space-separated tokens</a></td>
     </tr>
     <tr>

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -185,11 +185,6 @@
   : <dfn element-attr for="option"><code>name</code></dfn> on <{option}> elements
   :: Use the <{global/id}> attribute instead.
 
-  : <dfn element-attr for="a"><code>rev</code></dfn> on <{a}> elements
-  : <dfn element-attr for="link"><code>rev</code></dfn> on <{link}> elements
-  :: Use the <code>rel</code> attribute instead, with an opposite term. (For example, instead of
-      <code>rev="made"</code>, use <code>rel="author"</code>.)
-
   : <dfn element-attr for="a"><code>urn</code></dfn> on <{a}> elements
   : <dfn element-attr for="link"><code>urn</code></dfn> on <{link}> elements
   :: Specify the preferred persistent identifier using the <{link/href}> attribute instead.
@@ -867,13 +862,14 @@
       attribute DOMString coords;
       attribute DOMString charset;
       attribute DOMString name;
-      attribute DOMString rev;
       attribute DOMString shape;
     };
   </pre>
 
-  The <dfn attribute for="HTMLAnchorElement"><code>coords</code></dfn>, <dfn attribute for="HTMLAnchorElement"><code>charset</code></dfn>, <dfn attribute for="HTMLAnchorElement"><code>name</code></dfn>,
-  {{HTMLAnchorElement/rev}}, and <dfn attribute for="HTMLAnchorElement"><code>shape</code></dfn> IDL attributes of the
+  The <dfn attribute for="HTMLAnchorElement"><code>coords</code></dfn>,
+  <dfn attribute for="HTMLAnchorElement"><code>charset</code></dfn>,
+  <dfn attribute for="HTMLAnchorElement"><code>name</code></dfn>, and
+  <dfn attribute for="HTMLAnchorElement"><code>shape</code></dfn> IDL attributes of the
   <{a}> element must <a>reflect</a> the respective content attributes of the same name.
 
   <hr />
@@ -1183,14 +1179,13 @@
   <pre class="idl" data-highlight="webidl" dfn-for="HTMLLinkElement">
     partial interface HTMLLinkElement {
       attribute DOMString charset;
-      attribute DOMString rev;
       attribute DOMString target;
     };
   </pre>
 
-  The <dfn attribute for="HTMLLinkElement"><code>charset</code></dfn>, {{HTMLLinkElement/rev}}, and
-  <dfn attribute for="HTMLLinkElement"><code>target</code></dfn> IDL attributes of the <{link}> element must <a>reflect</a>
-  the respective content attributes of the same name.
+  The <dfn attribute for="HTMLLinkElement"><code>charset</code></dfn> and
+  <dfn attribute for="HTMLLinkElement"><code>target</code></dfn> IDL attributes of the <{link}>
+  element must <a>reflect</a> the respective content attributes of the same name.
 
   <hr />
 

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -322,14 +322,14 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> — Address of the <a>hyperlink</a></dd>
     <dd><code>crossorigin</code> — How the element handles crossorigin requests</dd>
-    <dd>
-      <code>rel</code> — Relationship between the document containing the hyperlink and the
-      destination resource
-    </dd>
+    <dd><{link/rel}> — Relationship between the document containing the hyperlink and the
+        destination resource</dd>
+    <dd><{link/rev}> — Reverse relationship between the destination resource and the document
+        containing the hyperlink</dd>
     <dd><code>media</code> — Applicable media</dd>
     <dd><code>hreflang</code> — Language of the linked resource</dd>
     <dd><code>type</code> — Hint for the type of the referenced resource</dd>
-    <dd><code>sizes</code> — Sizes of the icons (for <code>rel</code>="<code>icon</code>")</dd>
+    <dd><code>sizes</code> — Sizes of the icons (for <{link/rel}>="<code>icon</code>")</dd>
     <dd>
       Also, the <{link/title}> attribute has special semantics on this element:  Title of the
       link; alternative style sheet set name.
@@ -347,7 +347,6 @@
           attribute DOMString href;
           attribute DOMString? crossOrigin;
           attribute DOMString rel;
-
           attribute DOMString rev;
           readonly attribute DOMTokenList relList;
           attribute DOMString media;
@@ -367,33 +366,33 @@
   <span class="impl">If the <{link/href}> attribute is absent, then the element does not define
   a link.</span>
 
-  A <{link}> element must a <code>rel</code> attribute.
+  A <{link}> element must have a <{link/rel}> attribute.
 
   <p class="note">
-    If the <code>rel</code> attribute is used, the element is restricted to the <code>head</code>
+    If the <{link/rel}> attribute is used, the element is restricted to the <code>head</code>
     element.
   </p>
 
   The types of link indicated (the relationships) are given by the value of the
-  <dfn element-attr for="link"><code>rel</code></dfn> attribute, which, if present, must have a value that is a <a>set of
-  space-separated tokens</a>. The <a>allowed keywords and their meanings</a> are defined in a later
-  section. <span class="impl">If the <code>rel</code> attribute is absent, has no keywords, or if
-  none of the keywords used are allowed according to the definitions in this specification, then the
-  element does not create any links.</span>
+  <dfn element-attr for="link,links"><code>rel</code></dfn> attribute, which, if present, must have a
+  value that is a <a>set of space-separated tokens</a>. The <a>allowed keywords and their
+  meanings</a> are defined in a later section. If the <{link/rel}> attribute is absent, has no
+  keywords, or if none of the keywords used are allowed according to the definitions in this
+  specification, then the element does not create any links.
 
   Two categories of links can be created using the <{link}> element:
   <a>Links to external resources</a> and <a>hyperlinks</a>. The [[#sec-link-types]] section defines
   whether a particular link type is an external resource or a hyperlink. One <code>link</code>
   element can create multiple links (of which some might be external resource links and some might
   be hyperlinks); exactly which and how many links are created depends on the keywords given in the
-  <code>rel</code> attribute. User agents must process the links on a per-link
+  <{link/rel}> attribute. User agents must process the links on a per-link
   basis, not a per-element basis.
 
   <p class="note">
     Each link created for a <{link}> element is handled separately. For instance, if there
     are two <{link}> elements with <code>rel="stylesheet"</code>, they each count as a
     separate external resource, and each is affected by its own attributes independently. Similarly,
-    if a single <{link}> element has a <code>rel</code> attribute with the value
+    if a single <{link}> element has a <{link/rel}> attribute with the value
     <code>next stylesheet</code>, it creates both a <a>hyperlink</a> (for the <code>next</code>
     keyword) and an <a>external resource link</a> (for the <code>stylesheet</code> keyword), and
     they are affected by other attributes (such as <code>media</code> or <code>title</code>)
@@ -408,6 +407,30 @@
     The two links created by this element are one whose semantic is that the target page has
     information about the current page's author, and one whose semantic is that the target page has
     information regarding the license under which the current page is provided.
+  </div>
+
+  <{link}> and <{a}> elements may also have a
+  <dfn element-attr for="links,link,a"><code>rev</code></dfn> attribute, which is used to describe
+  a <a>reverse link</a> relationship from the resource specified by the <{links/href}> to the
+  current document. If present, the value of this attribute must be a <a>set of space-separated
+  tokens</a>. Like the <{links/rel}> attribute, [[#sec-link-types]] describes the <a>allowed
+  keywords and their meanings</a> for the <{links/rev}> attribute. Both the <{links/rel}> and
+  <{links/rev}> attributes may be present on the same element.
+
+  <dfn lt="reverse link|Reverse links">Reverse links</dfn> compliment the typical "forward link" by
+  describing the relationship that the linked-to document has with the current document. This can
+  enable user agents to build a more comprehensive map of linked documents.
+
+  <div class="example">Given two documents, each containing a chapter of a book, the links between
+  them could be described with the <{link/rel}> and <{links/rev}> attributes as follows (where both
+  links are semantically equivalent:
+
+  Document with URL "chapter1.html" 
+  <pre highlight="html">&lt;link href="chapter2.html" rel="Next"&gt;</pre>
+  
+  Document with URL "chapter2.html" 
+  <pre highlight="html">&lt;link href="chapter1.html" rev="Prev"&gt;</pre>
+
   </div>
 
   The <dfn element-attr for="link"><code>crossorigin</code></dfn> attribute is a <a>CORS settings attribute</a>. It is
@@ -466,7 +489,7 @@
     from the element's attributes, again as defined below), in some form or another (possibly
     simplified), for each hyperlink created with each <{link}> element in the document:
 
-    * The relationship between this document and the resource (given by the <code>rel</code>
+    * The relationship between this document and the resource (given by the <{link/rel}>
         attribute)
     * The title of the resource (given by the <code>title</code> attribute).
     * The address of the resource (given by the <{link/href}> attribute).
@@ -478,8 +501,8 @@
   </div>
 
   <p class="note">
-    Hyperlinks created with the <{link}> element and its <code>rel</code> attribute apply
-    to the whole page. This contrasts with the <code>rel</code> attribute of <{a}> and
+    Hyperlinks created with the <{link}> element and its <{link/rel}> attribute apply
+    to the whole page. This contrasts with the <{links/rel}> attribute of <{a}> and
     <{area}> elements, which indicates the type of a link whose context is given by the
     link's location within the document.
   </p>
@@ -587,7 +610,7 @@
   </p>
 
   The <code>sizes</code> attribute is used with the <code>icon</code> link type. The attribute must
-  not be specified on <{link}> elements that do not have a <code>rel</code> attribute that
+  not be specified on <{link}> elements that do not have a <{link/rel}> attribute that
   specifies the <code>icon</code> keyword.
 
   <div class="impl">
@@ -622,19 +645,19 @@
     defined in <a>HTML link types</a> which are allowed on <code>link</code> elements and supported
     by the user agent.
 
-    <code>rel</code>'s
+    <{link/rel}>'s
     <a>supported tokens</a> are the keywords defined in
     <a>HTML link types</a> which are allowed on <code>link</code> elements, impact
     the processing model, and are supported by the user agent. The possible supported tokens are
     <code>alternate</code>, <code>icon</code>, <code>prefetch</code>,
     <code>stylesheet</code> and <code>next</code>.
-    <code>rel</code>'s
+    <{link/rel}>'s
     <a>supported tokens</a> must only include the tokens from
     this list that the user agent implements the processing model for.
 
     Other specifications may add <a>HTML link types</a> as
     defined in <a>Other link types</a>. These specifications may require
-    that their link types be included in <code>rel</code>'s supported
+    that their link types be included in <{link/rel}>'s supported
     tokens.
   </div>
 

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -322,8 +322,8 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> — Address of the <a>hyperlink</a></dd>
     <dd><code>crossorigin</code> — How the element handles crossorigin requests</dd>
-    <dd><{link/rel}> — Relationship between the document containing the hyperlink and the destination resource</dd>
-    <dd><{link/rev}> — Describes a <a>reverse link</a> from the resource to the containing document</dd>
+    <dd><{link/rel}> — Relationship of this document (or subsection/topic) to the destination resource</dd>
+    <dd><{link/rev}> — <a>Reverse link</a> relationship of the destination resource to this document (or subsection/topic)</dd>
     <dd><code>media</code> — Applicable media</dd>
     <dd><code>hreflang</code> — Language of the linked resource</dd>
     <dd><code>type</code> — Hint for the type of the referenced resource</dd>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -322,10 +322,8 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>href</code> — Address of the <a>hyperlink</a></dd>
     <dd><code>crossorigin</code> — How the element handles crossorigin requests</dd>
-    <dd><{link/rel}> — Relationship between the document containing the hyperlink and the
-        destination resource</dd>
-    <dd><{link/rev}> — Reverse relationship between the destination resource and the document
-        containing the hyperlink</dd>
+    <dd><{link/rel}> — Relationship between the document containing the hyperlink and the destination resource</dd>
+    <dd><{link/rev}> — Describes a <a>reverse link</a> from the resource to the containing document</dd>
     <dd><code>media</code> — Applicable media</dd>
     <dd><code>hreflang</code> — Language of the linked resource</dd>
     <dd><code>type</code> — Hint for the type of the referenced resource</dd>
@@ -418,17 +416,17 @@
   <{links/rev}> attributes may be present on the same element.
 
   <dfn lt="reverse link|Reverse links">Reverse links</dfn> compliment the typical "forward link" by
-  describing the relationship that the linked-to document has with the current document. This can
+  indicating a relationship to the current document from the the linked-to resource. This can
   enable user agents to build a more comprehensive map of linked documents.
 
   <div class="example">Given two documents, each containing a chapter of a book, the links between
   them could be described with the <{link/rel}> and <{links/rev}> attributes as follows (where both
   links are semantically equivalent:
 
-  Document with URL "chapter1.html" 
+  Document with URL "chapter1.html"
   <pre highlight="html">&lt;link href="chapter2.html" rel="Next"&gt;</pre>
-  
-  Document with URL "chapter2.html" 
+
+  Document with URL "chapter2.html"
   <pre highlight="html">&lt;link href="chapter1.html" rev="Prev"&gt;</pre>
 
   </div>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -415,19 +415,42 @@
   keywords and their meanings</a> for the <{links/rev}> attribute. Both the <{links/rel}> and
   <{links/rev}> attributes may be present on the same element.
 
-  <dfn lt="reverse link|Reverse links">Reverse links</dfn> compliment the typical "forward link" by
-  indicating a relationship to the current document from the the linked-to resource. This can
-  enable user agents to build a more comprehensive map of linked documents.
+  <dfn lt="reverse link|Reverse links">Reverse links</dfn> are a way to express the reverse
+  directional relationship of a link. In contrast to the <{links/rel}> attribute, whose value
+  conveys a forward directional relationship ("how is the link related to me"), the <{links/rev}>
+  attribute allows for similiar relationships to be expressed in the reverse direction ("how am I
+  related to this link"). These values can enable user agents to build a more comprehensive map of
+  linked documents.
 
   <div class="example">Given two documents, each containing a chapter of a book, the links between
-  them could be described with the <{link/rel}> and <{links/rev}> attributes as follows (where both
-  links are semantically equivalent:
+  them could be described with the <{link/rel}> and <{links/rev}> attributes as follows:
 
   Document with URL "chapter1.html"
-  <pre highlight="html">&lt;link href="chapter2.html" rel="Next"&gt;</pre>
+  <pre highlight="html">&lt;link href="chapter2.html" rel="next" rev="prev"&gt;</pre>
 
   Document with URL "chapter2.html"
-  <pre highlight="html">&lt;link href="chapter1.html" rev="Prev"&gt;</pre>
+  <pre highlight="html">
+&lt;link href="chapter1.html" rel="prev" rev="next"&gt;
+&lt;link href="chapter3.html" rel="next" rev="prev"&gt;</pre>
+
+  From chapter1.html, the link to chapter2.html is the "<code>next</code>" chapter in the series in the
+  forward direction, and the "<code>previous</code>" chapter in the reverse diretion (from
+  chapter2.html to chapter1.html).
+  </div>
+
+  <div class="example">The links in a table of contents document might be described using
+  <{links/rel}> and <{links/rev}> as follows:
+  <pre highlight="html">
+  &lt;ol&gt;
+    &lt;li&gt;&lt;a href="chapter1.html" rev="toc" rel="next"&gt;chapter 1&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="chapter2.html" rev="toc"&gt;&lt;/a&gt;chapter 2&lt;/li&gt;
+    &lt;li&gt;&lt;a href="chapter3.html" rev="toc"&gt;&lt;/a&gt;chapter 3&lt;/li&gt;
+  &lt;/ol&gt;
+  </pre>
+
+  From the table of contents, the "<code>next</code>" logical path is to the first chapter,
+  expressed using <{links/rel}>. Each chapter link has a "<code>toc</code>" <{links/rev}> value
+  which indicates that the current document is the table of contents document for every chapter.
 
   </div>
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -12995,7 +12995,7 @@ red:89
     <dd><code>download</code> - Whether to download the resource instead of navigating to it, and its file name if so</dd>
     <dd><code>href</code> - Address of the <a>hyperlink</a></dd>
     <dd><code>hreflang</code> -  Language of the linked resource</dd>
-    <dd><{area/rel}> - Relationship between the document containing the hyperlink and the destination resource</dd>
+    <dd><{area/rel}> - Relationship of this document (or subsection/topic) to the destination resource</dd>
     <dd><code>shape</code> - The kind of shape to be created in an <a>image map</a></dd>
     <dd><code>target</code> - <a>browsing context</a> for <a>hyperlink</a> <a>navigation</a></dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -12995,7 +12995,7 @@ red:89
     <dd><code>download</code> - Whether to download the resource instead of navigating to it, and its file name if so</dd>
     <dd><code>href</code> - Address of the <a>hyperlink</a></dd>
     <dd><code>hreflang</code> -  Language of the linked resource</dd>
-    <dd><code>rel</code> Relationship between the document containing the hyperlink and the destination resource</dd>
+    <dd><{area/rel}> - Relationship between the document containing the hyperlink and the destination resource</dd>
     <dd><code>shape</code> - The kind of shape to be created in an <a>image map</a></dd>
     <dd><code>target</code> - <a>browsing context</a> for <a>hyperlink</a> <a>navigation</a></dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
@@ -13118,13 +13118,13 @@ red:89
   When user agents allow users to <a>follow hyperlinks</a> or
   <a>download hyperlinks</a> created using the
   <{area}> element, as described in the next section, the <code>href</code>, <code>target</code>,
-  and <code>download</code> attributes decide how the link is followed. The <code>rel</code>,
+  and <code>download</code> attributes decide how the link is followed. The <{area/rel}>,
   <code>hreflang</code>, and <code>type</code> attributes may be used to indicate to the user the
   likely nature of the target resource before the user follows the link.
 
   </div>
 
-  The <code>target</code>, <code>download</code>, <code>rel</code>, <code>hreflang</code>, and
+  The <code>target</code>, <code>download</code>, <{area/rel}>, <code>hreflang</code>, and
   <code>type</code> attributes must be omitted if the <code>href</code> attribute is not present.
 
   <div class="impl">

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -25,14 +25,14 @@
   </dl>
 
   For <{link}> elements with an <code>href</code> attribute and a
-  <code>rel</code> attribute, links must be created for the keywords of the
-  <code>rel</code> attribute, as defined for those keywords in the <a>link types</a> section.
+  <{link/rel}> attribute, links must be created for the keywords of the
+  <{link/rel}> attribute, as defined for those keywords in the <a>link types</a> section.
 
-  Similarly, for <{a}> and <{area}> elements with an <code>href</code> attribute and a <code>rel</code> attribute, links must be created for the keywords of the
-  <code>rel</code> attribute as defined for those keywords in the <a>link types</a> section. Unlike <{link}> elements, however,
+  Similarly, for <{a}> and <{area}> elements with an <code>href</code> attribute and a <{links/rel}> attribute, links must be created for the keywords of the
+  <{links/rel}> attribute as defined for those keywords in the <a>link types</a> section. Unlike <{link}> elements, however,
   <{a}> and <{area}> elements with an <code>href</code>
-  attribute that either do not have a <code>rel</code> attribute, or
-  whose <code>rel</code> attribute has no keywords that are defined as
+  attribute that either do not have a <{links/rel}> attribute, or
+  whose <{links/rel}> attribute has no keywords that are defined as
   specifying <a>hyperlinks</a>, must also create a <a>hyperlink</a>.
   This implied hyperlink has no special meaning (it has no <a>link type</a>)
   beyond linking the element's <a>node document</a> to the resource given by the element's <code>href</code> attribute.
@@ -77,11 +77,12 @@
   what punctuation is supported in file names, and user agents are likely to adjust file names
   accordingly.
 
-  The <dfn element-attr for="links"><code>rel</code></dfn> attribute on <{a}> and
+  The <dfn element-attr for="a,area"><code>rel</code></dfn> attribute on <{a}> and
   <{area}> elements controls what kinds of links the elements create. The attribute's value
-  must be a <a>set of space-separated tokens</a>. The <a>allowed keywords and their meanings</a> are defined below.
+  must be a <a>set of space-separated tokens</a>. The <a>allowed keywords and their meanings</a> are
+  defined below.
 
-  <code>rel</code>'s
+  <{links/rel}>'s
   <a>supported tokens</a> are the keywords defined in
   <a>HTML link types</a> which are allowed on <{a}> and
   <{area}> elements, impact the processing model, and are supported by the user agent. The
@@ -89,16 +90,16 @@
   <code>noreferrer</code>,
   <code>noopener</code>, and
   <code>prefetch</code>.
-  <code>rel</code>'s
+  <{links/rel}>'s
   <a>supported tokens</a> must only include the tokens from
   this list that the user agent implements the processing model for.</p>
 
   Other specifications may add <a>HTML link types</a> as
   defined in <a>Other link types</a>. These specifications may require
-  that their link types be included in <code>rel</code>'s supported
+  that their link types be included in <{links/rel}>'s supported
   tokens.
 
-  The <code>rel</code> attribute has no default value. If the
+  The <{links/rel}> attribute has no default value. If the
   attribute is omitted or if none of the values in the attribute are recognized by the user agent,
   then the document has no particular relationship with the destination resource other than there
   being a hyperlink between the two.
@@ -870,12 +871,13 @@
   <div class="impl">
 
   To determine which link types apply to a <{link}>, <{a}>, or
-  <{area}> element, the element's <code>rel</code> attribute must be <a lt="split a string on spaces">split on spaces</a>. The resulting tokens are the link types
+  <{area}> element, the element's <{links/rel}> attribute must be <a lt="split a string on spaces">split on spaces</a>. The resulting tokens are the link types
   that apply to that element.
 
   </div>
 
-  Except where otherwise specified, a keyword must not be specified more than once per <code>rel</code> attribute.
+  Except where otherwise specified, a keyword must not be specified more than once per <{link/rel}>
+  attribute.
 
   Link types are always <a>ASCII case-insensitive</a><span class="impl">, and must be
   compared as such</span>.
@@ -1013,7 +1015,7 @@
 
   <dl class="switch">
 
-    <dt>If the element is a <{link}> element and the <code>rel</code>
+    <dt>If the element is a <{link}> element and the <{link/rel}>
     attribute also contains the keyword <code>stylesheet</code></dt>
 
     <dd>
@@ -1115,7 +1117,7 @@
   <div class="impl">
 
   <strong>Synonyms</strong>: For historical reasons, user agents must also treat
-  <{link}>, <{a}>, and <{area}> elements that have a <code>rev</code> attribute with the value "<code>made</code>" as having the <code>author</code> keyword specified as a link relationship.
+  <{link}>, <{a}>, and <{area}> elements that have a <{links/rev}> attribute with the value "<code>made</code>" as having the <code>author</code> keyword specified as a link relationship.
 
   </div>
 
@@ -1328,7 +1330,7 @@
 
   For historical reasons, the <code>icon</code> keyword may be preceded by the
   keyword "<code>shortcut</code>". If the "<code>shortcut</code>" keyword is
-  present, the <code>rel</code> attribute's entire value must be an
+  present, the <{link/rel}> attribute's entire value must be an
   <a>ASCII case-insensitive</a> match for the string "<code>shortcut&nbsp;icon</code>" (with a single U+0020 SPACE character between the tokens and
   no other <a>space characters</a>).
 
@@ -1837,7 +1839,7 @@
 
   Types defined as extensions in the <a>microformats
   wiki existing-rel-values page</a> with the status "proposed" or "ratified" may be used with the
-  <code>rel</code> attribute on <{link}>, <{a}>, and <code>area</code>
+  <{links/rel}> attribute on <{link}>, <{a}>, and <{area}>
   elements in accordance to the "Effect on..." field. [[!MFREL]]
 
 </section>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -27,10 +27,10 @@
       <code>download</code> - Whether to download the resource instead of navigating to it, and its
       file name if so
     </dd>
-    <dd>
-      <code>rel</code> - Relationship between the document containing the hyperlink and the
-      destination resource
-    </dd>
+    <dd><{a/rel}> - Relationship between the document containing the hyperlink and the destination
+        resource</dd>
+    <dd><{a/rev}> — Reverse relationship between the destination resource and the document
+        containing the hyperlink</dd>
     <dd><code>hreflang</code> - Language of the linked resource</dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
@@ -65,13 +65,11 @@
   If the <{a}> element has an <{links/href}> attribute, then it <a>represents</a> a
   <a>hyperlink</a> (a hypertext anchor) labeled by its contents.
 
-
-
   If the <{a}> element has no <{links/href}> attribute, then the element
   <a>represents</a> a placeholder for where a link might otherwise have been placed, if it had been
   relevant, consisting of just the element's contents.
 
-  The <code>target</code>, <code>download</code>, <code>rel</code>, <code>hreflang</code>, and
+  The <code>target</code>, <code>download</code>, <{a/rel}>, <{a/rev}>, <code>hreflang</code>, and
   <code>type</code> attributes must be omitted if the <{links/href}> attribute is not present.
 
   <div class="example">
@@ -94,7 +92,7 @@
   <div class="impl">
     The <{links/href}>, <code>target</code>, <code>download</code>, and attributes affect what
     happens when users <a>follow hyperlinks</a> or <a>download hyperlinks</a> created using the
-    <{a}> element. The <code>rel</code>, <code>hreflang</code>, and <code>type</code>
+    <{a}> element. The <{a/rel}>, <{a/rev}>, <code>hreflang</code>, and <code>type</code>
     attributes may be used to indicate to the user the likely nature of the target resource before
     the user follows the link.
 
@@ -143,7 +141,7 @@
     <dfn attribute for="HTMLAnchorElement"><code>hreflang</code></dfn>, and <dfn attribute for="HTMLAnchorElement"><code>type</code></dfn>, must <a>reflect</a> the
     respective content attributes of the same name.
 
-    The IDL attribute <dfn attribute for="HTMLAnchorElement"><code>relList</code></dfn> must <a>reflect</a> the <code>rel</code>
+    The IDL attribute <dfn attribute for="HTMLAnchorElement"><code>relList</code></dfn> must <a>reflect</a> the <{a/rel}>
     content attribute.
 
     The <dfn attribute for="HTMLAnchorElement"><code>text</code></dfn> IDL attribute, on getting, must return the same value as the

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -27,10 +27,8 @@
       <code>download</code> - Whether to download the resource instead of navigating to it, and its
       file name if so
     </dd>
-    <dd><{a/rel}> - Relationship between the document containing the hyperlink and the destination
-        resource</dd>
-    <dd><{a/rev}> — Reverse relationship between the destination resource and the document
-        containing the hyperlink</dd>
+    <dd><{a/rel}> - Relationship between the document containing the hyperlink and the destination resource</dd>
+    <dd><{a/rev}> - Describes a <a>reverse link</a> from the resource to the containing document</dd>
     <dd><code>hreflang</code> - Language of the linked resource</dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -27,8 +27,8 @@
       <code>download</code> - Whether to download the resource instead of navigating to it, and its
       file name if so
     </dd>
-    <dd><{a/rel}> - Relationship between the document containing the hyperlink and the destination resource</dd>
-    <dd><{a/rev}> - Describes a <a>reverse link</a> from the resource to the containing document</dd>
+    <dd><{a/rel}> — Relationship of this document (or subsection/topic) to the destination resource</dd>
+    <dd><{a/rev}> — <a>Reverse link</a> relationship of the destination resource to this document (or subsection/topic)</dd>
     <dd><code>hreflang</code> - Language of the linked resource</dd>
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -161,7 +161,7 @@ path: sections/semantics-common-idioms.include
     </li><li><code>noshade</code>
     </li><li><code>nowrap</code>
     </li><li><code>readonly</code>
-    </li><li><code>rel</code>
+    </li><li><{links/rel}>
     </li><li><code>rev</code>
     </li><li><code>rules</code>
     </li><li><code>scope</code>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -4927,7 +4927,7 @@
     agent and made available to the user by the user agent for which the resulting <a>absolute
     URL</a> is a <a>prefix match</a> of the search engine's <a for="url">URL</a>, if any. For
     search engines registered using OpenSearch description documents, the <a for="url">URL</a> of the
-    search engine corresponds to the URL given in a <code>Url</code> element whose <code>rel</code> attribute is "<code>results</code>" (the default). [[!OPENSEARCH]]</li>
+    search engine corresponds to the URL given in a <code>Url</code> element whose <{links/rel}> attribute is "<code>results</code>" (the default). [[!OPENSEARCH]]</li>
 
     <li>If <var>search engines</var> is empty, return 0 and abort these steps.</li>
 


### PR DESCRIPTION
Removes it from the obsolete section too and fixes a few links.
See Issue #256.
