### PR TITLE
Finish up object/useMap in obsolete

### DIFF
--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -241,7 +241,8 @@
   : <dfn element-attr for="object"><code>standby</code></dfn> on <{object}> elements
   :: Optimize the linked resource so that it loads quickly or, at least, incrementally.
   : <dfn element-attr for="object"><code>usemap</code></dfn> on <{object}> elements
-  
+  :: Use <code>img</code> instead of <code>object</code> for image maps.
+
   : <dfn element-attr for="param"><code>type</code></dfn> on <{param}> elements
   : <dfn element-attr for="param"><code>valuetype</code></dfn> on <{param}> elements
   :: Use the <code>name</code> and <code>value</code> attributes without declaring value types.
@@ -1262,6 +1263,7 @@
       attribute unsigned long vspace;
       attribute DOMString codeBase;
       attribute DOMString codeType;
+      attribute DOMString useMap;
 
       [TreatNullAs=EmptyString] attribute DOMString border;
     };
@@ -1283,6 +1285,9 @@
 
   The <dfn attribute for="HTMLObjectElement"><code>codeType</code></dfn> IDL attribute of the
   <{object}> element must <a>reflect</a> the element's <{object/codetype}> content attribute.
+
+  The <dfn attribute for="HTMLObjectElement"><code>useMap</code></dfn> IDL attribute of the
+  <{object}> element must <a>reflect</a> the element's <{object/usemap}> content attribute.
 
   <hr />
 


### PR DESCRIPTION
Finish adding `useMap` to obsolete section for `<object>`

Fix #285 
