### PR TITLE
Fix content attribute and IDL attribute linking

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -32,7 +32,7 @@
       <td><a>Ordered set of unique space-separated tokens</a>, <a>ASCII case-insensitive</a>, consisting of <a>labels</a> of <a>ASCII-compatible character encodings</a>*</td>
     </tr>
     <tr>
-      <th><code>accesskey</code></th>
+      <th><{global/accesskey}></th>
       <td><a>HTML elements</a></td>
       <td>Keyboard shortcut to activate or focus element</td>
       <td><a>Ordered set of unique space-separated tokens</a>, <a>case-sensitive</a>, consisting of one Unicode code point in length</td>
@@ -259,13 +259,13 @@
       <td>Text</td>
     </tr>
     <tr>
-      <th><code>draggable</code></th>
+      <th><{global/draggable}></th>
       <td><a>HTML elements</a></td>
       <td>Whether the element is draggable</td>
       <td>"<code>true</code>"; "<code>false</code>"</td>
     </tr>
     <tr>
-      <th><code>dropzone</code></th>
+      <th><{global/dropzone}></th>
       <td><a>HTML elements</a></td>
       <td>Accepted item types for drag-and-drop</td>
       <td><a>Unordered set of unique space-separated tokens</a>, <a>ASCII case-insensitive</a>, consisting of accepted types and drag feedback*</td>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1545,13 +1545,13 @@
   The following attributes are common to and may be specified on all <a>html elements</a>
   <span class="impl"> (even those not defined in this specification)</span>:
 
-  * <code>accesskey</code>
+  * <{global/accesskey}>
   * <code>class</code>
-  * <code>contenteditable</code>
+  * <{global/contenteditable}>
   * <{global/contextmenu}>
   * <{global/dir}>
-  * <code>draggable</code>
-  * <code>dropzone</code>
+  * <{global/draggable}>
+  * <{global/dropzone}>
   * <code>hidden</code>
   * <{global/id}>
   * <{global/lang}>
@@ -1996,9 +1996,9 @@
   Authors must not use the <code>xml:base</code> attribute on <a>html elements</a> in
   <a>HTML documents</a>.
 
-<h5 id="the-dir-attribute">The <dfn element-attr for="global"><code>dir</code></dfn> attribute</h5>
+<h5 id="the-dir-attribute">The <code>dir</code> attribute</h5>
 
-  The <code>dir</code> attribute specifies the element's text directionality. The attribute is an
+  The <dfn element-attr for="global"><code>dir</code></dfn> attribute specifies the element's text directionality. The attribute is an
   <a>enumerated attribute</a> with the following keywords and states:
 
   : The <dfn attr-value for="global/dir"><code>ltr</code></dfn> keyword, which maps to the <dfn state for="dir">ltr</dfn> state

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -687,7 +687,7 @@
 
       <li><{button}> elements</li>
 
-      <li><{input}> elements whose <code>type</code> attribute are
+      <li><{input}> elements whose <{input/type}> attribute are
       not in the <a>Hidden</a> state</li>
 
       <li><{select}> elements</li>
@@ -696,7 +696,7 @@
 
       <li><{menuitem}> elements</li>
 
-      <li>Elements with a <code>draggable</code> attribute set, if that would
+      <li>Elements with a <{global/draggable}> attribute set, if that would
       enable the user agent to allow the user to begin a drag operations for those elements without
       the use of a pointing device</li>
 
@@ -1642,13 +1642,13 @@
   <em>This section is non-normative.</em>
 
   Each element that can be activated or focused can be assigned a shortcut key combination to
-  activate it, using the <code>accesskey</code> attribute.
+  activate it, using the <{global/accesskey}> attribute.
 
   The exact shortcut is determined by the user agent, potentially using information about the user's
   preferences, what keyboard shortcuts already exist on the platform, and what other shortcuts have
-  been specified on the page, as well as the value of the <code>accesskey</code> attribute.
+  been specified on the page, as well as the value of the <{global/accesskey}> attribute.
 
-  A valid value for <code>accesskey</code> consists of a single character, such as a letter or digit.
+  A valid value for <{global/accesskey}> consists of a single character, such as a letter or digit.
 
   User agents can provide users with a list of the keyboard shortcuts, but authors are encouraged
   to do so also.
@@ -1663,17 +1663,17 @@
   </div>
 
 
-<h4 id="the-accesskey-attribute">The <dfn element-attr for="global"><code>accesskey</code></dfn> attribute</h4>
+<h4 id="the-accesskey-attribute">The <code>accesskey</code> attribute</h4>
 
-  All <a>html elements</a> may have the <code>accesskey</code>
-  content attribute set. The <code>accesskey</code> attribute's value is used
+  All <a>html elements</a> may have the <dfn element-attr for="global"><code>accesskey</code></dfn>
+  content attribute set. The <{global/accesskey}> attribute's value is used
   by the user agent as a guide for creating a keyboard shortcut that activates or focuses the
   element.
 
   If specified, the value must be a single printable character: a string exactly one Unicode code point in length.
 
   Authors should not use <samp>" "</samp>, nor characters that normally require a modifier key to
-  generate, as a value of <code>accesskey</code>.
+  generate, as a value of <{global/accesskey}>.
 
   <div class="example">
     In the following example, a variety of links are given with access keys so that keyboard users
@@ -1697,23 +1697,23 @@
 <h4 id="assigning-keyboard-shortcuts-processing-model">Processing model</h4>
 
   An element's <dfn>assigned access key</dfn> is a key combination derived from the element's
-  <code>accesskey</code> content attribute, or assigned by the user agent, optionally
+  <{global/accesskey}> content attribute, or assigned by the user agent, optionally
   based on a user preference. Initially, an element must not have an
   <a>assigned access key</a>.
 
-  Whenever an element's <code>accesskey</code> attribute is set, changed,
+  Whenever an element's <{global/accesskey}> attribute is set, changed,
   or removed, the user agent must update the element's <a>assigned access key</a> by running
   the following steps:
 
   <ol>
 
-    <li>If the element has no <code>accesskey</code> attribute, then skip
+    <li>If the element has no <{global/accesskey}> attribute, then skip
     to the <i>fallback</i> step below.</li>
 
     <li>The user agent may assign a key combination based on stored user preferences as the
     element's <a>assigned access key</a> and then abort these steps.</li>
 
-    <li>Let <var>value</var> be the value of the <code>accesskey</code> attribute.
+    <li>Let <var>value</var> be the value of the <{global/accesskey}> attribute.
 
     <li>The user agent may strip content from <var>value</var> to reduce the length of
     <var>value</var> to a single unicode code point.</li>
@@ -1732,7 +1732,7 @@
   </ol>
 
   Once a user agent has selected and assigned an access key for an element, the user agent should
-  not change the element's <a>assigned access key</a> unless the <code>accesskey</code> content
+  not change the element's <a>assigned access key</a> unless the <{global/accesskey}> content
   attribute is changed or the element is moved to another {{Document}}.
 
   When the user presses the key combination corresponding to the <a>assigned access key</a>
@@ -1745,14 +1745,14 @@
 
   <p class="note">
   User agents might expose elements that have
