### PR TITLE
Moved all links possible to https

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -5,7 +5,7 @@
 
   Full details of all changes since 12 January 2016 are available from the <a href="https://github.com/w3c/html/commits/master">commit log</a> of the <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various editorial and linking fixes.
 
-<h3 id="changes-20160602">Changes since the <a href="http://www.w3.org/TR/2016/WD-html51-20160503/">3 May 2016 Public Working Draft</a>.</h3>
+<h3 id="changes-20160602">Changes since the <a href="https://www.w3.org/TR/2016/WD-html51-20160503/">3 May 2016 Public Working Draft</a>.</h3>
  <dl>
   <dt>Changes to match implementation or reflect lack of it</dt>
     <dd><a href="https://github.com/w3c/html/pull/453/commits/4459c0c6c442d3765ac2f8a1f505521db9f22343">Add <code>oncopy</code> /<code>oncut</code> /<code>onpaste</code> handling</a></dd>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -12840,7 +12840,7 @@ var selectionText = control.value.substring(control.selectionStart, control.sele
 var oldStart = control.selectionStart;
 var oldEnd = control.selectionEnd;
 var oldDirection = control.selectionDirection;
-var prefix = "http://";
+var prefix = "https://";
 control.value = prefix + control.value;
 control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldDirection);
     </pre>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -170,28 +170,28 @@
  <pre highlight="html">
  &lt;article&gt;
   &lt;header&gt;
-   &lt;h2&gt;&lt;a href="http://herbert.io"&gt;Short note on wearing shorts&lt;/a&gt;&lt;/h2&gt;
+   &lt;h2&gt;&lt;a href="https://herbert.io"&gt;Short note on wearing shorts&lt;/a&gt;&lt;/h2&gt;
     &lt;p&gt;Posted on Wednesday, 10 February 2016 by Patrick Lauke.
-    &lt;a href="http://herbert.io/short-note/#comments"&gt;6 comments&lt;/a&gt;&lt;/p&gt;
+    &lt;a href="https://herbert.io/short-note/#comments"&gt;6 comments&lt;/a&gt;&lt;/p&gt;
   &lt;/header&gt;
   &lt;p&gt;A fellow traveller posed an interesting question: Why do you wear shorts rather than
   longs? The person was wearing <em>culottes</em> as the time, so I considered the question equivocal in nature,
   but I attempted to provide an honest answer despite the dubiousness of the questioner's dress.&lt;/p&gt;
   &lt;p&gt;The short answer is that I enjoy wearing shorts, the long answer is...&lt;/p&gt;
-  &lt;p&gt;&lt;a href="http://herbert.io/short-note/"&gt;Continue reading: Short note on
+  &lt;p&gt;&lt;a href="https://herbert.io/short-note/"&gt;Continue reading: Short note on
   wearing shorts&lt;/a&gt;&lt;/p&gt;
  &lt;/article&gt;</pre>
  </div>
 
  <p class="note">The schema.org  vocabulary can be used to provide more granular information about
-  the type of article, using the <a href="http://schema.org/Article">CreativeWork - Article</a>
+  the type of article, using the <a href="https://schema.org/Article">CreativeWork - Article</a>
   subtypes, other information such as the publication date for the article can also be provided.</p>
 
   <div class="example">
   <p>This example shows a blog post using the <code>article</code> element, with some schema.org
   annotations: </p>
   <pre highlight="html">
-      &lt;article itemscope <mark>itemtype="http://schema.org/BlogPosting"</mark>&gt;
+      &lt;article itemscope <mark>itemtype="https://schema.org/BlogPosting"</mark>&gt;
         &lt;header&gt;
           &lt;h2 itemprop="headline"&gt;The Very First Rule of Life&lt;/h2&gt;
           &lt;p&gt;&lt;time <mark>itemprop="datePublished"</mark> datetime="2016-02-28"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
@@ -206,7 +206,7 @@
     </pre>
 
     <p>Here is that same blog post, but showing some of the comments: </p>
-  <pre highlight="html">     &lt;article itemscope itemtype="http://schema.org/BlogPosting"&gt;
+  <pre highlight="html">     &lt;article itemscope itemtype="https://schema.org/BlogPosting"&gt;
         &lt;header&gt;
           &lt;h2 itemprop="headline"&gt;The Very First Rule of Life&lt;/h2&gt;
           &lt;p&gt;&lt;time itemprop="datePublished" datetime="2009-10-09"&gt;3 days ago&lt;/time&gt;&lt;/p&gt;
@@ -217,14 +217,14 @@
         &lt;section&gt;
           &lt;h3&gt;Comments&lt;/h3&gt;
           &lt;ol&gt;
