### PR TITLE
Remove spurious backslash characters from the spec

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -75,7 +75,7 @@
       customizations:
       * For the global object, create a new {{Window}} object <var>window</var>.
       * For the global <em>this</em> value, create a new {{WindowProxy}} object
-         <var>windowProxy</var>, whose \[[{{Window}}]] internal slot value is <var>window</var>.
+         <var>windowProxy</var>, whose [[{{Window}}]] internal slot value is <var>window</var>.
 
          <p class="note">The internal slot value is updated when navigations occur.</p>
       * Let <var>realm execution context</var> be the created <a>JavaScript execution context</a>.
@@ -746,10 +746,10 @@
 
 <h4 id="shared-internal-slot-crossoriginpropertydescriptormap">Shared internal slot: \[[CrossOriginPropertyDescriptorMap]]</h4>
 
-  {{Window}} and {{Location}} objects both have a \[[<dfn>CrossOriginPropertyDescriptorMap</dfn>]]
+  {{Window}} and {{Location}} objects both have a [[<dfn>CrossOriginPropertyDescriptorMap</dfn>]]
   internal slot, whose value is initially an empty map.
 
-  <p class="note">The \[[<a>CrossOriginPropertyDescriptorMap</a>]] internal slot contains a map with
+  <p class="note">The [[<a>CrossOriginPropertyDescriptorMap</a>]] internal slot contains a map with
   entries whose keys are (currentOrigin, objectOrigin, propertyKey)-tuples and values are property
   descriptors, as a memoization of what is visible to scripts when currentOrigin inspects a
   {{Window}} or {{Location}} object from objectOrigin. It is filled lazily by
@@ -782,58 +782,73 @@
 <h5 id="crossoriginproperties-algorithm"><dfn>CrossOriginProperties</dfn> ( <var>O</var> )</h5>
 
   1. Assert: <var>O</var> is a {{Location}} or {{Window}} object.
-  2. If <var>O</var> is a {{Location}} object, then return « <pre>{
-        \[[Property]]: "href",
-        \[[NeedsGet]]: false,
-        \[[NeedsSet]]: true
-      }, {
-        \[[Property]]: "replace"
-      }</pre> ».
-  3. Let <var>crossOriginWindowProperties</var> be « <pre>{
-        \[[Property]]: "window",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "self",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "location",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: true
-      }, {
-        \[[Property]]: "close"
-      }, {
-        \[[Property]]: "closed",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "focus"
-      }, {
-        \[[Property]]: "blur"
-      }, {
-        \[[Property]]: "frames",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "length",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "top",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "opener",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "parent",
-        \[[NeedsGet]]: true,
-        \[[NeedsSet]]: false
-      }, {
-        \[[Property]]: "postMessage"
-      }</pre> ».
+  2. If <var>O</var> is a {{Location}} object, then return <pre>
+      « {
+          [[Property]]: "href",
+          [[NeedsGet]]: false,
+          [[NeedsSet]]: true
+        },
+        {
+          [[Property]]: "replace"
+        } »</pre>
+  3. Let <var>crossOriginWindowProperties</var> be <pre>
+      « {
+          [[Property]]: "window",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "self",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "location",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: true
+        },
+        {
+          [[Property]]: "close"
+        },
+        {
+          [[Property]]: "closed",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "focus"
+        },
+        {
+          [[Property]]: "blur"
+        },
+        {
+          [[Property]]: "frames",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "length",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "top",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "opener",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "parent",
+          [[NeedsGet]]: true,
+          [[NeedsSet]]: false
+        },
+        {
+          [[Property]]: "postMessage"
+        } »</pre>
   4. Repeat for each <var>e</var> that is an element of the
       <a>child browsing context name property set</a>:
       1. Add { \[[Property]]: <var>e</var> } as the last element of <var>crossOriginWindowProperties</var>.
