### PR TITLE
Fix markup

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -436,7 +436,7 @@
     <tr>
       <th rowspan=2>Keyword
       <th rowspan=2>Ordinary effect
-      <th colspan=5>Effect in an <code>iframe</code> with...
+      <th colspan=2>Effect in an <code>iframe</code> with...
     <tr>
       <th><code>sandbox=""</code>
       <th><code>sandbox="allow-top-navigation"</code>


### PR DESCRIPTION
The table in the "Browsing context names" only has 4 columns. That PR fixes the `colspan` number