-  an <code>accesskey</code> attribute in other ways as well, e.g., in a menu
+  an <{global/accesskey}> attribute in other ways as well, e.g., in a menu
   displayed in response to a specific key combination.
   </p>
 
   <hr />
 
   The <dfn attribute for="HTMLElement"><code>accessKey</code></dfn> IDL attribute must
-  <a>reflect</a> the <code>accesskey</code> content attribute.
+  <a>reflect</a> the <{global/accesskey}> content attribute.
 
   </div>
 
@@ -1780,11 +1780,11 @@
 
   <dl class="domintro">
 
-    <dt><var>element</var> . <code>contentEditable</code> [ = <var>value</var> ]</dt>
+    <dt><var>element</var> . {{ElementContentEditable/contentEditable}} [ = <var>value</var> ]</dt>
 
     <dd>
 
-    Returns "<code>true</code>", "<code>false</code>", or "<code>inherit</code>", based on the state of the <code>contenteditable</code> attribute.
+    Returns "<code>true</code>", "<code>false</code>", or "<code>inherit</code>", based on the state of the <{global/contenteditable}> attribute.
 
     Can be set, to change that state.
 
@@ -1918,7 +1918,7 @@
 
   User agents can support the checking of spelling and grammar of editable text, either in form
   controls (such as the value of <{textarea}> elements), or in elements in an <a>editing
-  host</a> (e.g., using <code>contenteditable</code>).
+  host</a> (e.g., using <{global/contenteditable}>).
 
   For each element, user agents must establish a <dfn>default behavior</dfn>, either through
   defaults or through preferences expressed by the user. There are
@@ -2014,7 +2014,7 @@
 
   <ul>
 
-    <li>The <a for="forms">value</a> of <{input}> elements whose <code>type</code> attributes are in the <a element-state for="input">Text</a>, <a element-state for="input">Search</a>,
+    <li>The <a for="forms">value</a> of <{input}> elements whose <{input/type}> attributes are in the <a element-state for="input">Text</a>, <a element-state for="input">Search</a>,
     <a element-state for="input">URL</a>, or <a element-state for="input">E-mail</a> states and that are <i>mutable</i> (i.e., that do not have the <code>readonly</code> attribute specified and that are not disabled).</li>
 
     <li>The <a for="forms">value</a> of <{textarea}> elements that do not
@@ -2145,10 +2145,10 @@
 
   <em>This section is non-normative.</em>
 
-  To make an element draggable is simple: give the element a <code>draggable</code> attribute, and set an event listener for <code>dragstart</code> that stores the data being dragged.
+  To make an element draggable is simple: give the element a <{global/draggable}> attribute, and set an event listener for <code>dragstart</code> that stores the data being dragged.
 
   The event handler typically needs to check that it's not a text selection that is being
-  dragged, and then needs to store data into the <code>DataTransfer</code> object and set the
+  dragged, and then needs to store data into the {{DataTransfer}} object and set the
   allowed effects (copy, move, link, or some combination).
 
   For example:
@@ -2169,23 +2169,23 @@
 
   <hr />
 
-  To accept a drop, the drop target has to have a <code>dropzone</code>
+  To accept a drop, the drop target has to have a <{global/dropzone}>
   attribute and listen to the <code>drop</code> event.
 
-  The value of the <code>dropzone</code> attribute specifies what kind of
+  The value of the <{global/dropzone}> attribute specifies what kind of
   data to accept (e.g., "<code>string:text/plain</code>" to accept any text strings, or
   "<code>file:image/png</code>" to accept a PNG image file) and what kind of feedback to
   give (e.g., "<code>move</code>" to indicate that the data will be moved).
 
   <p class="note">
-  Instead of using the <code>dropzone</code> attribute, a drop
+  Instead of using the <{global/dropzone}> attribute, a drop
   target can handle the <code>dragenter</code> event (to report whether or
   not the drop target is to accept the drop) and the <code>dragover</code>
   event (to specify what feedback is to be shown to the user).
   </p>
 
   The <code>drop</code> event allows the actual drop to be performed. This
-  event needs to be canceled, so that the <code>dropEffect</code> attribute's value can be used by the source
+  event needs to be canceled, so that the {{DataTransfer/dropEffect}} attribute's value can be used by the source
   (otherwise it's reset).
 
   For example:
@@ -2284,7 +2284,7 @@
 
       <p class="note">
   Strings that contain <a>space characters</a>
-      cannot be used with the <code>dropzone</code> attribute, so authors are
+      cannot be used with the <{global/dropzone}> attribute, so authors are
       encouraged to use only <a>MIME types</a> or custom strings (without
       spaces).
   </p>
@@ -2372,7 +2372,7 @@
 
 <h4 id="the-datatransfer-interface">The <code>DataTransfer</code> interface</h4>
 
-  <code>DataTransfer</code> objects are used to expose the <a>drag data store</a> that
+  {{DataTransfer}} objects are used to expose the <a>drag data store</a> that
   underlies a drag-and-drop operation.
 
   <pre class="idl" data-highlight="webidl" dfn-for="DataTransfer">
@@ -2395,12 +2395,12 @@
 
   <dl class="domintro">
 
-    <dt><var>dataTransfer</var> . <code>dropEffect</code> [ = <var>value</var> ]</dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/dropEffect}} [ = <var>value</var> ]</dt>
 
     <dd>
 
     Returns the kind of operation that is currently selected. If the kind of operation isn't one
-    of those that is allowed by the <code>effectAllowed</code> attribute, then the operation will
+    of those that is allowed by the {{DataTransfer/effectAllowed}} attribute, then the operation will
     fail.
 
     Can be set, to change the selected operation.
@@ -2409,7 +2409,7 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>effectAllowed</code> [ = <var>value</var> ]</dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/effectAllowed}} [ = <var>value</var> ]</dt>
 
     <dd>
 
@@ -2423,15 +2423,15 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>items</code></dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/items}}</dt>
 
     <dd>
 
-    Returns a <code>DataTransferItemList</code> object, with the drag data.
+    Returns a {{DataTransferItemList}} object, with the drag data.
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>setDragImage</code>(<var>element</var>, <var>x</var>, <var>y</var>)</dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/setDragImage()|setDragImage}}(<var>element</var>, <var>x</var>, <var>y</var>)</dt>
 
     <dd>
 
@@ -2440,7 +2440,7 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>types</code></dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/types}}</dt>
 
     <dd>
 
@@ -2449,7 +2449,7 @@
 
     </dd>
 
-    <dt><var>data</var> = <var>dataTransfer</var> . <code>getData</code>(<var>format</var>)</dt>
+    <dt><var>data</var> = <var>dataTransfer</var> . {{DataTransfer/getData()|getData}}(<var>format</var>)</dt>
 
     <dd>
 
@@ -2457,7 +2457,7 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>setData</code>(<var>format</var>, <var>data</var>)</dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/setData()|setData}}(<var>format</var>, <var>data</var>)</dt>
 
     <dd>
 
@@ -2465,7 +2465,7 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>clearData</code>( [ <var>format</var> ] )</dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/clearData()|clearData}}( [ <var>format</var> ] )</dt>
 
     <dd>
 
