### PR TITLE
Add note for html and head element attribute usage suggestions

### DIFF
--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -43,8 +43,7 @@
     </dd>
   </dl>
 
-  The <{head}> element <a>represents</a> a collection of metadata for the
-  {{Document}}.
+  The <{head}> element <a>represents</a> a collection of metadata for the {{Document}}.
 
   <div class="example">
     The collection of metadata in a <{head}> element can be large or small. Here is an
@@ -83,6 +82,12 @@
     The <a element for="html"><code>title</code></a> element is a required child in most situations, but when a higher-level
     protocol provides title information, e.g., in the Subject line of an e-mail when HTML is used as
     an e-mail authoring format, the <a element for="html"><code>title</code></a> element can be omitted.
+  </p>
+
+  <p class="note">
+    It is recommended to keep the usage of attributes and their values on the <{head}> element to a
+    minimum and to not exceed 1024 bytes. This allows for proper detection of the
+    <a>character encoding declaration</a> within the first 1024 bytes.
   </p>
 
 <h4 id="the-title-element">The <dfn element><code>title</code></dfn> element</h4>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -85,9 +85,9 @@
   </p>
 
   <p class="note">
-    It is recommended to keep the usage of attributes and their values on the <{head}> element to a
-    minimum and to not exceed 1024 bytes. This allows for proper detection of the
-    <a>character encoding declaration</a> within the first 1024 bytes.
+    It is recommended to keep the usage of attributes and their values defined on the <{head}>
+    element to a minimum to allow for proper detection of the <a>character encoding declaration</a>
+    within the first 1024 bytes.
   </p>
 
 <h4 id="the-title-element">The <dfn element><code>title</code></dfn> element</h4>

--- a/sections/semantics-root.include
+++ b/sections/semantics-root.include
@@ -43,6 +43,12 @@
   pronunciations to use, translation tools to determine what rules to use, and so
   forth.
 
+  <p class="note">
+    It is recommended to keep the usage of attributes and their values on the <{html}> element to a
+    minimum and to not exceed 1024 bytes. This allows for proper detection of the
+    <a>character encoding declaration</a> within the first 1024 bytes.
+  </p>
+
   The <dfn element-attr for="html"><code>manifest</code></dfn> attribute gives the address of the document's
   <a>application cache</a> <code>manifest</code>, if there is one. If the attribute is present,
   the attribute's value must be a <a>valid non-empty URL potentially surrounded by spaces</a>.

--- a/sections/semantics-root.include
+++ b/sections/semantics-root.include
@@ -44,9 +44,9 @@
   forth.
 
   <p class="note">
-    It is recommended to keep the usage of attributes and their values on the <{html}> element to a
-    minimum and to not exceed 1024 bytes. This allows for proper detection of the
-    <a>character encoding declaration</a> within the first 1024 bytes.
+    It is recommended to keep the usage of attributes and their values defined on the <{html}>
+    element to a minimum to allow for proper detection of the <a>character encoding declaration</a>
+    within the first 1024 bytes.
   </p>
 
   The <dfn element-attr for="html"><code>manifest</code></dfn> attribute gives the address of the document's


### PR DESCRIPTION
- Add a note for recommending not to exceed 1024 bytes

Fix: #305 