@@ -862,14 +877,14 @@
       object's <a for="concept">origin</a>'s <a>effective domain</a>, and <var>P</var>.
   3. Repeat for each <var>e</var> that is an element of <a>CrossOriginProperties</a>(<var>O</var>):
      1. If <a>SameValue</a>(<var>e</var>.\[[Property]], <var>P</var>) is true, then:
-         1. If the value of the \[[<a>CrossOriginPropertyDescriptorMap</a>]] internal slot of
+         1. If the value of the [[<a>CrossOriginPropertyDescriptorMap</a>]] internal slot of
              <var>O</var> contains an entry whose key is <var>crossOriginKey</var>, then return that
              entry's value.
          2. Let <var>originalDesc</var> be <a>OrdinaryGetOwnProperty</a>(<var>O</var>,
              <var>P</var>).
          3. Let <var>crossOriginDesc</var> be <a>CrossOriginPropertyDescriptor</a>(<var>e</var>,
              <var>originalDesc</var>).
-         4. Create an entry in the value of the \[[<a>CrossOriginPropertyDescriptorMap</a>]]
+         4. Create an entry in the value of the [[<a>CrossOriginPropertyDescriptorMap</a>]]
              internal slot of <var>O</var> with key <var>crossOriginKey</var> and value
              <var>crossOriginDesc</var>.
          5. Return <var>crossOriginDesc</var>.
@@ -901,7 +916,7 @@
       <var>functionToWrap</var>.
 
   A <dfn>cross-origin wrapper function</dfn> is an anonymous built-in function that has a
-  \\[[Wrapped]] internal slot.
+  \[[Wrapped]] internal slot.
 
   When a <a>cross-origin wrapper function</a> <var>F</var> is called with a list of arguments
   <var>argumentsList</var>, the following steps are taken:
@@ -1602,7 +1617,7 @@
 
   There is no {{WindowProxy}} interface object.
 
-  Every {{WindowProxy}} object has a \[[<dfn lt="window slot">Window</dfn>]] internal slot
+  Every {{WindowProxy}} object has a [[<dfn lt="window slot">Window</dfn>]] internal slot
   representing the wrapped {{Window}} object.
 
   <p class="note">Although {{WindowProxy}} is named as a "proxy", it does not do polymorphic
@@ -1627,29 +1642,29 @@
 
   The {{WindowProxy}} object internal methods are described in the subsections below.
 
-<h6 id="windowproxy-getprototypeof-algorithm">\[[<dfn lt="windowproxy getprototypeof">GetPrototypeOf</dfn>]] ( )</h6>
+<h6 id="windowproxy-getprototypeof-algorithm">[[<dfn lt="windowproxy getprototypeof">GetPrototypeOf</dfn>]] ( )</h6>
 
-  1. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  1. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   2. If <a>IsPlatformObjectSameOrigin</a>(<var>W</var>) is true, then return !
       <a>OrdinaryGetPrototypeOf</a>(<var>W</var>).
   3. Return null.
 
-<h6 id="windowproxy-setprototypeof-algorithm">\[[<dfn lt="windowproxy setprototypeof">SetPrototypeOf</dfn>]] ( V )</h6>
+<h6 id="windowproxy-setprototypeof-algorithm">[[<dfn lt="windowproxy setprototypeof">SetPrototypeOf</dfn>]] ( V )</h6>
 
   1. Return false.
 
-<h6 id="windowproxy-isextensible-algorithm">\[[<dfn lt="windowproxy isextensible">IsExtensible</dfn>]] ( )</h6>
+<h6 id="windowproxy-isextensible-algorithm">[[<dfn lt="windowproxy isextensible">IsExtensible</dfn>]] ( )</h6>
 
   1. Return true.
 
-<h6 id="windowproxy-preventextensions-algorithm">\[[<dfn lt="windowproxy preventextensions">PreventExtensions</dfn>]] ( )</h6>
+<h6 id="windowproxy-preventextensions-algorithm">[[<dfn lt="windowproxy preventextensions">PreventExtensions</dfn>]] ( )</h6>
 
   1. Return false.
 
