### PR TITLE
Editorial fix for #371

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -176,8 +176,7 @@
   A content attribute is said to <dfn>change</dfn> value only if its new value is different than its
   previous value; setting an attribute to a value it already has does not change it.
 
-  The term <dfn>empty</dfn>, when used of an attribute value, {{Text}} node, or string,
-  means that the length of the text is zero (i.e., not even containing spaces or
+  When an attribute value, {{Text}} node, or string is described as <dfn>empty</dfn>, it means that the length of the text is zero (i.e., not even containing spaces or
   <a>control characters</a>).
 
   A <a for="Node" lt="insert">node <var>A</var> is


### PR DESCRIPTION
Rephrased the sentence reported by @DavidMacDonald, per the suggestion from @Chaals, in issue #371 
