### PR TITLE
Make editing refs informative

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -1910,9 +1910,9 @@
   <dfn><code>queryCommandState()</code></dfn>,
   <dfn><code>queryCommandSupported()</code></dfn>, and
   <dfn><code>queryCommandValue()</code></dfn>
-  methods, text selections, and the <dfn>delete the selection</dfn> algorithm are defined in the
-  HTML Editing APIs specification. The interaction of editing and the undo/redo features in user
-  agents is defined by the UndoManager and DOM Transaction specification. [[!EDITING]] [[!UNDO]]
+  methods, text selections, and the <dfn>delete the selection</dfn> algorithm are being defined in the
+  various HTML Editing specification drafts [[EDITING]]. The interaction of editing and undo/redo
+  features are being defined in the UndoManager and DOM Transaction specification. [[UNDO]]
 
 <h4 id="spelling-and-grammar-checking">Spelling and grammar checking</h4>
 


### PR DESCRIPTION
These are drafts in considerable flux. They are useful, but should not
be considered normative at this stage