-<h6 id="windowproxy-getownproperty-algorithm">\[[<dfn lt="windowproxy getownproperty">GetOwnProperty</dfn>]] ( <var>P</var> )</h6>
+<h6 id="windowproxy-getownproperty-algorithm">[[<dfn lt="windowproxy getownproperty">GetOwnProperty</dfn>]] ( <var>P</var> )</h6>
 
-  1. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  1. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   2. If <var>P</var> is an <a>array index property name</a>, then:
       1. Let <var>index</var> be <a>ToUint32</a>(<var>P</var>).
@@ -1681,10 +1696,10 @@
           \[[Writable]]: false, \[[Configurable]]: true }.
   7. Throw a "{{SecurityError}}" {{DOMException}}.
 
-<h6 id="windowproxy-defineownproperty-algorithm">\[[<dfn lt="windowproxy defineownproperty">DefineOwnProperty</dfn>]] ( <var>P</var>, <var>Desc</var> )</h6>
+<h6 id="windowproxy-defineownproperty-algorithm">[[<dfn lt="windowproxy defineownproperty">DefineOwnProperty</dfn>]] ( <var>P</var>, <var>Desc</var> )</h6>
 
   1. If <var>P</var> is an <a>array index property name</a>, return false.
-  2. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  2. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   3. If <a>IsPlatformObjectSameOrigin</a>(<var>W</var>) is true, then return
       <a>OrdinaryDefineOwnProperty</a>(<var>W</var>, <var>P</var>, <var>Desc</var>).
@@ -1692,34 +1707,34 @@
       <p class="note">See above about how this violates JavaScript's internal method invariants.</p>
   4. Return false.
 
-<h6 id="windowproxy-get-algorithm">\[[<dfn lt="windowproxy get">Get</dfn>]] ( <var>P</var>, <var>Receiver</var> )</h6>
+<h6 id="windowproxy-get-algorithm">[[<dfn lt="windowproxy get">Get</dfn>]] ( <var>P</var>, <var>Receiver</var> )</h6>
 
-  1. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  1. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   2. If <a>IsPlatformObjectSameOrigin</a>(<var>W</var>) is true, then return
       <a>OrdinaryGet</a>(this, <var>P</var>, <var>Receiver</var>).
   3. Return ? <a>CrossOriginGet</a>(this, <var>P</var>, <var>Receiver</var>).
 
-<h6 id="windowproxy-set-algorithm">\[[<dfn lt="windowproxy set">Set</dfn>]] ( <var>P</var>, V, <var>Receiver</var> )</h6>
+<h6 id="windowproxy-set-algorithm">[[<dfn lt="windowproxy set">Set</dfn>]] ( <var>P</var>, V, <var>Receiver</var> )</h6>
 
-  1. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  1. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   2. If <a>IsPlatformObjectSameOrigin</a>(<var>W</var>) is true, then return
       <a>OrdinarySet</a>(<var>W</var>, this, <var>Receiver</var>).
   3. Return <a>CrossOriginSet</a>(this, <var>P</var>, V, <var>Receiver</var>).
 
-<h6 id="windowproxy-delete-algorithm">\[[<dfn lt="windowproxy delete">Delete</dfn>]] ( <var>P</var> )</h6>
+<h6 id="windowproxy-delete-algorithm">[[<dfn lt="windowproxy delete">Delete</dfn>]] ( <var>P</var> )</h6>
 
   1. If <var>P</var> is an <a>array index property name</a>, return false.
-  2. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  2. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   3. If <a>IsPlatformObjectSameOrigin</a>(<var>W</var>) is true, then return
       <a>OrdinaryDelete</a>(<var>W</var>, <var>P</var>).
   4. Return false.
 
