### PR TITLE
Fix for #336

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -26,13 +26,11 @@
   Any form starts with a <{form}> element, inside which are placed the controls. Most
   controls are represented by the <{input}> element, which by default provides a one-line
   text field. To label a control, the <{label}> element is used; the label text and the
-  control itself go inside the <{label}> element. Each part of a form is considered a
-  <a>paragraph</a>, and is typically separated from other parts using <{p}> elements.
-  Putting this together, here is how one might ask for the customer's name:
+  control itself go inside the <{label}> element. Each area within a form is typically represented using a <{div}> element. Putting this together, here is how one might ask for the customer's name:
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
 &lt;/form&gt;
     </pre>
 
@@ -45,12 +43,12 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
 &lt;/form&gt;
     </pre>
@@ -63,19 +61,19 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Toppings &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
 &lt;/form&gt;
     </pre>
@@ -89,21 +87,21 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Toppings &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
 &lt;/form&gt;
     </pre>
@@ -118,23 +116,23 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Toppings &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
-  &lt;p&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/div&gt;
 &lt;/form&gt;
     </pre>
 
@@ -144,24 +142,24 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Toppings &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
-  &lt;p&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Delivery instructions: &lt;textarea&gt;&lt;/textarea&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Delivery instructions: &lt;textarea&gt;&lt;/textarea&gt;&lt;/label&gt;&lt;/div&gt;
 &lt;/form&gt;
     </pre>
 
@@ -169,25 +167,25 @@
 
   <pre highlight="html">
 &lt;form&gt;
-  &lt;p&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Customer name: &lt;input&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Telephone: &lt;input type=tel&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;E-mail address: &lt;input type=email&gt;&lt;/label&gt;&lt;/div&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Size &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Small &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Medium &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=radio name=size&gt; Large &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
   &lt;fieldset&gt;
   &lt;legend&gt; Pizza Toppings &lt;/legend&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Bacon &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Extra Cheese &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Onion &lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt; &lt;input type=checkbox&gt; Mushroom &lt;/label&gt;&lt;/div&gt;
   &lt;/fieldset&gt;
-  &lt;p&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;label&gt;Delivery instructions: &lt;textarea&gt;&lt;/textarea&gt;&lt;/label&gt;&lt;/p&gt;
-  &lt;p&gt;&lt;button&gt;Submit order&lt;/button&gt;&lt;/p&gt;
+  &lt;div&gt;&lt;label&gt;Preferred delivery time: &lt;input type=time min="11:00" max="21:00" step="900"&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;label&gt;Delivery instructions: &lt;textarea&gt;&lt;/textarea&gt;&lt;/label&gt;&lt;/div&gt;
+  &lt;div&gt;&lt;button&gt;Submit order&lt;/button&gt;&lt;/div&gt;
 &lt;/form&gt;
     </pre>
 


### PR DESCRIPTION
Removed recommendation to use `<p>` to segment areas within a form, and replaced with `<div>` (including in examples).
