### PR TITLE
Correct en-gb text to en-us to be consistent with the document text

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -2657,7 +2657,7 @@
   of the <a>joint session history</a>: since each <a>browsing context</a> might, at any
   particular time, have a different <a>event loop</a> (this can happen if the user agent has
   more than one <a>event loop</a> per <a>unit of related browsing contexts</a>),
-  transitions would otherwise have to involve cross-event-loop synchronisation.
+  transitions would otherwise have to involve cross-event-loop synchronization.
 
   <hr />
 
@@ -5279,7 +5279,7 @@
   </dl>
 
   <p class="note">
-  There are no <code>BeforeUnloadEvent</code>-specific initialisation methods.
+  There are no <code>BeforeUnloadEvent</code>-specific initialization methods.
   </p>
 
   <div class="impl">

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -11214,7 +11214,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
       </td><td> <a state for="inputmode">Latin Text</a>
       </td><td> Latin-script input in the user's preferred language(s), with typing aids intended for
       entering human names enabled (e.g., text prediction from the user's contact list and automatic
-      capitalisation at every word). Intended for situations such as customer name fields.
+      capitalization at every word). Intended for situations such as customer name fields.
 
     </td></tr><tr>
       <td> <dfn value for="form/inputmode"><code>latin-prose</code></dfn>
@@ -11222,7 +11222,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
       </td><td> <a state for="inputmode">Latin Text</a>
       </td><td> Latin-script input in the user's preferred language(s), with aggressive typing aids
       intended for human-to-human communications enabled (e.g., text prediction and automatic
-      capitalisation at the start of sentences). Intended for situations such as e-mails and instant
+      capitalization at the start of sentences). Intended for situations such as e-mails and instant
       messaging.
 
     </td></tr><tr>
@@ -11231,7 +11231,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
       </td><td> <a state for="inputmode">Latin Prose</a>
       </td><td> Latin-script input in the user's secondary language(s), using full-width characters, with
       aggressive typing aids intended for human-to-human communications enabled (e.g., text prediction
-      and automatic capitalisation at the start of sentences). Intended for latin text embedded
+      and automatic capitalization at the start of sentences). Intended for latin text embedded
       inside CJK text.
 
     </td></tr><tr>

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -270,7 +270,7 @@
    of this element's <a for="url">URL</a>'s <a>origin</a>.</li>
   </ol>
 
-  <p class="note">It returns the Unicode rather than the ASCII serialisation for
+  <p class="note">It returns the Unicode rather than the ASCII serialization for
   compatibility with <code>MessageEvent</code>.</p>
 
   <p>The <dfn attribute for="HTMLHyperlinkElementUtils"><code>protocol</code></dfn> attribute's getter must

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -1240,7 +1240,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <a>ruby text container</a>, <a>ruby base container</a>, and <a>ruby annotation container</a>
     have their equivalents in <cite>CSS Ruby Module Level 3</cite>. [[!CSS3-RUBY]]
 
-    Informally, the segmentation and categorisation algorithm below performs a simple set of
+    Informally, the segmentation and categorization algorithm below performs a simple set of
     tasks. First it processes adjacent <{rb}> elements, text nodes, and non-ruby
     elements into a list of bases. Then it processes any number of <{rtc}> elements or
     sequences of <{rt}> elements that are considered to automatically map to an
@@ -1250,7 +1250,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     of the algorithm below compared to this informal description stems from the need to support
     an author-friendly syntax and being mindful of inter-element white space.
 
-    At any particular time, the <dfn>segmentation and categorisation of content of a
+    At any particular time, the <dfn>segmentation and categorization of content of a
     <code>ruby</code></dfn> element is the result that would be obtained from running the following
     algorithm:
 
@@ -1607,7 +1607,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
       <a>represents</a> the same thing as its children.
 
       When an <{rtc}> element is processed as part of the segmentation and
-      categorisation of content for a <{ruby}> element, the following algorithm
+      categorization of content for a <{ruby}> element, the following algorithm
       defines how to <dfn>process an <{rtc}> element</dfn>:
 
     <ol>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -2884,13 +2884,13 @@
   <hr />
 
   The <dfn method for="WindowTimers"><code>setTimeout()</code></dfn> method must return
-  the value returned by the <a>timer initialisation steps</a>, passing them the method's
+  the value returned by the <a>timer initialization steps</a>, passing them the method's
   arguments, the object on which the method for which the algorithm is running is implemented (a
   <code>Window</code> or <code>WorkerGlobalScope</code> object) as the <var>method
   context</var>, and the <var>repeat</var> flag set to false.
 
   The <dfn method for="WindowTimers"><code>setInterval()</code></dfn> method must
-  return the value returned by the <a>timer initialisation steps</a>, passing them the
+  return the value returned by the <a>timer initialization steps</a>, passing them the
   method's arguments, the object on which the method for which the algorithm is running is
   implemented (a <code>Window</code> or <code>WorkerGlobalScope</code> object) as the <var>method context</var>, and the <var>repeat</var> flag set to true.
 
@@ -2910,7 +2910,7 @@
 
   <hr />
 
-  The <dfn>timer initialisation steps</dfn>, which are invoked with some method arguments, a <var>method context</var>, a <var>repeat</var> flag which can be true or false, and
+  The <dfn>timer initialization steps</dfn>, which are invoked with some method arguments, a <var>method context</var>, a <var>repeat</var> flag which can be true or false, and
   optionally (and only if the <var>repeat</var> flag is true) a <var>previous handle</var>, are as follows:
 
   <ol>
@@ -2979,7 +2979,7 @@
 
       </li>
 
-      <li>If the <var>repeat</var> flag is true, then call <a>timer initialisation
+      <li>If the <var>repeat</var> flag is true, then call <a>timer initialization
       steps</a> again, passing them the same method arguments, the same <var>method
       context</var>, with the <var>repeat</var> flag still set to true, and with the <var>previous handle</var> set to <var>handler</var>.</li>
 


### PR DESCRIPTION
- change 'isation' to 'ization' where appropriate.
