### PR TITLE
Fix technical inaccuracy in case change

### DIFF
--- a/sections/dom.include
+++ b/sections/dom.include
@@ -2370,7 +2370,8 @@
     <dd>
       Returns a <code>DOMStringMap</code> object for the element's <code>data-*</code> attributes.
 
-      Hyphenated names become camel-cased. For example, <code>data-foo-bar=""</code> becomes
+      Hyphenated names are converted to dromedaryCase (which is the same as CamelCase except
+      the initial letter is not uppercased). For example, <code>data-foo-bar=""</code> becomes
       <code>element.dataset.fooBar</code>.
     </dd>
 


### PR DESCRIPTION
Camel case is like this: FooBarBazBlah
Dromedar case is like this: fooBarBazBlah

The algorithm described a few lines further down
clearly is dromedar case because the first letter is not
converted as it does not start with a hyphen-minus.
