### PR TITLE
Mark things "at risk"

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -10491,6 +10491,14 @@ zero or more <{track}> elements, then
 
 <h6 id="text-tracks-exposing-inband-metadata">Text tracks exposing in-band metadata</h6>
 
+  <p class="warning">
+  The use of text tracks exposing in-band metadata is "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of text tracks exposing in-band metadata
+  this section will be removed from the HTML 5.1 Specification.
+  </p>
+
+
   <a>Media resources</a> often contain one or more
   <a>media-resource-specific text tracks</a>
   containing data that browsers don't render, but want to expose to script to allow being

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -644,6 +644,13 @@
 
     <dd>
 
+    <p class="warning">
+    The status of <{label}> as a reassociatable element is "at risk". If testing during the Candidate Recommendation phase
+    shows that there are not at least two interoperable independent currently shipping browsers
+    implementing <{label}> as a reassociatable element,
+    it will be removed from this category.
+  </p>
+
     Denotes elements that have a <{formelements/form}> content attribute, and a
     matching {{FormIDLAttribute/form}} IDL attribute, that allow authors to specify an
     explicit <a>form owner</a>.
@@ -1485,6 +1492,15 @@ part of the form.</p>
 
   The <{input}> element <a>represents</a> a typed data field, usually with a form
   control to allow the user to edit the data.
+
+  <p class="warning">
+  The <code>datetime</code> and <code>datetime-local</code> values of the <{form/type}> attribute are "at risk".
+  If testing during the Candidate Recommendation phase shows that there are not at least
+  two interoperable independent currently shipping browsers implementing each value,
+  that value will be removed from the HTML 5.1 specification.
+  </p>
+
+
 
   The <dfn element-attr for="input"><code>type</code></dfn> attribute controls the data type of the
   element. It is an <a>enumerated attribute</a>. The data type is used to select the control to
@@ -8896,6 +8912,18 @@ Daddy"&gt;&lt;/textarea&gt;
 
 <h4 id="the-keygen-element">The <dfn element><code>keygen</code></dfn> element</h4>
 
+  <div class="warning">
+
+  The <{keygen}> element is "at risk". If testing during the Candidate Recommendation phase
+  shows that there are not at least two interoperable independent currently shipping browsers implementing <{keygen}>,
+  it will be removed from the HTML 5.1 specification.
+
+  Of the two known implementations, one has announced an intention to deprecate the element.
+
+  Potential replacements for the functionality include the proposed Web Crypto API draft [[WebCryptoAPI]], as well as current early-stage work on hardware-based security such as that of the <a href="https://www.w3.org/community/hb-secure-services/">Hardware-Based Secure Services Community Group</a>.
+
+  </div>
+
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Flow content</a>.</dd>
@@ -10826,6 +10854,12 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
 <h5 id="input-modalities-the-inputmode-attribute">Input modalities: the <code>inputmode</code> attribute</h5>
 
+  <p class="Warning">
+  The <{input/inputmode}> attribute is "at risk". If testing during the Candidate Recommendation phase
+  shows that there are not at least two interoperable independent currently shipping browsers implementing it,
+  it will be removed from the HTML 5.1 specification.
+  </p>
+
   The <dfn element-attr for="input"><code>inputmode</code></dfn> content attribute is an
   <a>enumerated attribute</a> that specifies what kind of input mechanism would be most
   helpful for users entering content into the form control.
@@ -10979,6 +11013,13 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   </div>
 
 <h5 id="sec-autofill"><dfn lt="autofill|autofill mechanism">Autofill</dfn></h5>
+
+  <p class="warning">
+  The autofill mechanism is "at risk". If testing during the Candidate Recommendation phase
+  shows that there are not at least two interoperable independent currently shipping browsers
+  implementing a feature that is part of the autofill mechanism,
+  that feature will be removed from the HTML 5.1 specification.
+  </p>
 
 <h6 id="autofilling-form-controls-the-autocomplete-attribute">Autofilling form controls: the <code>autocomplete</code> attribute</h6>
 

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -195,6 +195,15 @@
 
 <h4 id="the-menu-element">The <dfn element><code>menu</code></dfn> element</h4>
 