@@ -2473,7 +2473,7 @@
 
     </dd>
 
-    <dt><var>dataTransfer</var> . <code>files</code></dt>
+    <dt><var>dataTransfer</var> . {{DataTransfer/files}}</dt>
 
     <dd>
 
@@ -2483,34 +2483,34 @@
 
   </dl>
 
-  <code>DataTransfer</code> objects are used during the <a>drag-and-drop events</a>, and are only valid while those events are being fired.
+  {{DataTransfer}} objects are used during the <a>drag-and-drop events</a>, and are only valid while those events are being fired.
 
   <div class="impl">
 
-  A <code>DataTransfer</code> object is associated with a <a>drag data store</a> while it
+  A {{DataTransfer}} object is associated with a <a>drag data store</a> while it
   is valid.
 
   The <dfn attribute for="DataTransfer"><code>dropEffect</code></dfn> attribute controls
   the drag-and-drop feedback that the user is given during a drag-and-drop operation. When the
-  <code>DataTransfer</code> object is created, the <code>dropEffect</code> attribute is set to a string value. On
+  {{DataTransfer}} object is created, the {{DataTransfer/dropEffect}} attribute is set to a string value. On
   getting, it must return its current value. On setting, if the new value is one of "<dfn value for="dropEffect"><code>none</code></dfn>", "<dfn value for="dropEffect"><code>copy</code></dfn>", "<dfn value for="dropEffect"><code>link</code></dfn>", or "<dfn value for="dropEffect"><code>move</code></dfn>", then the attribute's current value must be
   set to the new value. Other values must be ignored.
 
   The <dfn attribute for="DataTransfer"><code>effectAllowed</code></dfn> attribute is
-  used in the drag-and-drop processing model to initialize the <code>dropEffect</code> attribute during the <code>dragenter</code> and <code>dragover</code> events. When the <code>DataTransfer</code> object is
-  created, the <code>effectAllowed</code> attribute is set
+  used in the drag-and-drop processing model to initialize the {{DataTransfer/dropEffect}} attribute during the <code>dragenter</code> and <code>dragover</code> events. When the {{DataTransfer}} object is
+  created, the {{DataTransfer/effectAllowed}} attribute is set
   to a string value. On getting, it must return its current value. On setting, if <a>drag data
   store</a>'s mode is the <a>read/write mode</a> and the new value is one of "<dfn value for="effectAllowed"><code>none</code></dfn>", "<dfn value for="effectAllowed"><code>copy</code></dfn>", "<dfn value for="effectAllowed"><code>copyLink</code></dfn>", "<dfn value for="effectAllowed"><code>copyMove</code></dfn>", "<dfn value for="effectAllowed"><code>link</code></dfn>", "<dfn value for="effectAllowed"><code>linkMove</code></dfn>", "<dfn value for="effectAllowed"><code>move</code></dfn>", "<dfn value for="effectAllowed"><code>all</code></dfn>", or "<dfn value for="effectAllowed"><code>uninitialized</code></dfn>", then the attribute's
   current value must be set to the new value. Otherwise it must be left unchanged.
 
   The <dfn attribute for="DataTransfer"><code>items</code></dfn> attribute must return a
-  <code>DataTransferItemList</code> object associated with the <code>DataTransfer</code> object.
+  {{DataTransferItemList}} object associated with the {{DataTransfer}} object.
 
-  The <dfn method for="DataTransfer"><code>setDragImage(<var>element</var>, <var>x</var>, <var>y</var>)</code></dfn> method must run the following steps:
+  The <dfn method for="DataTransfer" lt="setDragImage()"><code>setDragImage(<var>element</var>, <var>x</var>, <var>y</var>)</code></dfn> method must run the following steps:
 
   <ol>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, abort these steps. Nothing happens.</li>
 
     <li>If the <a>drag data store</a>'s mode is
@@ -2536,14 +2536,14 @@
 
     <li>Start with an empty list <var>L</var>.</li>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, the array is empty. Abort these steps; return the empty list <var>L</var>.</li>
 
     <li>For each item in the <a>drag data store item list</a>
-    whose <a>kind</a> is <i>Plain Unicode string</i>, add an
+    whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i>, add an
     entry to the list <var>L</var> consisting of the item's <a>type string</a>.</li>
 
-    <li>If there are any items in the <a>drag data store item list</a> whose <a>kind</a> is <i>File</i>, then add an entry to the list
+    <li>If there are any items in the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>File</i>, then add an entry to the list
     <var>L</var> consisting of the string "<code>Files</code>". (This value can be
     distinguished from the other values because it is not lowercase.)</li>
 
@@ -2551,12 +2551,12 @@
 
   </ol>
 
-  The <dfn method for="DataTransfer"><code>getData(<var>format</var>)</code></dfn> method
+  The <dfn method for="DataTransfer" lt="getData()"><code>getData(<var>format</var>)</code></dfn> method
   must run the following steps:
 
   <ol>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, return the empty string and abort these steps.</li>
 
     <li>If the <a>drag data store</a>'s mode is
@@ -2572,11 +2572,11 @@
 
     <li>If <var>format</var> equals "<code>url</code>", change it to "<code>text/uri-list</code>" and set <var>convert-to-URL</var> to true.</li>
 
-    <li>If there is no item in the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, return the empty string
+    <li>If there is no item in the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, return the empty string
     and abort these steps.</li>
 
     <li>Let <var>result</var> be the data of the item in the <a>drag data store item
-    list</a> whose <a>kind</a> is <i>Plain Unicode
+    list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode
     string</i> and whose <a>type string</a> is equal to
     <var>format</var>.</li>
 
@@ -2588,11 +2588,11 @@
 
   </ol>
 
-  The <dfn method for="DataTransfer"><code>setData(<var>format</var>, <var>data</var>)</code></dfn> method must run the following steps:
+  The <dfn method for="DataTransfer" lt="setData()"><code>setData(<var>format</var>, <var>data</var>)</code></dfn> method must run the following steps:
 
   <ol>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, abort these steps. Nothing happens.</li>
 
     <li>If the <a>drag data store</a>'s mode is
@@ -2610,10 +2610,10 @@
 
     </li>
 
-    <li>Remove the item in the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, if there is
+    <li>Remove the item in the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, if there is
     one.</li>
 
-    <li>Add an item to the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i>, whose <a>type string</a> is equal to <var>format</var>, and whose data is the string
+    <li>Add an item to the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i>, whose <a>type string</a> is equal to <var>format</var>, and whose data is the string
     given by the method's second argument.</li>
 
   </ol>
@@ -2623,7 +2623,7 @@
 
   <ol>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, abort these steps. Nothing happens.</li>
 
     <li>If the <a>drag data store</a>'s mode is
@@ -2631,7 +2631,7 @@
     happens.</li>
 
     <li>If the method was called with no arguments, remove each item in the <a>drag data store
-    item list</a> whose <a>kind</a> is <i>Plain Unicode
+    item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode
     string</i>, and abort these steps.</li>
 
     <li>Let <var>format</var> be the first argument, <a>converted to ASCII