-<h6 id="windowproxy-ownpropertykeys-algorithm">\[[<dfn lt="windowproxy ownpropertykeys">OwnPropertyKeys</dfn>]] ( )</h6>
+<h6 id="windowproxy-ownpropertykeys-algorithm">[[<dfn lt="windowproxy ownpropertykeys">OwnPropertyKeys</dfn>]] ( )</h6>
 
-  1. Let <var>W</var> be the value of the \[[<a lt="window slot">Window</a>]] internal slot of
+  1. Let <var>W</var> be the value of the [[<a lt="window slot">Window</a>]] internal slot of
       <em>this</em>.
   2. Let <var>keys</var> be a new empty <a for="ecma">List</a>.
   3. Let <var>maxProperties</var> be the <a>number of child browsing contexts</a> of <var>W</var>.
@@ -2947,7 +2962,7 @@
   5. Perform ! <var>location</var>.\[[DefineOwnProperty]](<a>@@toPrimitive</a>, {
       \[[Value]]: undefined, \[[Writable]]: false, \[[Enumerable]]: false,
       \[[Configurable]]: false }).
-  6. Set the value of the \[[<a>DefaultProperties</a>]] internal slot of <var>location</var> to
+  6. Set the value of the [[<a>DefaultProperties</a>]] internal slot of <var>location</var> to
       <var>location</var>.\[[OwnPropertyKeys]]().
   7. Return <var>location</var>.
 
@@ -3445,7 +3460,7 @@
   The {{Location}} object requires additional logic beyond IDL for security purposes. The internal
   slot and internal methods {{Location}} objects must implement are defined below.
 
-  Every {{Location}} object has a \[[<dfn>DefaultProperties</dfn>]] internal slot representing its
+  Every {{Location}} object has a [[<dfn>DefaultProperties</dfn>]] internal slot representing its
   own properties at time of its creation.
 
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -4361,13 +4361,13 @@
 
   <a>Platform objects</a> have the following internal method:
 
-  \[[<dfn for="structured">Clone</dfn>]] ( <var>targetRealm</var>, <var>memory</var> )
+  [[<dfn for="structured">Clone</dfn>]] ( <var>targetRealm</var>, <var>memory</var> )
 
-  Unless specified otherwise, invoking the \[[<a for="structured">Clone</a>]] internal method must
+  Unless specified otherwise, invoking the [[<a for="structured">Clone</a>]] internal method must
   throw a "{{DataCloneError}}" {{DOMException}}. (By default, <a>platform objects</a> are not
   <a>cloneable objects</a>.)
 
-  <a>Platform objects</a> that are <a>cloneable objects</a> have a \[[<a for="structured">Clone</a>]]
+  <a>Platform objects</a> that are <a>cloneable objects</a> have a [[<a for="structured">Clone</a>]]
   internal method which is specified to run a series of steps. The result of running those steps
   must be a thrown exception or a clone of <em>this</em>, created in <var>targetRealm</var>. It is
   up such objects to define what cloning means for them.
@@ -4386,19 +4386,19 @@
   <p class="note">Transferring is an irreversible and non-idempotent operation. Once an object has
   been transferred, it cannot be transferred, or indeed used, again.</p>
 
-  <a>Platform objects</a> that are <a>transferable objects</a> have a \[[<dfn>Detached</dfn>]]
+  <a>Platform objects</a> that are <a>transferable objects</a> have a [[<dfn>Detached</dfn>]]
   internal slot and the following internal method:
 
-  \[[<dfn>Transfer</dfn>]] ( <var>targetRealm</var> )
+  [[<dfn>Transfer</dfn>]] ( <var>targetRealm</var> )
 
-  <p class="note">Whereas all <a>platform objects</a> have a \[[<a for="structured">Clone</a>]]
-  internal method, not all have a \[[<a>Detached</a>]] internal slot and a \[[<a>Transfer</a>]]
+  <p class="note">Whereas all <a>platform objects</a> have a [[<a for="structured">Clone</a>]]
+  internal method, not all have a [[<a>Detached</a>]] internal slot and a [[<a>Transfer</a>]]
   internal method.</p>
 
