### PR TITLE
Change 'popup' to 'context'

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -846,7 +846,7 @@
       <th><code>type</code></th>
       <td><{menu}></td>
       <td>Type of menu</td>
-      <td>"<code>popup</code>"; "<code>toolbar</code>"</td>
+      <td>"<code>context</code>"; "<code>toolbar</code>"</td>
     </tr>
     <tr>
       <th><code>type</code></th>


### PR DESCRIPTION
- Remove last reference to the `popup` value for `<menu type=`

Fix: #38 
- This was already added to changes section
