### PR TITLE
fix two typos in the description of the dl element

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1114,7 +1114,7 @@
 
   The <{dl}> element <a>represents</a> a description list of zero or more term-description groups. Each term-description group consists of one or more terms (represented by <{dt}> elements), and one or more descriptions (represented by <{dd}> elements).
 
-  term-description groups may be names  and definitions, questions and answers, categories and topics, or any other groups of term-description pairs.
+  Term-description groups may be names  and definitions, questions and answers, categories and topics, or any other groups of term-description pairs.
 
   <div class="example">
     <p>In this example a <{dl}> is used to represent a simple list of names and descriptions:</p>
@@ -1177,7 +1177,7 @@
 
   If a <{dl}> element has one or more <{dd}> element children, but no <{dt}> element children, it consists of one group with descriptions but no terms.
 
-  If a <{dd}> element is the first child of a <{dl}> element (excepting an <a>script-supporting element</a>), the first group has no associated term.
+  If a <{dd}> element is the first child of a <{dl}> element (excepting a <a>script-supporting element</a>), the first group has no associated term.
 
   If a <{dt}> element is the last child of a <{dl}> element (excepting a <a>script-supporting element</a>), the last group has no associated descriptions.
 


### PR DESCRIPTION
- start paragraph with a capital letter
- a**n** script-supporting element → a script-supporting element