@@ -2645,15 +2645,15 @@
 
     </li>
 
-    <li>Remove the item in the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, if there is
+    <li>Remove the item in the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to <var>format</var>, if there is
     one.</li>
 
   </ol>
 
   <p class="note">
-  The <code>clearData()</code> method does not
-  affect whether any files were included in the drag, so the <code>types</code> attribute's list might still not be empty after
-  calling <code>clearData()</code> (it would still contain the
+  The {{DataTransfer/clearData()}} method does not
+  affect whether any files were included in the drag, so the {{DataTransfer/types}} attribute's list might still not be empty after
+  calling {{DataTransfer/clearData()}} (it would still contain the
   "<code>Files</code>" string if any files were included in the drag).
   </p>
 
@@ -2667,7 +2667,7 @@
 
     <li>Start with an empty list <var>L</var>.</li>
 
-    <li>If the <code>DataTransfer</code> object is no longer associated with a <a>drag data
+    <li>If the {{DataTransfer}} object is no longer associated with a <a>drag data
     store</a>, the <code>FileList</code> is empty. Abort these steps; return the empty list <var>L</var>.</li>
 
     <li>If the <a>drag data store</a>'s mode is
@@ -2675,7 +2675,7 @@
     <var>L</var>.</li>
 
     <li>For each item in the <a>drag data store item list</a>
-    whose <a>kind</a> is <i>File</i> , add the item's data (the file, in particular its name and contents, as well as
+    whose {{DataTransferItem/kind}} is <i>File</i> , add the item's data (the file, in particular its name and contents, as well as
     its <a for="request">type</a>) to the list <var>L</var>.</li>
 
     <li>The files found by these steps are those in the list <var>L</var>.</li>
@@ -2691,7 +2691,7 @@
 
 <h5 id="the-datatransferitemlist-interface">The <code>DataTransferItemList</code> interface</h5>
 
-  Each <code>DataTransfer</code> object is associated with a <code>DataTransferItemList</code>
+  Each {{DataTransfer}} object is associated with a {{DataTransferItemList}}
   object.
 
   <pre class="idl" data-highlight="webidl" dfn-for="DataTransferItemList">
@@ -2707,7 +2707,7 @@
 
   <dl class="domintro">
 
-    <dt><var>items</var> . <code>length</code></dt>
+    <dt><var>items</var> . {{DataTransferItemList/length}}</dt>
 
     <dd>Returns the number of items in the <a>drag data store</a>.</dd>
 
@@ -2715,12 +2715,12 @@
 
     <dd>
 
-    Returns the <code>DataTransferItem</code> object representing the <var>index</var>th
+    Returns the {{DataTransferItem}} object representing the <var>index</var>th
     entry in the <a>drag data store</a>.
 
     </dd>
 
-    <dt><var>items</var> . <code>remove</code>(<var>index</var>)</dt>
+    <dt><var>items</var> . {{DataTransferItemList/remove()|remove}}(<var>index</var>)</dt>
 
     <dd>
 
@@ -2728,7 +2728,7 @@
 
     </dd>
 
-    <dt><var>items</var> . <code>clear</code>()</dt>
+    <dt><var>items</var> . {{DataTransferItemList/clear()}}</dt>
 
     <dd>
 
@@ -2736,8 +2736,8 @@
 
     </dd>
 
-    <dt><var>items</var> . <code>add</code>(<var>data</var>)</dt>
-    <dt><var>items</var> . <code>add</code>(<var>data</var>, <var>type</var>)</dt>
+    <dt><var>items</var> . {{DataTransferItemList/add()|add}}(<var>data</var>)</dt>
+    <dt><var>items</var> . {{DataTransferItemList/add()|add}}(<var>data</var>, <var>type</var>)</dt>
 
     <dd>
 
@@ -2751,38 +2751,38 @@
 
   <div class="impl">
 
-  While the <code>DataTransferItemList</code> object's <code>DataTransfer</code> object is
-  associated with a <a>drag data store</a>, the <code>DataTransferItemList</code> object's
+  While the {{DataTransferItemList}} object's {{DataTransfer}} object is
+  associated with a <a>drag data store</a>, the {{DataTransferItemList}} object's
   <i>mode</i> is the same as the <a>drag data store mode</a>. When the
-  <code>DataTransferItemList</code> object's <code>DataTransfer</code> object is <em>not</em>
-  associated with a <a>drag data store</a>, the <code>DataTransferItemList</code> object's
+  {{DataTransferItemList}} object's {{DataTransfer}} object is <em>not</em>
+  associated with a <a>drag data store</a>, the {{DataTransferItemList}} object's
   <i>mode</i> is the <i>disabled mode</i>. The <a>drag data store</a> referenced in this
-  section (which is used only when the <code>DataTransferItemList</code> object is not in the
+  section (which is used only when the {{DataTransferItemList}} object is not in the
   <i>disabled mode</i>) is the <a>drag data store</a> with which the
-  <code>DataTransferItemList</code> object's <code>DataTransfer</code> object is associated.
+  {{DataTransferItemList}} object's {{DataTransfer}} object is associated.
 
   The <dfn attribute for="DataTransferItemList"><code>length</code></dfn> attribute must
   return zero if the object is in the <i>disabled mode</i>; otherwise it must return the number of
   items in the <a>drag data store item list</a>.
 
-  When a <code>DataTransferItemList</code> object is not in the <i>disabled mode</i>, its
+  When a {{DataTransferItemList}} object is not in the <i>disabled mode</i>, its
   <a>supported property indices</a> are the numbers in the range 0 .. <var>n</var>-1, where
   <var>n</var> is the number of items in the <a>drag data store item list</a>.
 
   To <a>determine the value of an indexed property</a>
-  <var>i</var> of a <code>DataTransferItemList</code> object, the user agent must return a
-  <code>DataTransferItem</code> object representing the <var>i</var>th item in the
+  <var>i</var> of a {{DataTransferItemList}} object, the user agent must return a
+  {{DataTransferItem}} object representing the <var>i</var>th item in the
   <a>drag data store</a>. The same object must be returned each time a particular item is
-  obtained from this <code>DataTransferItemList</code> object. The <code>DataTransferItem</code>
-  object must be associated with the same <code>DataTransfer</code> object as the
-  <code>DataTransferItemList</code> object when it is first created.
+  obtained from this {{DataTransferItemList}} object. The {{DataTransferItem}}
+  object must be associated with the same {{DataTransfer}} object as the
+  {{DataTransferItemList}} object when it is first created.
 
-  The <dfn method for="DataTransferItemList"><code>add()</code></dfn> method must run the
+  The <dfn method for="DataTransferItemList" lt="add()|add(data)|add(data, type)"><code>add()</code></dfn> method must run the
   following steps:
 
   <ol>
 
-    <li>If the <code>DataTransferItemList</code> object is not in the <i>read/write mode</i>, return null and abort these steps.</li>
+    <li>If the {{DataTransferItemList}} object is not in the <i>read/write mode</i>, return null and abort these steps.</li>
 
     <li>
 
@@ -2794,11 +2794,11 @@
 
       <dd>
 
-      If there is already an item in the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to the value of the
+      If there is already an item in the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i> and whose <a>type string</a> is equal to the value of the
       method's second argument, <a>converted to ASCII lowercase</a>, then throw a
       {{NotSupportedError}} exception and abort these steps.
 
-      Otherwise, add an item to the <a>drag data store item list</a> whose <a>kind</a> is <i>Plain Unicode string</i>, whose <a>type string</a> is equal to the value of the method's second
+      Otherwise, add an item to the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>Plain Unicode string</i>, whose <a>type string</a> is equal to the value of the method's second
       argument, <a>converted to ASCII lowercase</a>, and whose data is the string given by the
       method's first argument.
 
@@ -2808,8 +2808,8 @@
 
       <dd>
 
-      Add an item to the <a>drag data store item list</a> whose <a>kind</a> is <i>File</i>, whose <a>type
-      string</a> is the <code>type</code> of the <code>File</code>,
+      Add an item to the <a>drag data store item list</a> whose {{DataTransferItem/kind}} is <i>File</i>, whose <a>type
+      string</a> is the {{DataTransferItem/type}} of the <code>File</code>,
       <a>converted to ASCII lowercase</a>, and whose data is the same as the
       <code>File</code>'s data.
 
@@ -2820,7 +2820,7 @@
     </li>
 
     <li><a lt="determine the value of an indexed property">Determine the value of the indexed property</a> corresponding to the newly added item, and return that value (a newly created
-    <code>DataTransferItem</code> object).</li>
+    {{DataTransferItem}} object).</li>
 
   </ol>
 