-  <a>Platform objects</a> that are <a>transferable objects</a> must define the \[[<a>Transfer</a>]]
+  <a>Platform objects</a> that are <a>transferable objects</a> must define the [[<a>Transfer</a>]]
   internal method such that it either throws an exception or returns a clone of <em>this</em>,
   created in <var>targetRealm</var>, with <em>this</em>'s underlying data shared with the return
-  value, and <em>this</em>'s \[[<a>Detached</a>]] internal slot value set to true. It is up to such
+  value, and <em>this</em>'s [[<a>Detached</a>]] internal slot value set to true. It is up to such
   objects to define what transfering means for them.
 
   Objects defined in the JavaScript specification are handled by the
@@ -4431,7 +4431,7 @@
 
           <p class="note">This is a rather unusual low-level operation for which no primitives are defined by JavaScript.</p>
       4. Add <var>transferResult</var> as the last element of <var>outputTransferList</var>.
-  6. Return { \[[Clone]]: <var>clone</var>, \[[<var>transferList</var>]]:
+  6. Return { \[[Clone]]: <var>clone</var>, [[<var>transferList</var>]]:
       <var>outputTransferList</var> }.
 
   <p class="note">Originally the <a>StructuredCloneWithTransfer</a> abstract operation was known as
@@ -4511,9 +4511,9 @@
        3. Let <var>output</var> be ! <a>ArrayCreate</a>(<var>inputLen</var>,
            <var>outputProto</var>).
        4. Set <var>deepClone</var> to true.
-  16. Otherwise, if <var>input</var> has a \[[<a for="structured">Clone</a>]] internal method, then
+  16. Otherwise, if <var>input</var> has a [[<a for="structured">Clone</a>]] internal method, then
        let <var>output</var> be ?
-       <var>input</var>.\[[<a for="structured">Clone</a>]](<var>targetRealm</var>,
+       <var>input</var>.[[<a for="structured">Clone</a>]](<var>targetRealm</var>,
        <var>memory</var>).
   17. Otherwise, if <a>IsCallable</a>(<var>input</var>)}} is true, then throw a
        "{{DataCloneError}}" {{DOMException}}.
@@ -4590,8 +4590,8 @@
   2. If <var>O</var> has an \[[ArrayBufferData]] internal slot, then:
       1. If <a>IsDetachedBuffer</a>(<var>O</var>) is true, then return false.
       2. Return true.
-  3. Otherwise, if <var>O</var> has a \[[<a>Detached</a>]] internal slot, then:
-      1. If <var>O</var>'s \[[<a>Detached</a>]] internal slot value is true, then return false.
+  3. Otherwise, if <var>O</var> has a [[<a>Detached</a>]] internal slot, then:
+      1. If <var>O</var>'s [[<a>Detached</a>]] internal slot value is true, then return false.
       2. Return true.
   4. Return false.
 
@@ -4604,6 +4604,6 @@
           \[[ArrayBufferData]] internal slot value of <var>input</var>.
       2. Perform ! <a>DetachArrayBuffer</a>(<var>input</var>).
       3. Return <var>output</var>.
-  2. Return ? <var>input</var>.\[[<a>Transfer</a>]](<var>targetRealm</var>).
+  2. Return ? <var>input</var>.[[<a>Transfer</a>]](<var>targetRealm</var>).
 
 </section>


### PR DESCRIPTION
Bikeshed typically wants you to escape a double-backslash `[[` if you intend it to
render as-is, and not turn it into a biblio reference. However, it has some exceptions
which I discover during this work:

Turns out that if you have an element inside of the double-brackets e.g.,
`[[<a>something</a>]]` then you don't need to escape the leading double-brackets.

Also, any content in `<pre>` tags is not checked for auto-linking.

Fixes #389 