+  <p class="warning">
+  The <{menu}> element, and each enumerated value of the <{menu/type}> attribute are "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of any value of the <{menu/type}> attribute on the <{menu}> element
+  that value will be removed from the HTML 5.1 Specification. If there are no values left, the <{menu}> element itself will be removed.
+  </p>
+
+
+
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Flow content</a>.</dd>
@@ -425,6 +434,13 @@
 
 <h4 id="the-menuitem-element">The <dfn element><code>menuitem</code></dfn> element</h4>
 
+  <p class="warning">
+  The <{menuitem}> element is "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of the <{menuitem}> element
+  it will be removed from the HTML 5.1 Specification.
+  </p>
+
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd>None.</dd>
@@ -634,6 +650,13 @@
   context menu. The value must be the <a>ID</a> of a <{menu}>
   element in the same <a>home subtree</a> whose <code>type</code>
   attribute is in the <a state for="menu">popup menu</a> state.
+
+  <p class="warning">
+  The <{global/contextmenu}> attribute is "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of the <{global/contextmenu}> attribute
+  it will be removed from the HTML 5.1 Specification.
+  </p>
 
   <p class="note">
     When a user right-clicks on an element with a <{global/contextmenu}> attribute, the user agent will first fire a <code>contextmenu</code> event at the element, and then, if that event is not
@@ -1060,6 +1083,14 @@
   </div>
 
 <h4 id="the-dialog-element">The <dfn element><code>dialog</code></dfn> element</h4>
+
+  <p class="warning">
+  The <{dialog}> element is "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of the <{dialog}> element
+  it will be removed from the HTML 5.1 Specification.
+  </p>
+
 
   <dl class="element">
     <dt><a>Categories</a>:</dt>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1,5 +1,5 @@
 <section>
-<!--
+<!-- Web App APIs - ASCII Art roolz
 ██      ██ ████████ ████████           ███    ████████  ████████           ███    ████████  ████  ██████
 ██  ██  ██ ██       ██     ██         ██ ██   ██     ██ ██     ██         ██ ██   ██     ██  ██  ██    ██
 ██  ██  ██ ██       ██     ██        ██   ██  ██     ██ ██     ██        ██   ██  ██     ██  ██  ██
@@ -3275,12 +3275,21 @@
   The <dfn lt="a registered handler"></dfn><dfn method for="NavigatorContentUtils"><code>registerProtocolHandler()</code></dfn> method
   allows Web sites to register themselves as possible handlers for particular schemes. For example,
   an online telephone messaging service could register itself as a handler of the <code>sms:</code> scheme, so that if the user clicks on such a link, he is given the
-  opportunity to use that Web site. Analogously, the <dfn method for="NavigatorContentUtils"><code>registerContentHandler()</code></dfn> method allows
+  opportunity to use that Web site.
+
+  <p class="warning">
+  The <code>registerContentHandler()</code> and associated methods are "at risk".
+  If testing during the Candidate Recommendation phase does not identify at least two interoperable implementations
+  in current shipping browsers of <code>registerContentHandler()</code> and associated methods
+  they will be removed from the HTML 5.1 Specification.
+  </p>
+
+  Analogously, the <dfn method for="NavigatorContentUtils"><code>registerContentHandler()</code></dfn> method allows
   Web sites to register themselves as possible handlers for content in a particular <a>MIME
   type</a>. For example, the same online telephone messaging service could register itself as a
   handler for <code>text/vcard</code> files, so that if the user has no native application capable
   of handling vCards, his Web browser can instead suggest he use that site to view contact
-  information stored on vCards that he opens. [[!RFC5724]] [[!RFC6350]]
+  information stored on vCards that he opens. [[RFC5724]] [[RFC6350]]
 
   <dl class="domintro">
 


### PR DESCRIPTION
Add warnings. Note they are framed as a positive requirement to find
implementation, which implies a positive requirement to make tests if
we don't want these things to disappear.