@@ -2829,7 +2829,7 @@
 
   <ol>
 
-    <li>If the <code>DataTransferItemList</code> object is not in the <i>read/write mode</i>, throw an <code>InvalidStateError</code> exception and
+    <li>If the {{DataTransferItemList}} object is not in the <i>read/write mode</i>, throw an <code>InvalidStateError</code> exception and
     abort these steps.</li>
 
     <li>Remove the <var>i</var>th item from the <a>drag data store</a>.</li>
@@ -2837,7 +2837,7 @@
   </ol>
 
   The <dfn method for="DataTransferItemList"><code>clear()</code></dfn> method, if the
-  <code>DataTransferItemList</code> object is in the <i>read/write mode</i>,
+  {{DataTransferItemList}} object is in the <i>read/write mode</i>,
   must remove all the items from the <a>drag data store</a>. Otherwise, it must do
   nothing.
 
@@ -2845,7 +2845,7 @@
 
 <h5 id="the-datatransferitem-interface">The <code>DataTransferItem</code> interface</h5>
 
-  Each <code>DataTransferItem</code> object is associated with a <code>DataTransfer</code>
+  Each {{DataTransferItem}} object is associated with a {{DataTransfer}}
   object.
 
   <pre class="idl" data-highlight="webidl" dfn-for="DataTransferItem">
@@ -2861,7 +2861,7 @@
 
   <dl class="domintro">
 
-    <dt><var>item</var> . <code>kind</code></dt>
+    <dt><var>item</var> . {{DataTransferItem/kind}}</dt>
     <dd>
 
     Returns <a>the drag data item kind</a>, one of: "string",
@@ -2869,14 +2869,14 @@
 
     </dd>
 
-    <dt><var>item</var> . <code>type</code></dt>
+    <dt><var>item</var> . {{DataTransferItem/type}}</dt>
     <dd>
 
     Returns <a>the drag data item type string</a>.
 
     </dd>
 
-    <dt><var>item</var> . <code>getAsString</code>(<var>callback</var>)</dt>
+    <dt><var>item</var> . {{DataTransferItem/getAsString()|getAsString}}(<var>callback</var>)</dt>
     <dd>
 
     Invokes the callback with the string data as the argument, if <a>the drag data item
@@ -2884,7 +2884,7 @@
 
     </dd>
 
-    <dt><var>file</var> = <var>item</var> . <code>getAsFile</code>()</dt>
+    <dt><var>file</var> = <var>item</var> . {{DataTransferItem/getAsFile()}}</dt>
     <dd>
 
     Returns a <code>File</code> object, if <a>the drag data item kind</a> is <i>File</i>.
@@ -2895,24 +2895,24 @@
 
   <div class="impl">
 
-  While the <code>DataTransferItem</code> object's <code>DataTransfer</code> object is associated
+  While the {{DataTransferItem}} object's {{DataTransfer}} object is associated
   with a <a>drag data store</a> and that <a>drag data store</a>'s <a>drag data store
-  item list</a> still contains the item that the <code>DataTransferItem</code> object represents,
-  the <code>DataTransferItem</code> object's <i>mode</i> is the same as the <a>drag data store
-  mode</a>. When the <code>DataTransferItem</code> object's <code>DataTransfer</code> object is
+  item list</a> still contains the item that the {{DataTransferItem}} object represents,
+  the {{DataTransferItem}} object's <i>mode</i> is the same as the <a>drag data store
+  mode</a>. When the {{DataTransferItem}} object's {{DataTransfer}} object is
   <em>not</em> associated with a <a>drag data store</a>, or if the item that the
-  <code>DataTransferItem</code> object represents has been removed from the relevant <a>drag data
-  store item list</a>, the <code>DataTransferItem</code> object's <i>mode</i> is the <i>disabled
+  {{DataTransferItem}} object represents has been removed from the relevant <a>drag data
+  store item list</a>, the {{DataTransferItem}} object's <i>mode</i> is the <i>disabled
   mode</i>. The <a>drag data store</a> referenced in this section (which is used only when the
-  <code>DataTransferItem</code> object is not in the <i>disabled mode</i>) is the <a>drag data
-  store</a> with which the <code>DataTransferItem</code> object's <code>DataTransfer</code>
+  {{DataTransferItem}} object is not in the <i>disabled mode</i>) is the <a>drag data
+  store</a> with which the {{DataTransferItem}} object's {{DataTransfer}}
   object is associated.
 
   The <dfn attribute for="DataTransferItem"><code>kind</code></dfn> attribute must return the
-  empty string if the <code>DataTransferItem</code> object is in the <i>disabled mode</i>; otherwise
+  empty string if the {{DataTransferItem}} object is in the <i>disabled mode</i>; otherwise
   it must return the string given in the cell from the second column of the following table from the
   row whose cell in the first column contains <a>the drag data item kind</a> of the item
-  represented by the <code>DataTransferItem</code> object:
+  represented by the {{DataTransferItem}} object:
 
   <table>
     <thead>
@@ -2925,24 +2925,24 @@
   </table>
 
   The <dfn attribute for="DataTransferItem"><code>type</code></dfn> attribute must return the
-  empty string if the <code>DataTransferItem</code> object is in the <i>disabled mode</i>; otherwise
+  empty string if the {{DataTransferItem}} object is in the <i>disabled mode</i>; otherwise
   it must return <a>the drag data item type string</a> of the item represented by the
-  <code>DataTransferItem</code> object.
+  {{DataTransferItem}} object.
 
