### PR TITLE
Add usage summary for the address element

### DIFF
--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -2158,6 +2158,20 @@
           </pre>
         </td>
       </tr>
+      <tr>
+        <td rowspan="2"><{address}></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="html">
+            &lt;address&gt;
+            To book DJ Steve Hill and Technikal, contact our
+            &lt;a href="mailto:management@example.com"&gt;management&lt;/a&gt;.
+            &lt;/address&gt;
+          </pre>
+        </td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
An usage example for every element in the sections chapter might be helpful. It’s a rather small change to a non-normative section, so I thought I’d just create a pull request. Hope that’s okay.
