### PR TITLE
Deprecated/removed 'usemap' on <object> as per Issue #285

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -873,7 +873,7 @@
     </tr>
     <tr>
       <th><code>usemap</code></th>
-      <td><{img}>; <{object}></td>
+      <td><{img}></td>
       <td>Name of <a>image map</a> to use</td>
       <td><a>Valid hash-name reference</a>*</td>
     </tr>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1208,7 +1208,6 @@
     </li>
     <li><{keygen}></li>
     <li><{label}></li>
-    <li><{object}> (if the <{object/usemap}> attribute is present)</li>
     <li><{select}></li>
     <li><{textarea}></li>
     <li><{video}> (if the <{video/controls}> attribute is present)</li>

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -250,7 +250,6 @@
         <{audio}> (if the <{audio/controls}> attribute is present);
       <{img}> (if the <{common/usemap}> attribute is present);
       <{input}> (if the <code><{input/type}> attribute is <em>not</em> in the <a element-state for="input">Hidden</a> state);
-      <{object}> (if the <{common/usemap}> attribute is present);
       <{video}> (if the <{video/controls}> attribute is present)
 
     </td>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -946,7 +946,6 @@
          <{object/type}>;
          <{object/typemustmatch}>;
          <{object/name}>;
-         <{object/usemap}>;
          <{object/form}>;
          <{media/width}>;
          <{media/height}></td>

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -240,7 +240,8 @@
 
   : <dfn element-attr for="object"><code>standby</code></dfn> on <{object}> elements
   :: Optimize the linked resource so that it loads quickly or, at least, incrementally.
-
+  : <dfn element-attr for="object"><code>usemap</code></dfn> on <{object}> elements
+  
   : <dfn element-attr for="param"><code>type</code></dfn> on <{param}> elements
   : <dfn element-attr for="param"><code>valuetype</code></dfn> on <{param}> elements
   :: Use the <code>name</code> and <code>value</code> attributes without declaring value types.

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4301,7 +4301,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><a>Flow content</a>.</dd>
     <dd><a>Phrasing content</a>.</dd>
     <dd><a>Embedded content</a>.</dd>
-    <dd>If the element has a <code>usemap</code> attribute: <a>interactive content</a>.</dd>
     <dd><a lt="listed element">listed</a>, <a>submittable</a>, and <a>reassociateable</a> <a>form-associated element</a>.</dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
@@ -4317,7 +4316,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>typemustmatch</code> - Whether the <code>type</code>
     attribute and the <a>Content-Type</a> value need to match for the resource to be used</dd>
     <dd><{object/name}> - Name of <a>nested browsing context</a></dd>
-    <dd><code>usemap</code> - Name of <a>image map</a> to use </dd>
     <dd><code>form</code> - Associates the control with a <{form}> element</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
@@ -4336,7 +4334,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
           attribute DOMString type;
           attribute boolean typeMustMatch;
           attribute DOMString name;
-          attribute DOMString useMap;
           readonly attribute HTMLFormElement? form;
           attribute DOMString width;
           attribute DOMString height;
@@ -4852,11 +4849,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
   </div>
 
-  The <dfn element-attr for="object"><code>usemap</code></dfn> attribute, if present while the
-  <{object}> element represents an image, can indicate that the object has an associated
-  <a>image map</a>. <span class="impl">The attribute must be ignored if the
-  <{object}> element doesn't represent an image.</span>
-
   The <{object/form}> attribute is used to explicitly associate the
   <{object}> element with its <a>form owner</a>.
 
@@ -4874,8 +4866,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   The IDL attributes {{HTMLObjectElement/data}}, {{HTMLObjectElement/type}} and {{HTMLObjectElement/name}} each must <a>reflect</a> the respective
   content attributes of the same name. The {{HTMLObjectElement/typeMustMatch}} IDL attribute must
   <a>reflect</a> the <{object/typemustmatch}> content
-  attribute. The {{HTMLObjectElement/useMap}} IDL attribute must
-  <a>reflect</a> the <{object/usemap}> content attribute.
+  attribute.
 
   The {{HTMLObjectElement/contentDocument}} IDL attribute must return the {{Document}} object of the
   <a>active document</a> of the <{object}> element's <a>nested browsing context</a>, if any and if
@@ -11926,10 +11917,9 @@ red:89
 
   An <dfn lt="image map|image maps">image map</dfn> allows geometric areas on an image to be associated with <a>hyperlinks</a>.
 
-  An image, in the form of an <{img}> element or an <{object}> element
-  representing an image, may be associated with an image map (in the form of a <code>map</code>
+  An image, in the form of an <{img}> element, may be associated with an image map (in the form of a <code>map</code>
   element) by specifying a <dfn element-attr for="common"><code>usemap</code></dfn> attribute on
-  the <{img}> or <{object}> element. The <code>usemap</code> attribute, if specified, must be a <a>valid
+  the <{img}> element. The <code>usemap</code> attribute, if specified, must be a <a>valid
   hash-name reference</a> to a <{map}> element.
 
   <div class="example">
@@ -11961,7 +11951,7 @@ red:89
 
 <h5 id="image-maps-processing-model">Processing model</h5>
 
-  If an <{img}> element or an <{object}> element representing an image has a
+  If an <{img}> element has a
   <code>usemap</code> attribute specified, user agents must process it
   as follows:
 


### PR DESCRIPTION
This removes 'usemap' from `<object>` as well as the 'useMap' IDL definition for HTMLObjectElement. Let me know if this should be added to the obsolete section. See issue #285 