-  The <dfn method for="DataTransferItem"><code>getAsString(<var>callback</var>)</code></dfn> method must run the following steps:
+  The <dfn method for="DataTransferItem" lt="getAsString()"><code>getAsString(<var>callback</var>)</code></dfn> method must run the following steps:
 
   <ol>
 
     <li>If the <var>callback</var> is null, abort these steps.</li>
 
-    <li>If the <code>DataTransferItem</code> object is not in the <i>read/write mode</i> or the <i>read-only mode</i>,
+    <li>If the {{DataTransferItem}} object is not in the <i>read/write mode</i> or the <i>read-only mode</i>,
     abort these steps. The callback is never invoked.</li>
 
     <li>If <a>the drag data item kind</a> is not <i>Plain Unicode string</i>, abort these
     steps. The callback is never invoked.</li>
 
     <li>Otherwise, <a>queue a task</a> to invoke <var>callback</var>, passing the
-    actual data of the item represented by the <code>DataTransferItem</code> object as the
+    actual data of the item represented by the {{DataTransferItem}} object as the
     argument.</li>
 
   </ol>
@@ -2952,14 +2952,14 @@
 
   <ol>
 
-    <li>If the <code>DataTransferItem</code> object is not in the <i>read/write mode</i> or the <i>read-only mode</i>,
+    <li>If the {{DataTransferItem}} object is not in the <i>read/write mode</i> or the <i>read-only mode</i>,
     return null and abort these steps.</li>
 
     <li>If <a>the drag data item kind</a> is not <i>File</i>, then return null and abort
     these steps.</li>
 
     <li>Return a new <code>File</code> object representing the actual data of the item represented
-    by the <code>DataTransferItem</code> object.
+    by the {{DataTransferItem}} object.
 
   </ol>
 
@@ -2968,7 +2968,7 @@
 <h4 id="the-dragevent-interface">The <code>DragEvent</code> interface</h4>
 
   The drag-and-drop processing model involves several events. They all use the
-  <code>DragEvent</code> interface.
+  {{DragEvent}} interface.
 
   <pre class="idl" data-highlight="webidl" dfn-for="DragEvent">
     [Constructor(DOMString type, optional DragEventInit eventInitDict)]
@@ -2983,32 +2983,26 @@
 
   <dl class="domintro">
 
-    <dt><var>event</var> . <code>dataTransfer</code></dt>
+    <dt><var>event</var> . {{DragEvent/dataTransfer}}</dt>
 
     <dd>
 
-    Returns the <code>DataTransfer</code> object for the event.
+    Returns the {{DataTransfer}} object for the event.
 
     </dd>
 
   </dl>
 
   <p class="note">
-  Although, for consistency with other event interfaces, the <code>DragEvent</code>
+  Although, for consistency with other event interfaces, the {{DragEvent}}
   interface has a constructor, it is not particularly useful. In particular, there's no way to
-  create a useful <code>DataTransfer</code> object from script, as <code>DataTransfer</code> objects
+  create a useful {{DataTransfer}} object from script, as {{DataTransfer}} objects
   have a processing and security model that is coordinated by the browser during drag-and-drops.
   </p>
 
-  <div class="impl">
-
   The <dfn attribute for="DragEvent"><code>dataTransfer</code></dfn> attribute of the
-  <code>DragEvent</code> interface must return the value it was initialized to. It represents the
+  {{DragEvent}} interface must return the value it was initialized to. It represents the
   context information for the event.
-
-  </div>
-
-  <div class="impl">
 
   When a user agent is required to <dfn>fire a DND event</dfn> named <var>e</var> at an element,
   using a particular <a>drag data store</a>, and optionally with a specific <var>related
@@ -3032,25 +3026,25 @@
 
     </li>
 
-    <li>Let <var>dataTransfer</var> be a newly created <code>DataTransfer</code> object
+    <li>Let <var>dataTransfer</var> be a newly created {{DataTransfer}} object
     associated with the given <a>drag data store</a>.</li>
 
-    <li>Set the <code>effectAllowed</code> attribute to the <a>drag data
+    <li>Set the {{DataTransfer/effectAllowed}} attribute to the <a>drag data
     store</a>'s <a>drag data store allowed effects state</a>.</li>
 
     <li>
 
-    Set the <code>dropEffect</code> attribute to "<code>none</code>" if <var>e</var> is <code>dragstart</code>, <code>drag</code>, <code>dragexit</code>, or <code>dragleave</code>; to the value corresponding to the <a>current
+    Set the {{DataTransfer/dropEffect}} attribute to "<code>none</code>" if <var>e</var> is <code>dragstart</code>, <code>drag</code>, <code>dragexit</code>, or <code>dragleave</code>; to the value corresponding to the <a>current
     drag operation</a> if <var>e</var> is <code>drop</code> or
-    <code>dragend</code>; and to a value based on the <code>effectAllowed</code> attribute's value and the
+    <code>dragend</code>; and to a value based on the {{DataTransfer/effectAllowed}} attribute's value and the
     drag-and-drop source, as given by the following table, otherwise (i.e., if <var>e</var>
     is <code>dragenter</code> or <code>dragover</code>):
 
     <table>
       <thead>
       <tr>
-        <th><code>effectAllowed</code></th>
-        <th><code>dropEffect</code></th>
+        <th>{{DataTransfer/effectAllowed}}</th>
+        <th>{{DataTransfer/dropEffect}}</th>
       </tr>
       </thead>
       <tr>
@@ -3118,23 +3112,23 @@
 
     <li>
 
-    Create a <a>trusted</a> <code>DragEvent</code> object
+    Create a <a>trusted</a> {{DragEvent}} object
     and initialize it to have the given name <var>e</var>, to bubble, to be cancelable unless
     <var>e</var> is <code>dragexit</code>, <code>dragleave</code>, or <code>dragend</code>, and to have the <code>view</code> attribute initialized to <var>window</var>, the <code>detail</code> attribute initialized to zero, the mouse and key
     attributes initialized according to the state of the input devices as they would be for user
     interaction events, the <code>relatedTarget</code>
-    attribute initialized to <var>related target</var>, and the <code>dataTransfer</code> attribute initialized to
-    <var>dataTransfer</var>, the <code>DataTransfer</code> object created above.
+    attribute initialized to <var>related target</var>, and the {{DragEvent/dataTransfer}} attribute initialized to
+    <var>dataTransfer</var>, the {{DataTransfer}} object created above.
 
     If there is no relevant pointing device, the object must have its <code>screenX</code>, <code>screenY</code>, <code>clientX</code>, <code>clientY</code>, and <code>button</code> attributes set to 0.
 
     </li>
 
     <li><a>Dispatch</a> the newly created
-    <code>DragEvent</code> object at the specified target element.</li>
+    {{DragEvent}} object at the specified target element.</li>
 
     <li>Set the <a>drag data store allowed effects state</a> to the current value of
-    <var>dataTransfer</var>'s <code>effectAllowed</code>
+    <var>dataTransfer</var>'s {{DataTransfer/effectAllowed}}
     attribute. (It can only have changed value if <var>e</var> is <code>dragstart</code>.)</li>
 
     <li>Set the <a>drag data store mode</a> back to the <a>protected mode</a> if it was changed in the first step.</li>
