### PR TITLE
Proposed improvements to dl, dt and dd definitions (issue #202)

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1112,105 +1112,50 @@
     </dd>
   </dl>
 
-  The <{dl}> element <a>represents</a> an association list consisting of zero or more
-  name-value groups (a description list). A name-value group consists of one or more names
-  (<code>dt</code> elements) followed by one or more values (<code>dd</code> elements), ignoring any
-  nodes other than <code>dt</code> and <{dd}> elements. Within a single <code>dl</code>
-  element, there should not be more than one <{dt}> element for each name.
+  The <{dl}> element <a>represents</a> a description list of zero or more term-description groups. Each term-description group consists of one or more terms (represented by <{dt}> elements), and one or more descriptions (represented by <{dd}> elements).
 
-  Name-value groups may be terms and definitions, metadata topics and values, questions and answers,
-  or any other groups of name-value data.
-
-  The values within a group are alternatives; multiple paragraphs forming part of the same value
-  must all be given within the same <{dd}> element.
-
-  The order of the list of groups, and of the names and values within each group, may be significant.
-
-  <div class="impl">
-    If a <{dl}> element has no <code>dt</code> or <{dd}> element children, it
-    contains no groups.
-
-    If a <{dl}> element has one or more non-<a>whitespace</a> <code>Text</code> node
-    children, or has child elements that are neither <code>dt</code> nor <{dd}> elements,
-    all such <code>Text</code> nodes and elements, as well as their descendants (including any
-    <code>dt</code> or <{dd}> elements), do not form part of any groups in that
-    <{dl}>.
-
-    If a <{dl}> element has one or more <{dt}> element children but no
-    <{dd}> element children, then it consists of one group with names but no values.
-
-    If a <{dl}> element has one or more <{dd}> element children but no
-    <{dt}> element children, then it consists of one group with values but no names.
-
-    If a <{dl}> element's first <code>dt</code> or <{dd}> element child is a
-    <{dd}> element, then the first group has no associated name.
-
-    If a <{dl}> element's last <code>dt</code> or <{dd}> element child is a
-    <{dt}> element, then the last group has no associated value.
-
-    <p class="note">
-      When a <{dl}> element doesn't match its content model, it is often due to
-      accidentally using <{dd}> elements in the place of <{dt}> elements and vice
-      versa. Conformance checkers can spot such mistakes and might be able to advise authors how to
-      correctly use the markup.
-    </p>
-  </div>
+  term-description groups may be names  and definitions, questions and answers, categories and topics, or any other groups of term-description pairs.
 
   <div class="example">
-    In the following example, one entry ("Authors") is linked to two values ("John" and "Luke").
-
+    <p>In this example a <{dl}> is used to represent a simple list of names and descriptions:</p>
     <pre highlight="html">
       &lt;dl&gt;
-        &lt;dt&gt; Authors
-        &lt;dd&gt; John
-        &lt;dd&gt; Luke
-        &lt;dt&gt; Editor
-        &lt;dd&gt; Frank
+        &lt;dt&gt;Blanco tequila&lt;/dt&gt;
+        &lt;dd&gt;The purest form of the blue agave spirit...&lt;/dd&gt;
+        &lt;dt&gt;Reposado tequila&lt;/dt&gt;
+        &lt;dd&gt;Typically aged in wooden barrels for between two and eleven months...&lt;/dd&gt;
       &lt;/dl&gt;
     </pre>
   </div>
 
-  <div class="example">
-    In the following example, one definition is linked to two terms.
+  Each term within a term-description group must be represented by a single <{dt}> element. The descriptions within a term-description group are alternatives. Each description must be represented by a single <{dd}> element.
 
+  <div class="example">
+    <p>In this example a <{dl}> element represents a set of terms, each of which has multiple descriptions:</p>
     <pre highlight="html">
+      &lt;p&gt;Information about the rock band Queen:&lt;/p&gt;
       &lt;dl&gt;
-        &lt;dt lang="en-US"&gt; &lt;dfn&gt;color&lt;/dfn&gt; &lt;/dt&gt;
-        &lt;dt lang="en-GB"&gt; &lt;dfn&gt;colour&lt;/dfn&gt; &lt;/dt&gt;
-        &lt;dd&gt; A sensation which (in humans) derives from the ability of
-        the fine structure of the eye to distinguish three differently
-        filtered analyses of a view. &lt;/dd&gt;
+        &lt;dt&gt;Members&lt;/dt&gt;
+        &lt;dd&gt;Brian May&lt;/dd&gt;
+        &lt;dd&gt;Freddie Mercury&lt;/dd&gt;
+        &lt;dd&gt;John Deacon&lt;/dd&gt;
+        &lt;dd&gt;Roger Taylor&lt;/dd&gt;
+        &lt;dt&gt;Record labels&lt;/dt&gt;
+        &lt;dd&gt;EMI&lt;/dd&gt;
+        &lt;dd&gt;Parlophone&lt;/dd&gt;
+        &lt;dd&gt;Capitol&lt;/dd&gt;
+        &lt;dd&gt;Hollywood&lt;/dd&gt;
+        &lt;dd&gt;Island&lt;/dd&gt;
       &lt;/dl&gt;
     </pre>
   </div>
 
-  <div class="example">
-    The following example illustrates the use of the <{dl}> element to mark up metadata of
-    sorts. At the end of the example, one group has two metadata labels ("Authors" and "Editors")
-    and two values ("Robert Rothman" and "Daniel Jackson").
-
-    <pre highlight="html">
-      &lt;dl&gt;
-        &lt;dt&gt; Last modified time &lt;/dt&gt;
-        &lt;dd&gt; 2004-12-23T23:33Z &lt;/dd&gt;
-        &lt;dt&gt; Recommended update interval &lt;/dt&gt;
-        &lt;dd&gt; 60s &lt;/dd&gt;
-        &lt;dt&gt; Authors &lt;/dt&gt;
-        &lt;dt&gt; Editors &lt;/dt&gt;
-        &lt;dd&gt; Robert Rothman &lt;/dd&gt;
-        &lt;dd&gt; Daniel Jackson &lt;/dd&gt;
-      &lt;/dl&gt;
-    </pre>
-  </div>
+  The order of term-description groups within a <{dl}> element, and the order of terms and descriptions within each group, may be significant.
 
   <div class="example">
-    The following example shows the <{dl}> element used to give a set of instructions. The
-    order of the instructions here is important (in the other examples, the order of the blocks was
-    not important).
-
+    <p>In this example a <{dl}> is used to show a set of instructions, where the order of the instructions is important:</p>
     <pre highlight="html">
-      &lt;p&gt;Determine the victory points as follows (use the
-      first matching case):&lt;/p&gt;
+      &lt;p&gt;Determine the victory points as follows (use the first matching case):&lt;/p&gt;
       &lt;dl&gt;
         &lt;dt&gt; If you have exactly five gold coins &lt;/dt&gt;
         &lt;dd&gt; You get five victory points &lt;/dd&gt;
@@ -1224,22 +1169,19 @@
     </pre>
   </div>
 
-  <div class="example">
-    The following snippet shows a <{dl}> element being used as a glossary. Note the use of
-    <code>dfn</code> to indicate the word being defined.
+  If a <{dl}> element contains no <{dt}> or <{dd}> child elements, it contains no term-description groups.
 
-    <pre highlight="html">
-      &lt;dl&gt;
-        &lt;dt&gt;&lt;dfn&gt;Apartment&lt;/dfn&gt;, n.&lt;/dt&gt;
-        &lt;dd&gt;An execution context grouping one or more threads with one or
-        more COM objects.&lt;/dd&gt;
-        &lt;dt&gt;&lt;dfn&gt;Flat&lt;/dfn&gt;, n.&lt;/dt&gt;
-        &lt;dd&gt;A deflated tire.&lt;/dd&gt;
-        &lt;dt&gt;&lt;dfn&gt;Home&lt;/dfn&gt;, n.&lt;/dt&gt;
-        &lt;dd&gt;The user's login directory.&lt;/dd&gt;
-      &lt;/dl&gt;
-    </pre>
-  </div>
+  If a <{dl}> element has one or more non-<a>whitespace</a> text node children, or has children that are neither <{dt}> or <{dd}> elements, then all such text nodes and elements as well as their descendants (including any <{dt}> and <{dd}> elements) do not form part of any term-description group within the <{dl}>.
+
+  If a <{dl}> element has one or more <{dt}> element children, but no <{dd}> element children, then it consists of one group with terms but no descriptions.
+
+  If a <{dl}> element has one or more <{dd}> element children, but no <{dt}> element children, it consists of one group with descriptions but no terms.
+
+  If a <{dd}> element is the first child of a <{dl}> element (excepting an <a>script-supporting element</a>), the first group has no associated term.
+
+  If a <{dt}> element is the last child of a <{dl}> element (excepting a <a>script-supporting element</a>), the last group has no associated descriptions.
+
+  <p class="note">Note: when a <{dl}> element does not match its content model, it is often because a <{dd}> element has been used instead of a <{dt}> element, or vice versa.</p>
 
 <h4 id="the-dt-element">The <dfn element><code>dt</code></dfn> element</h4>
 
@@ -1270,31 +1212,32 @@
     <dd>Uses <code>HTMLElement</code>.</dd>
   </dl>
 
-  The <{dt}> element <a>represents</a> the term, or name, part of a term-description group
-  in a description list (<code>dl</code> element).
-
-  <p class="note">
-    The <{dt}> element itself, when used in a <{dl}> element, does not indicate
-    that its contents are a term being defined, but this can be indicated using the <code>dfn</code>
-    element.
-  </p>
+  The <{dt}> element <a>represents</a> a term, part of a term-description group in a description list (<{dl}> element).
 
   <div class="example">
-    This example shows a list of frequently asked questions (a FAQ) marked up using the
-    <{dt}> element for questions and the <{dd}> element for answers.
-
+    <p>In this example the <{dt}> elements represent questions and the <{dd}> elements the answers:</p>
     <pre highlight="html">
-      &lt;article&gt;
-        &lt;h1&gt;FAQ&lt;/h1&gt;
-        &lt;dl&gt;
-          &lt;dt&gt;What do we want?&lt;/dt&gt;
-          &lt;dd&gt;Our data.&lt;/dd&gt;
-          &lt;dt&gt;When do we want it?&lt;/dt&gt;
-          &lt;dd&gt;Now.&lt;/dd&gt;
-          &lt;dt&gt;Where is it?&lt;/dt&gt;
-          &lt;dd&gt;We are not sure.&lt;/dd&gt;
-        &lt;/dl&gt;
-      &lt;/article&gt;
+      &lt;dl&gt;
+        &lt;dt&gt;What is my favorite drink?&lt;/dt&gt;
+        &lt;dd&gt;Tea&lt;/dd&gt;
+        &lt;dt&gt;What is my favorite food?&lt;/dt&gt;
+        &lt;dd&gt;Sushi&lt;/dd&gt;
+        &lt;dt&gt;What is my favourite film?&lt;/dt&gt;
+        &lt;dd&gt;What a Wonderful Life&lt;/dd&gt;
+      &lt;/dl&gt;
+    </pre>
+  </div>
+
+  <p class="note">When used within a <{dl}> element, the <{dt}> element does not necessarily represent the definition for a term. The <{dfn}> element should be used to represent a definition.</p>
+
+  <div class="example">
+    <p>In this example the <{dfn}> element indicates that the <{dt}> element contains a defined term, the definition for which is represented by the <{dd}> element:</p>
+    <pre highlight="html">
+      &lt;dl&gt;
+        &lt;dt lang="en-us"&gt;&lt;dfn&gt;Color&lt;/dfn&gt;&lt;/dt&gt;
+        &lt;dt lang="en-gb"&gt;&lt;dfn&gt;Colour&lt;/dfn&gt;&lt;/dt&gt;
+        &lt;dd&gt;A sensation which (in humans) derives from the ability of the fine structure of the eye to distinguish three differently filtered analyses of a view.&lt;/dd&gt;
+      &lt;/dl&gt;
     </pre>
   </div>
 
@@ -1325,25 +1268,20 @@
     <dd>Uses <code>HTMLElement</code>.</dd>
   </dl>
 
-  The <{dd}> element <a>represents</a> the description, definition, or value, part of a
-  term-description group in a description list (<{dl}> element).
+  The <{dd}> element <a>represents</a> a description, part of a term-description group in a description list (<{dl}> element).
 
   <div class="example">
-    A <{dl}> can be used to define a vocabulary list, like in a dictionary. In the
-    following example, each entry, given by a <{dt}> with a <{dfn}>, has several
-    <{dd}>s, showing the various parts of the definition.
-
+    <p>In this example the <{dd}> elements represent the keys that invoke the keycodes indicated in the <{dt}> elements:</p>
     <pre highlight="html">
       &lt;dl&gt;
-        &lt;dt&gt;&lt;dfn&gt;happiness&lt;/dfn&gt;&lt;/dt&gt;
-        &lt;dd class="pronunciation"&gt;/'hæ p. nes/&lt;/dd&gt;
-        &lt;dd class="part-of-speech"&gt;&lt;i&gt;&lt;abbr&gt;n.&lt;/abbr&gt;&lt;/i&gt;&lt;/dd&gt;
-        &lt;dd&gt;The state of being happy.&lt;/dd&gt;
-        &lt;dd&gt;Good fortune; success. &lt;q&gt;Oh &lt;b&gt;happiness&lt;/b&gt;! It worked!&lt;/q&gt;&lt;/dd&gt;
-        &lt;dt&gt;&lt;dfn&gt;rejoice&lt;/dfn&gt;&lt;/dt&gt;
-        &lt;dd class="pronunciation"&gt;/ri jois'/&lt;/dd&gt;
-        &lt;dd&gt;&lt;i class="part-of-speech"&gt;&lt;abbr&gt;v.intr.&lt;/abbr&gt;&lt;/i&gt; To be delighted oneself.&lt;/dd&gt;
-        &lt;dd&gt;&lt;i class="part-of-speech"&gt;&lt;abbr&gt;v.tr.&lt;/abbr&gt;&lt;/i&gt; To cause one to be delighted.&lt;/dd&gt;
+        &lt;dt&gt;37&lt;/dt&gt;
+        &lt;dd&gt;Left&lt;/dd&gt;
+        &lt;dt&gt;38&lt;/dt&gt;
+        &lt;dd&gt;Right&lt;/dd&gt;
+        &lt;dt&gt;39&lt;/dt&gt;
+        &lt;dd&gt;Up&lt;/dd&gt;
+        &lt;dt&gt;40&lt;/dt&gt;
+        &lt;dd&gt;Down&lt;/dd&gt;
       &lt;/dl&gt;
     </pre>
   </div>


### PR DESCRIPTION
Updated the prose definitions for the `<dl>`, `<dt>` and `<dd>` elements. Aim is to clarify how/where `<dfn>` fits in, and to generally simplify all three definitions for easier readability. Per issue #202