-           &lt;li itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c1"&gt;
-              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
+           &lt;li itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c1"&gt;
+              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
               &lt;span itemprop="name"&gt;George Washington&lt;/span&gt;
               &lt;/span&gt;&lt;/p&gt;
               &lt;p&gt;&lt;time itemprop="commentTime" datetime="2009-10-10"&gt;15 minutes ago&lt;/time&gt;&lt;/p&gt;
               &lt;p&gt;Yeah! Especially when talking about your lobbyist friends!&lt;/p&gt;
-           &lt;li itemprop="comment" itemscope itemtype="http://schema.org/UserComments" id="c2"&gt;
-              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="http://schema.org/Person"&gt;
+           &lt;li itemprop="comment" itemscope itemtype="https://schema.org/UserComments" id="c2"&gt;
+              &lt;p&gt;Posted by: &lt;span itemprop="creator" itemscope itemtype="https://schema.org/Person"&gt;
               &lt;span itemprop="name"&gt;George Hammond&lt;/span&gt;
               &lt;/span&gt;&lt;/p&gt;
               &lt;p&gt;&lt;time itemprop="commentTime" datetime="2009-10-10"&gt;5 minutes ago&lt;/time&gt;&lt;/p&gt;

--- a/single-page.bs
+++ b/single-page.bs
@@ -5,13 +5,13 @@ Level: 5.1
 Group: html
 Status: ED
 Date: 2016-06-02
-TR: http://www.w3.org/TR/html51/
+TR: https://www.w3.org/TR/html51/
 ED: https://w3c.github.io/html/
 Repository: w3c/html
 Boilerplate: omit feedback-header
 !Participate: <a href="https://github.com/w3c/html/issues/new">File an issue</a> (<a href="https://github.com/w3c/html/issues">open issues</a>)
 !Others: <a href="single-page.html">Single page version</a>
-Previous Version: http://www.w3.org/TR/2016/WD-html51-20160503/
+Previous Version: https://www.w3.org/TR/2016/WD-html51-20160503/
 
 Editor: Steve Faulkner, The Paciello Group, sfaulkner@paciellogroup.com
 Editor: Arron Eicholz, Microsoft, arronei@microsoft.com
@@ -33,7 +33,7 @@ Ignored Vars: this, object, variable, optionalArgument, name, value, e, oldParen
 <pre class="anchors">
 url: https://www.w3.org/TR/selection-api/#idl-def-Selection; type: interface; spec: SELECTION-API;
     text: Selection;
-urlPrefix: http://validator.w3.org/nu/; url:; type:dfn;
+urlPrefix: https://validator.w3.org/nu/; url:; type:dfn;
     text: Nu Markup Validation Service;
 urlPrefix: https://whatwg.org/specs/web-apps/current-work/; url:; type: dfn; spec: WHATWG;
     text: WHATWG HTML specification;
@@ -316,7 +316,7 @@ url: https://www.w3.org/TR/WCAG20/#text-altdef; type: dfn;
     text: Text alternatives
 url: https://www.w3.org/TR/rdfa-lite/#h-document-conformance; type: dfn;
     text: RDFA Lite
-url: http://www.w3.org/WAI/alt/#resources; type: dfn;
+url: https://www.w3.org/WAI/alt/#resources; type: dfn;
     text: Resources on Alternative Text for Images
 url: http://www.tate.org.uk/art/artworks/waterhouse-the-lady-of-shalott-n01543#main; type:dfn;
     text: information about the painting
@@ -343,7 +343,7 @@ url: https://www.iso.org/obp/ui/#iso:std:iso:3166:-1:ed-3:v1:en,fr; type: dfn;
     text: iso 3166-1-alpha-2 country code
 urlPrefix: https://www.w3.org/TR/2dcontext/#; type: interface;
     text: CanvasRenderingContext2D
-url: http://wiki.whatwg.org/wiki/CanvasContexts#content; type: dfn;
+url: https://wiki.whatwg.org/wiki/CanvasContexts#content; type: dfn;
     text: WHATWG Wiki CanvasContexts page
 url: https://whatwg.org/demos/offline/clock/live-demo/clock.html#clock; type: dfn;
     text: view this example online


### PR DESCRIPTION
Fixes #399 

Remaining links (that redirect to http, or fail with https):
- http://www.reusableart.com
- http://berjon.com/
- http://www.tate.org.uk/
- http://www.bbc.com/
- http://microformats.org/
- http://www.ecma-international.org/ (bad cert?)

Everything else is:
- a namespace
- a registered protocol