@@ -3166,7 +3160,7 @@
 
     Otherwise, if the drag operation was invoked on a {{Document}}, it is the first
     element, going up the ancestor chain, starting at the node that the user tried to drag, that has
-    the IDL attribute <code>draggable</code> set to true. If there is no such
+    the IDL attribute {{HTMLElement/draggable}} set to true. If there is no such
     element, then nothing is being dragged; abort these steps, the drag-and-drop operation is never
     started.
 
@@ -3174,7 +3168,7 @@
     dragged is defined by the document or application where the drag was started.
 
     <p class="note">
-  <{img}> elements and <{a}> elements with an <{links/href}> attribute have their <code>draggable</code> attribute set to true by default.
+  <{img}> elements and <{a}> elements with an <{links/href}> attribute have their <{global/draggable}> attribute set to true by default.
   </p>
 
     </li>
@@ -3486,7 +3480,7 @@
         <dl class="switch">
 
           <dt>If the <a>immediate user selection</a> is a text field (e.g.,
-          <{textarea}>, or an <{input}> element whose <code>type</code> attribute is in the <a>Text</a> state) or an <a>editing host</a> or
+          <{textarea}>, or an <{input}> element whose <{input/type}> attribute is in the <a>Text</a> state) or an <a>editing host</a> or
           <a>editable</a> element, and the <a>drag data store item list</a> has an item
           with <a>the drag data item type string</a> "<code>text/plain</code>" and <a>the
           drag data item kind</a> <i>Plain Unicode string</i></dt>
@@ -3494,13 +3488,13 @@
           <dd>Set the <a>current target element</a> to the <a>immediate user
           selection</a> anyway.</dd>
 
-          <dt>If the <a>immediate user selection</a> is an element with a <code>dropzone</code> attribute that <a>matches</a> the <a>drag data store</a></dt>
+          <dt>If the <a>immediate user selection</a> is an element with a <{global/dropzone}> attribute that <a>matches</a> the <a>drag data store</a></dt>
 
           <dd>Set the <a>current target element</a> to the <a>immediate user
           selection</a> anyway.</dd>
 
           <dt>If the <a>immediate user selection</a> is an element that itself has an ancestor
-          element with a <code>dropzone</code> attribute that <a>matches</a> the <a>drag data store</a></dt>
+          element with a <{global/dropzone}> attribute that <a>matches</a> the <a>drag data store</a></dt>
 
           <dd>
 
@@ -3560,7 +3554,7 @@
       <dl class="switch">
 
         <dt>If the <a>current target element</a> is a text field (e.g., <{textarea}>,
-        or an <{input}> element whose <code>type</code> attribute
+        or an <{input}> element whose <{input/type}> attribute
         is in the <a>Text</a> state) or an <a>editing
         host</a> or <a>editable</a> element, and the <a>drag data store item list</a>
         has an item with <a>the drag data item type string</a> "<code>text/plain</code>" and
@@ -3569,12 +3563,12 @@
         <dd>Set the <a>current drag operation</a> to either "<code>copy</code>" or "<code>move</code>", as appropriate given the platform
         conventions.</dd>
 
-        <dt>If the <a>current target element</a> is an element with a <code>dropzone</code> attribute that <a>matches</a> the <a>drag data store</a> and <a>specifies an operation</a></dt>
+        <dt>If the <a>current target element</a> is an element with a <{global/dropzone}> attribute that <a>matches</a> the <a>drag data store</a> and <a>specifies an operation</a></dt>
 
-        <dd>Set the <a>current drag operation</a> to the operation <a>specified</a> by the <code>dropzone</code> attribute of the <a>current target
+        <dd>Set the <a>current drag operation</a> to the operation <a>specified</a> by the <{global/dropzone}> attribute of the <a>current target
         element</a>.
 
-        <dt>If the <a>current target element</a> is an element with a <code>dropzone</code> attribute that <a>matches</a> the <a>drag data store</a> and does not
+        <dt>If the <a>current target element</a> is an element with a <{global/dropzone}> attribute that <a>matches</a> the <a>drag data store</a> and does not
         <a>specify an operation</a></dt>
 
         <dd>Set the <a>current drag operation</a> to "<code>copy</code>".
@@ -3586,16 +3580,16 @@
       </dl>
 
       Otherwise (if the <code>dragover</code> event <em>is</em>
-      canceled), set the <a>current drag operation</a> based on the values of the <code>effectAllowed</code> and <code>dropEffect</code> attributes of the
-      <code>DragEvent</code> object's <code>dataTransfer</code>
+      canceled), set the <a>current drag operation</a> based on the values of the {{DataTransfer/effectAllowed}} and {{DataTransfer/dropEffect}} attributes of the
+      {{DragEvent}} object's {{DragEvent/dataTransfer}}
       object as they stood after the event <a>dispatch</a>
       finished, as per the following table:
 
       <table>
         <thead>
           <tr>
-            <th><code>effectAllowed</code></th>
-            <th><code>dropEffect</code></th>
+            <th>{{DataTransfer/effectAllowed}}</th>
+            <th>{{DataTransfer/dropEffect}}</th>
             <th>Drag operation</th>
           </tr>
         </thead>
@@ -3707,8 +3701,8 @@
         <li>
 
         If the event is canceled, set the <a>current drag operation</a> to the value of the
-        <code>dropEffect</code> attribute of the
-        <code>DragEvent</code> object's <code>dataTransfer</code>
+        {{DataTransfer/dropEffect}} attribute of the
+        {{DragEvent}} object's {{DragEvent/dataTransfer}}
         object as it stood after the event <a>dispatch</a>
         finished.
 
@@ -3718,7 +3712,7 @@
         <dl class="switch">
 
           <dt>If the <a>current target element</a> is a text field (e.g., <{textarea}>,
-          or an <{input}> element whose <code>type</code> attribute
+          or an <{input}> element whose <{input/type}> attribute
           is in the <a>Text</a> state) or an <a>editing
           host</a> or <a>editable</a> element, and the <a>drag data store item
           list</a> has an item with <a>the drag data item type string</a>
@@ -3830,7 +3824,7 @@
         <th>Target</th>
         <th>Cancelable?</th>
         <th><a>Drag data store mode</a></th>
-        <th><code>dropEffect</code></th>
+        <th>{{DataTransfer/dropEffect}}</th>
         <th>Default Action</th>
       </tr>
     </thead>
@@ -3856,7 +3850,7 @@
         <td><a>Immediate user selection</a> or <a href="#the-body-element">the <code>body</code> element</a></td>
         <td>&#x2713; Cancelable</td>
         <td><a>Protected mode</a>
-        <td>Based on <code>effectAllowed</code> value</td>
+        <td>Based on {{DataTransfer/effectAllowed}} value</td>
         <td>Reject <a>immediate user selection</a> as potential <a>target element</a></td>
       </tr>
       <tr>
@@ -3880,7 +3874,7 @@
         <td><a>Current target element</a></td>
         <td>&#x2713; Cancelable</td>
         <td><a>Protected mode</a>
-        <td>Based on <code>effectAllowed</code> value</td>
+        <td>Based on {{DataTransfer/effectAllowed}} value</td>
         <td>Reset the <a>current drag operation</a> to "none"</td>
       </tr>
       <tr>
