### PR TITLE
Added title attributes to iframe examples in 4.7.6

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3490,15 +3490,15 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   &lt;/footer&gt;
   &lt;article&gt;
   &lt;footer&gt; Thirteen minutes ago, &lt;a href="/users/ch"&gt;ch&lt;/a&gt; wrote: &lt;/footer&gt;
-  &lt;iframe seamless sandbox srcdoc="&lt;p&gt;did you get a cover picture yet?"&gt;&lt;/iframe&gt;
+  &lt;iframe title="Comment" seamless sandbox srcdoc="&lt;p&gt;did you get a cover picture yet?"&gt;&lt;/iframe&gt;
   &lt;/article&gt;
   &lt;article&gt;
   &lt;footer&gt; Nine minutes ago, &lt;a href="/users/cap"&gt;cap&lt;/a&gt; wrote: &lt;/footer&gt;
-  &lt;iframe seamless sandbox srcdoc="&lt;p&gt;Yeah, you can see it &lt;a href=&amp;quot;/gallery?mode=cover&amp;amp;amp;page=1&amp;quot;&gt;in my gallery&lt;/a&gt;."&gt;&lt;/iframe&gt;
+  &lt;iframe title="Comment" seamless sandbox srcdoc="&lt;p&gt;Yeah, you can see it &lt;a href=&amp;quot;/gallery?mode=cover&amp;amp;amp;page=1&amp;quot;&gt;in my gallery&lt;/a&gt;."&gt;&lt;/iframe&gt;
   &lt;/article&gt;
   &lt;article&gt;
   &lt;footer&gt; Five minutes ago, &lt;a href="/users/ch"&gt;ch&lt;/a&gt; wrote: &lt;/footer&gt;
-  &lt;iframe seamless sandbox srcdoc="&lt;p&gt;hey that's earl's table.
+  &lt;iframe title="Comment" seamless sandbox srcdoc="&lt;p&gt;hey that's earl's table.
 &lt;p&gt;you should get earl&amp;amp;amp;me on the next cover."&gt;&lt;/iframe&gt;
   &lt;/article&gt;
     </pre>
@@ -3788,7 +3788,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
 
     <pre highlight="html">
 &lt;p&gt;We're not scared of you! Here is your content, unedited:&lt;/p&gt;
-&lt;iframe sandbox src="http://usercontent.example.net/getusercontent.cgi?id=12193"&gt;&lt;/iframe&gt;
+&lt;iframe title="Example iframe" sandbox src="http://usercontent.example.net/getusercontent.cgi?id=12193"&gt;&lt;/iframe&gt;
     </pre>
 
     <p class="warning">It is important to use a separate domain so that if the attacker convinces the
@@ -3804,7 +3804,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     thus reducing the risk of the user being exposed to malware and other annoyances.
 
     <pre highlight="html">
-&lt;iframe sandbox="allow-same-origin allow-forms allow-scripts"
+&lt;iframe title="Maps" sandbox="allow-same-origin allow-forms allow-scripts"
         src="http://maps.example.com/embedded.html"&gt;&lt;/iframe&gt;
     </pre>
 
@@ -3814,13 +3814,13 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     Suppose a file A contained the following fragment:
 
     <pre highlight="html">
-&lt;iframe sandbox="allow-same-origin allow-forms" src=B&gt;&lt;/iframe&gt;
+&lt;iframe title="Example iframe" sandbox="allow-same-origin allow-forms" src=B&gt;&lt;/iframe&gt;
     </pre>
 
     Suppose that file B contained an iframe also:
 
     <pre highlight="html">
-&lt;iframe sandbox="allow-scripts" src=C&gt;&lt;/iframe&gt;
+&lt;iframe title="Example iframe" sandbox="allow-scripts" src=C&gt;&lt;/iframe&gt;
     </pre>
 
     Further, suppose that file C contained a link:
@@ -3872,7 +3872,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   &lt;h1&gt;Mirror Mirror&lt;/h1&gt;
   &lt;p&gt;Part of the MovieInfo™ Database&lt;/p&gt;
   &lt;nav&gt;
-  &lt;iframe seamless src="nav.inc"&gt;&lt;/iframe&gt;
+  &lt;iframe title="Movie links" seamless src="nav.inc"&gt;&lt;/iframe&gt;
   &lt;/nav&gt;
 &lt;/header&gt;
 ...
@@ -4028,7 +4028,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   &lt;/header&gt;
   &lt;main&gt;
   &lt;p&gt;Check out my new ride!&lt;/p&gt;
-  &lt;iframe src="https://video.example.com/embed?id=92469812" allowfullscreen&gt;&lt;/iframe&gt;
+  &lt;iframe title="Video" src="https://video.example.com/embed?id=92469812" allowfullscreen&gt;&lt;/iframe&gt;
   &lt;/main&gt;
 &lt;/article&gt;
     </pre>
@@ -4094,7 +4094,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     advertising broker:
 
     <pre highlight="html">
-&lt;iframe src="http://ads.example.com/?customerid=923513721&amp;amp;format=banner"
+&lt;iframe title="Advert" src="http://ads.example.com/?customerid=923513721&amp;amp;format=banner"
         width="468" height="60"&gt;&lt;/iframe&gt;
     </pre>
 


### PR DESCRIPTION
Proposed fix for <a href="https://github.com/w3c/html/issues/298">#298</a>
