### PR TITLE
modify header/footer content model to allow header/footer descendants

### DIFF
--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1023,8 +1023,8 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>
-      <a>Flow content</a>, but with no <{header}>, <{footer}>, or
-      <{main}> element descendants.
+      <a>Flow content</a>, but with no <{main}> element descendants, or <{header}>, <{footer}> elements
+	  that are not descendants of <a>sectioning content</a> which is a descendant of the <{footer}>. 
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -878,8 +878,8 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>
-      <a>Flow content</a>, but with no <{header}>, <{footer}>, or
-      <{main}> element descendants.
+      <a>Flow content</a>, but with no <{main}> element descendants, or <{header}>, <{footer}> elements
+	  that are not descendants of <a>sectioning content</a> which is a descendant of the <{header}>. 
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
@@ -980,6 +980,37 @@
         &lt;!-- this is still part of the subsection entitled "Games" --&gt;
         ...
   </pre>
+  </div>
+  <p class="note">
+    For cases where an developer wants to nest a <code>header</code> or <code>footer</code> within 
+	another <code>header</code>: The <{header}> element can only contain a <{header}> or <{footer}> 
+	if they are themselves contained within <a>sectioning content</a>. 
+  </p>
+
+  <div class="example">
+ <p>In this example, the <code>article</code> has a <code>header</code> which contains an <code>aside</code>
+  which itself contains a <{header}>. This is conforming as the descendant <code>header</code> is contained 
+  within the <{aside}> element.</p>
+
+  <pre highlight="html">
+&lt;article&gt;
+ 
+&lt;header&gt;
+&lt;h1&gt;Flexbox the definitive guide&lt;/h1&gt; 
+ &lt;aside&gt;
+  &lt;header&gt;
+   &lt;h2&gt;About the author&lt;/h2&gt; 
+    &lt;p&gt;A nice person that hates everything and everyone&lt;/p&gt;
+    &lt;p&gt;&lt;a href="./wes/"&gt;Contact Wes!&lt;/a&gt;&lt;/p&gt;
+   &lt;/header&gt;
+  &lt;p&gt;This article is brought to you by Wesley, skilled expert in "always-in-beta" 
+  applications that will never see the&lt;/p&gt;
+ &lt;/aside&gt;
+&lt;/header&gt;
+
+&lt;p&gt;Actual article here... Actual article here... Actual article here...&lt;/p&gt;
+
+&lt;/article&gt;</pre>
   </div>
 
 <h4 id="the-footer-element">The <dfn element><code>footer</code></dfn> element</h4>


### PR DESCRIPTION
allows only when nested header/footer are descendants of sectioning content.
refer to https://github.com/w3c/html/issues/273