@@ -3902,14 +3896,14 @@
     </tbody>
   </table>
 
-  Not shown in the above table: all these events bubble, and the <code>effectAllowed</code>
+  Not shown in the above table: all these events bubble, and the {{DataTransfer/effectAllowed}}
   attribute always has the value it had after the <code>dragstart</code> event, defaulting to
   "<code>uninitialized</code>" in the <code>dragstart</code> event.
 
-<h4 id="the-draggable-attribute">The <dfn element-attr for="global"><code>draggable</code></dfn> attribute</h4>
+<h4 id="the-draggable-attribute">The <code>draggable</code> attribute</h4>
 
-  All <a>html elements</a> may have the <code>draggable</code> content attribute set. The
-  <code>draggable</code> attribute is an <a>enumerated attribute</a>. It has three states. The first
+  All <a>html elements</a> may have the <dfn element-attr for="global"><code>draggable</code></dfn> content attribute set. The
+  <{global/draggable}> attribute is an <a>enumerated attribute</a>. It has three states. The first
   state is <i>true</i> and it has the keyword <code>true</code>. The second state is <i>false</i>
   and it has the keyword <code>false</code>. The third state is <i>auto</i>; it has no keywords but
   it is the <i>missing value default</i>.
@@ -3917,46 +3911,44 @@
   The <i>true</i> state means the element is draggable; the <i>false</i> state means that it is not.
   The <i>auto</i> state uses the default behavior of the user agent.
 
-  An element with a <code>draggable</code> attribute should also have a <code>title</code> attribute
+  An element with a <{global/draggable}> attribute should also have a <code>title</code> attribute
   that names the element for the purpose of non-visual interactions.
 
   <dl class="domintro">
-    <dt><var>element</var> . <code>draggable</code> [ = <var>value</var> ]</dt>
+    <dt><var>element</var> . {{HTMLElement/draggable}} [ = <var>value</var> ]</dt>
     <dd>
     Returns true if the element is draggable; otherwise, returns false.
 
-    Can be set, to override the default and set the <code>draggable</code>
+    Can be set, to override the default and set the <{global/draggable}>
     content attribute.
     </dd>
   </dl>
 
-  <div class="impl">
-    The {{draggable}} IDL attribute, whose value depends on the content
+    The <dfn attribute for="HTMLElement"><code>draggable</code></dfn> IDL attribute, whose value depends on the content
     attribute's in the way described below, controls whether or not the element is draggable.
-    Generally, only text selections are draggable, but elements whose <code>draggable</code> IDL
+    Generally, only text selections are draggable, but elements whose {{HTMLElement/draggable}} IDL
     attribute is true become draggable as well.
 
-    If an element's <code>draggable</code> content attribute has the state <i>true</i>, the
-    <code>draggable</code> IDL attribute must return true.
+    If an element's <{global/draggable}> content attribute has the state <i>true</i>, the
+    {{HTMLElement/draggable}} IDL attribute must return true.
 
-    Otherwise, if the element's <code>draggable</code> content attribute has the state <i>false</i>,
-    the <code>draggable</code> IDL attribute must return false.
+    Otherwise, if the element's <{global/draggable}> content attribute has the state <i>false</i>,
+    the {{HTMLElement/draggable}} IDL attribute must return false.
 
-    Otherwise, the element's <code>draggable</code> content attribute has the state <i>auto</i>. If
+    Otherwise, the element's <{global/draggable}> content attribute has the state <i>auto</i>. If
     the element is an <{img}> element, an <{object}> element that
     <a>represents</a> an image, or an <{a}> element with an <{links/href}> content
-    attribute, the <code>draggable</code> IDL attribute must return true; otherwise, the
-    <code>draggable</code> IDL attribute must return false.
+    attribute, the {{HTMLElement/draggable}} IDL attribute must return true; otherwise, the
+    {{HTMLElement/draggable}} IDL attribute must return false.
 
-    If the <code>draggable</code> IDL attribute is set to the value false, the
-    <code>draggable</code> content attribute must be set to the literal value "<code>false</code>".
-    If the <code>draggable</code> IDL attribute is set to the value true, the <code>draggable</code>
+    If the {{HTMLElement/draggable}} IDL attribute is set to the value false, the
+    <{global/draggable}> content attribute must be set to the literal value "<code>false</code>".
+    If the {{HTMLElement/draggable}} IDL attribute is set to the value true, the <{global/draggable}>
     content attribute must be set to the literal value "<code>true</code>".
-  </div>
 
-<h4 id="the-dropzone-attribute">The <dfn element-attr for="global"><code>dropzone</code></dfn> attribute</h4>
+<h4 id="the-dropzone-attribute">The <code>dropzone</code> attribute</h4>
 
-  All <a>html elements</a> may have the <{global/dropzone}> content attribute set. When specified,
+  All <a>html elements</a> may have the <dfn element-attr for="global"><code>dropzone</code></dfn> content attribute set. When specified,
   its value must be an <a>unordered set of unique space-separated tokens</a> that are
   <a>ASCII case-insensitive</a>. The allowed values are the following:
 
@@ -4040,11 +4032,11 @@
         The algorithm results in a specified operation if <var>operation</var> is not unspecified.
         The specified operation, if one is specified, is the one given by <var>operation</var>.
 
-    The <dfn attribute for="global"><code>dropzone</code></dfn> IDL attribute must <a>reflect</a> the content attribute of
+    The <dfn attribute for="HTMLElement"><code>dropzone</code></dfn> IDL attribute must <a>reflect</a> the content attribute of
     the same name.
 
     The <a>supported tokens</a> for
-    {{global/dropzone}} are the allowed values defined for the
+    {{HTMLElement/dropzone}} are the allowed values defined for the
     <{global/dropzone}> attribute that are supported by the user agent.
 
   </div>
@@ -4075,7 +4067,7 @@
   <div class="impl">
     <h4 id="security-risks-in-the-drag-and-drop-model">Security risks in the drag-and-drop model</h4>
 
-    User agents must not make the data added to the <code>DataTransfer</code> object during the
+    User agents must not make the data added to the {{DataTransfer}} object during the
     <code>dragstart</code> event available to scripts until the <code>drop</code> event, because
     otherwise, if a user were to drag sensitive information from one document to a second document,
     crossing a hostile third document in the process, the hostile document could intercept the data.
@@ -4097,7 +4089,7 @@
 
     <div class="example">
       Consider a hostile page providing some content and getting the user to select and drag and
-      drop (or indeed, copy and paste) that content to a victim page's <code>contenteditable</code>
+      drop (or indeed, copy and paste) that content to a victim page's <{global/contenteditable}>
       region. If the browser does not ensure that only safe content is dragged, potentially unsafe
       content such as scripts and event handlers in the selection, once dropped (or pasted) into the
       victim site, get the privileges of the victim site. This would thus enable a cross-site


### PR DESCRIPTION
...In the editing section (in part)

Hooks up:
- draggable
- dropzone
- contenteditable
- Members of the various DND interfaces

(No associated issue)
