### PR TITLE
Appcache is non-conforming.

### DIFF
--- a/sections/events.include
+++ b/sections/events.include
@@ -268,4 +268,6 @@
     </tbody>
   </table>
 
-  See also <a href="#media-elements-event-summary">media element events</a> and <a>drag-and-drop events</a>.
+  See also <a href="#media-elements-event-summary">media element events</a>,
+  <a href="#application-cache-api">application cache events</a>, and
+  <a>drag-and-drop events</a>.

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1,5 +1,5 @@
 <section>
-<!--
+<!-- Infrastructure - ASCII Art roolz
 ████ ██    ██ ████████ ████████     ███     ██████  ████████ ████████  ██     ██  ██████  ████████ ██     ██ ████████  ████████
  ██  ███   ██ ██       ██     ██   ██ ██   ██    ██    ██    ██     ██ ██     ██ ██    ██    ██    ██     ██ ██     ██ ██
  ██  ████  ██ ██       ██     ██  ██   ██  ██          ██    ██     ██ ██     ██ ██          ██    ██     ██ ██     ██ ██
@@ -3392,6 +3392,10 @@
       would be associated doesn't have an associated <a>browsing context</a>, then abort these
       steps.
   11. This is the <i>main step</i>.
+
+      If the resource is to be obtained from an <a>application cache</a>, then use the data from
+      that <a>application cache</a>, as if it had been obtained in the manner appropriate given
+      its <a for="url">URL</a>.
 
       If the resource is identified by an <a>absolute URL</a>, and the resource is to be obtained
       using an idempotent action (such as an HTTP GET <a>or equivalent</a>), and it is already

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -392,9 +392,14 @@
   from many disparate parts of the network.
 
   However, the IP address used for a user's requests is not the only mechanism by which a user's
-  requests could be related to each other. Cookies, for example, are designed specifically to enable
-  this, and are the basis of most of the Web's session features that enable you to log into a site
-  with which you have an account.
+  requests could be related to each other. 
+
+  Cookies, for example, are designed specifically to enable this, and are the basis of most of the
+  Web's session features that enable you to log into a site with which you have an account.
+
+  Application caches have similar implications with respect to privacy, for example if the
+  site can identify the user when providing the cache, it can store data in the cache that can be
+  used for cookie resurrection.
 
   There are other mechanisms that are more subtle. Certain characteristics of a user's system can be
   used to distinguish groups of users from each other; by collecting enough such information, an

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -207,6 +207,10 @@
   : <dfn element-attr for="html"><code>version</code></dfn> on <{html}> elements
   :: Unnecessary. Omit it altogether.
 
+  : <dfn element-attr for="html"><code>manifest</code></dfn> on <{html}> elements
+  :: The use of application caches is not recommended. Alternative mechanisms to support offline applications
+       include the use of [[webstorage]], [[IndexedDB]], and [[SERVICE-WORKERS]].
+
   : <dfn element-attr for="input"><code>ismap</code></dfn> on <{input}> elements
   :: Unnecessary. Omit it altogether. All <{input}> elements with a <code>type</code> attribute in
       the <a element-state for="input">image button</a> state are processed as server-side image
@@ -849,6 +853,1532 @@
 
   The <dfn attribute for="HTMLFrameElement"><code>marginWidth</code></dfn> IDL attribute of the
   <{frame}> element must <a>reflect</a> the element's <code>marginwidth</code> content attribute.
+
+
+<h4 id="application-caches">Application caches</h4>
+
+  An <dfn lt="application cache manifest|application cache">application cache</dfn> is a set of cached resources consisting of:
+
+  <ul>
+
+    <li>
+
+    One or more resources (including their out-of-band metadata, such as HTTP headers, if any),
+    identified by URLs, each falling into one (or more) of the following categories:
+
+    <dl>
+
+      <dt><dfn lt="master|master entries">Master entries</dfn>
+
+      <dd><p class="note">
+  These are documents that were added to the cache because a <a>browsing
+      context</a> was <a>navigated</a> to that document and the document
+      indicated that this was its cache, using the <code>manifest</code>
+      attribute.
+  </p>
+
+      <dt><dfn lt="the manifest|manifest">The manifest</dfn>
+
+      <dd><p class="note">
+  This is the resource corresponding to the URL that was given in a master
+      entry's <{html}> element's <code>manifest</code> attribute.
+      The manifest is fetched and processed during the <a>application cache download
+      process</a>. All the <a>master entries</a> have the
+      <a>same origin</a> as the manifest.
+  </p>
+
+      <dt><dfn lt="an explicit entry|explicit entries">Explicit entries</dfn>
+
+      <dd><p class="note">
+  These are the resources that were listed in the cache's <a>manifest</a> in an <a>explicit section</a>.
+  </p>
+
+      <dt><dfn lt="a fallback entry|fallback entries">Fallback entries</dfn>
+
+      <dd><p class="note">
+  These are the resources that were listed in the cache's <a>manifest</a> in a <a>fallback section</a>.
+  </p>
+
+    </dl>
+
+    <a>Explicit entries</a> and <a>Fallback entries</a> can be marked as <dfn>foreign</dfn>, which means that they have a <code>manifest</code> attribute but that it doesn't point at this cache's
+    <a>manifest</a>.
+
+    <p class="note">
+  A URL in the list can be flagged with multiple different types, and thus an
+    entry can end up being categorized as multiple entries. For example, an entry can be a manifest
+    entry and an explicit entry at the same time, if the manifest is listed within the manifest.
+  </p>
+
+    </li>
+
+    <li>
+
+    Zero or more <dfn>fallback namespaces</dfn>, each of
+    which is mapped to a <a>fallback entry</a>.
+
+    <p class="note">
+  These are URLs used as <a>prefix
+    match patterns</a> for resources that are to be fetched from the network if possible, or to
+    be replaced by the corresponding <a>fallback entry</a>
+    if not. Each namespace URL has the <a>same origin</a> as <a>the manifest</a>.
+  </p>
+
+    </li>
+
+    <li>
+
+    Zero or more URLs that form the <dfn>online
+    safelist namespaces</dfn>.
+
+    <p class="note">
+  These are used as prefix match patterns, and declare URLs for which the user
+    agent will ignore the application cache, instead fetching them normally (i.e., from the network
+    or local HTTP cache as appropriate).
+  </p>
+
+    </li>
+
+    <li>
+
+    An <dfn>online safelist wildcard
+    flag</dfn>, which is either <i>open</i> or <i>blocking</i>.
+
+    <p class="note">
+  The <i>open</i> state indicates that any URL not listed as cached is to
+    be implicitly treated as being in the <a>online
+    safelist namespaces</a>; the <i>blocking</i> state indicates that URLs not listed
+    explicitly in the manifest are to be treated as unavailable.
+  </p>
+
+    </li>
+
+    <li>
+
+    A <dfn lt="application cache mode|cache mode flag">cache mode flag</dfn>, which is either in the <dfn><i>fast</i></dfn> state or the <dfn><i>prefer-online</i></dfn> state.
+
+    </li>
+
+  </ul>
+
+  Each <a>application cache</a> has a <dfn>completeness flag</dfn>, which is either <i>complete</i> or
+  <i>incomplete</i>.
+
+  <hr />
+
+  An <dfn>application cache group</dfn> is a group of <a>application
+  caches</a>, identified by the <a>absolute URL</a> of a resource <a>manifest</a> which is used to populate the caches in the
+  group.
+
+  An <a>application cache</a> is <dfn lt="newest|newer">newer</dfn> than
+  another if it was created after the other (in other words, <a>application caches</a> in an <a>application cache group</a> have a chronological
+  order).
+
+  Only the newest <a>application cache</a> in an <a>application cache group</a> can
+  have its <a>completeness flag</a> set to
+  <i>incomplete</i>; the others are always all <i>complete</i>.
+
+  Each <a>application cache group</a> has an <dfn>update status</dfn>, which is one of the following: <i>idle</i>, <i>checking</i>, <i>downloading</i>.
+
+  A <dfn>relevant application cache</dfn> is an <a>application cache</a> that is the <a>newest</a> in its <a>group</a> to be <i>complete</i>.
+
+  Each <a>application cache group</a> has a <dfn>list of pending master entries</dfn>. Each entry in this
+  list consists of a resource and a corresponding {{Document}} object. It is used during
+  the <a>application cache download process</a> to ensure that new master entries are cached
+  even if the <a>application cache download process</a> was already running for their
+  <a>application cache group</a> when they were loaded.
+
+  An <a>application cache group</a> can be marked as <dfn for="ApplicationCache">obsolete</dfn>, meaning that it must be ignored when looking at
+  what <a>application cache groups</a> exist.
+
+  <hr />
+
+  A <dfn>cache host</dfn> is a {{Document}} or a <code>SharedWorkerGlobalScope</code>
+  object. A <a>cache host</a> can be associated with an <a>application cache</a>.
+
+  [[!WEBWORKERS]]
+
+  A {{Document}} initially is not associated with an <a>application cache</a>, but
+  can become associated with one early during the page load process, when steps <a>in the parser</a> and in the <a>navigation</a>
+  sections cause <a>cache selection</a> to occur.
+
+  A <code>SharedWorkerGlobalScope</code> can be associated with an <a>application cache</a>
+  when it is created.
+
+  [[!WEBWORKERS]]
+
+  Each <a>cache host</a> has an associated <code>ApplicationCache</code> object.
+
+  <hr />
+
+  Multiple <a>application caches</a> in different <a>application cache groups</a> can contain the same resource,
+  e.g., if the manifests all reference that resource. If the user agent is to <dfn lt="most appropriate application cache|select an application cache">select an application cache</dfn> from a list of <a>relevant application caches</a> that contain a resource, the
+  user agent must use the application cache that the user most likely wants to see the resource
+  from, taking into account the following:
+
+  <ul>
+
+    <li>which application cache was most recently updated,
+
+    <li>which application cache was being used to display the resource from which the user decided to
+    look at the new resource, and
+
+    <li>which application cache the user prefers.
+
+  </ul>
+
+  <hr />
+
+  A URL <dfn lt="matches the fallback namespace|matches a fallback namespace|prefix match patterns">matches a fallback namespace</dfn> if
+  there exists a <a>relevant application cache</a> whose <a>manifest</a>'s URL has the <a>same origin</a> as the
+  URL in question, and that has a <a>fallback
+  namespace</a> that is a <a>prefix match</a> for the URL being examined. If multiple
+  fallback namespaces match the same URL, the longest one is the one that matches. A URL looking for
+  a fallback namespace can match more than one application cache at a time, but only matches one
+  namespace in each cache.
+
+
+<h6 id="parsing-cache-manifests">Parsing cache manifests</h6>
+
+  When a user agent is to <dfn lt="rules for parsing manifests|parse a manifest">parse a manifest</dfn>, it means that the user agent must run the
+  following steps:
+
+  <ol>
+
+    <li>
+
+    <a>UTF-8 decode</a> the byte stream corresponding with the manifest to be parsed.
+
+    <p class="note">
+  The <a>UTF-8 decode</a> algorithm strips a leading BOM, if any.
+  </p>
+
+    </li>
+
+    <li>Let <var>base URL</var> be the <a>absolute URL</a> representing the
+    manifest.</li>
+
+    <li>Apply the <a>URL parser</a> to <var>base URL</var>, and let <var>manifest path</var>
+    be the <a>path</a> component thus obtained.</li>
+
+    <li>Remove all the characters in <var>manifest path</var> after the last U+002F SOLIDUS
+    character (/), if any. (The first character and the last character in <var>manifest path</var>
+    after this step will both be slashes, the URL path separator character.)</li>
+
+    <li>Apply the <a>URL parser</a> steps to the <var>base URL</var>, so that the
+    components from its <a>URL record</a> can be used by the subsequent steps of this
+    algorithm.</li>
+
+    <li>Let <var>explicit URLs</var> be an initially empty list of <a>absolute URLs</a> for <a>explicit
+    entries</a>.</li>
+
+    <li>Let <var>fallback URLs</var> be an initially empty mapping of <a>fallback namespaces</a> to <a>absolute URLs</a> for <a>fallback
+    entries</a>.</li>
+
+    <li>Let <var>online safelist namespaces</var> be an initially empty list of <a>absolute URLs</a> for an <a>online safelist</a>.</li>
+
+    <li>Let <var>online safelist wildcard flag</var> be <i>blocking</i>. </li>
+
+    <li>Let <var>cache mode flag</var> be <i>fast</i>. </li>
+
+    <li>Let <var>input</var> be the decoded text of the manifest's byte stream.</li>
+
+    <li>Let <var>position</var> be a pointer into <var>input</var>, initially
+    pointing at the first character.</li>
+
+    <li>If the characters starting from <var>position</var> are "CACHE", followed by a
+    U+0020 SPACE character, followed by "MANIFEST", then advance <var>position</var> to the
+    next character after those. Otherwise, this isn't a cache manifest; abort this algorithm with a
+    failure while checking for the magic signature.</li>
+
+    <li>If the character at <var>position</var> is neither a U+0020 SPACE character, a
+    U+0009 CHARACTER TABULATION (tab) character, U+000A LINE FEED (LF) character, nor a U+000D
+    CARRIAGE RETURN (CR) character, then this isn't a cache manifest; abort this algorithm with a
+    failure while checking for the magic signature.</li>
+
+    <li>This is a cache manifest. The algorithm cannot fail beyond
+    this point (though bogus lines can get ignored).</li>
+
+    <li><a>Collect a sequence of characters</a> that are <em>not</em> U+000A LINE FEED (LF)
+    or U+000D CARRIAGE RETURN (CR) characters, and ignore those characters. (Extra text on the first
+    line, after the signature, is ignored.)</li>
+
+    <li>Let <var>mode</var> be "explicit".</li>
+
+    <li><var>Start of line</var>: If <var>position</var> is past the end of <var>input</var>, then jump to the last step. Otherwise, <a>collect a sequence of
+    characters</a> that are U+000A LINE FEED (LF), U+000D CARRIAGE RETURN (CR), U+0020 SPACE, or
+    U+0009 CHARACTER TABULATION (tab) characters.</li>
+
+    <li>Now, <a>collect a sequence of characters</a> that are <em>not</em> U+000A LINE FEED
+    (LF) or U+000D CARRIAGE RETURN (CR) characters, and let the result be <var>line</var>.</li>
+
+    <li>Drop any trailing U+0020 SPACE and U+0009 CHARACTER TABULATION (tab) characters at the end
+    of <var>line</var>.</li>
+
+    <li>If <var>line</var> is the empty string, then jump back to the step labeled <i>start
+    of line</i>.</li>
+
+    <li>If the first character in <var>line</var> is a U+0023 NUMBER SIGN character (#),
+    then jump back to the step labeled <var>Start of line</var>.</li>
+
+    <li>If <var>line</var> equals "CACHE:" (the word "CACHE" followed by a U+003A COLON
+    character (:)), then set <var>mode</var> to "explicit" and jump back to the step labeled
+    <var>Start of line</var>.</li>
+
+    <li>If <var>line</var> equals "FALLBACK:" (the word "FALLBACK" followed by a U+003A
+    COLON character (:)), then set <var>mode</var> to "fallback" and jump back to the step
+    labeled <var>Start of line</var>.</li>
+
+    <li>If <var>line</var> equals "NETWORK:" (the word "NETWORK" followed by a U+003A
+    COLON character (:)), then set <var>mode</var> to "online safelist" and jump back to
+    the step labeled <var>Start of line</var>.</li>
+
+    <li>If <var>line</var> equals "SETTINGS:" (the word "SETTINGS" followed by a U+003A
+    COLON character (:)), then set <var>mode</var> to "settings" and jump back to the step
+    labeled <var>Start of line</var>.</li>
+
+    <li>If <var>line</var> ends with a U+003A COLON character (:), then set <var>mode</var> to "unknown" and jump back to the step labeled <var>Start of line</var>.</li>
+
+    <li>This is either a data line or it is syntactically incorrect.</li>
+
+    <li>Let <var>position</var> be a pointer into <var>line</var>, initially
+    pointing at the start of the string.</li>
+
+    <li>Let <var>tokens</var> be a list of strings, initially empty.</li>
+
+    <li>
+
+    While <var>position</var> doesn't point past the end of <var>line</var>:
+
+    <ol>
+
+      <li>Let <var>current token</var> be an empty string.</li>
+
+      <li>While <var>position</var> doesn't point past the end of <var>line</var> and the character at <var>position</var> is neither a U+0020 SPACE
+      nor a U+0009 CHARACTER TABULATION (tab) character, add the character at <var>position</var> to <var>current token</var> and advance <var>position</var> to the next character in <var>input</var>.</li>
+
+      <li>Add <var>current token</var> to the <var>tokens</var> list.</li>
+
+      <li>While <var>position</var> doesn't point past the end of <var>line</var> and the character at <var>position</var> is either a U+0020 SPACE
+      or a U+0009 CHARACTER TABULATION (tab) character, advance <var>position</var> to the
+      next character in <var>input</var>.</li>
+
+    </ol>
+
+    </li>
+
+    <li>
+
+    Process <var>tokens</var> as follows:
+
+    <dl class="switch">
+
+      <dt>If <var>mode</var> is "explicit"</dt>
+
+      <dd>
+
+      Let <var>urlRecord</var> be the result of <a lt="url parser">parsing</a> the first item in
+      <var>tokens</var>, with <var>base URL</var>; ignore the rest.
+
+      If <var>urlRecord</var> is failure, then jump back to the step labeled
+      <var>Start of line</var>.
+
+      If <var>urlRecord</var> has a different <a for="url">scheme</a> component than
+      <var>base URL</var> (the manifest's URL), then jump back to the step labeled
+      <var>Start of line</var>.
+
+      Let <var>new URL</var> be the result of applying the <a>URL serializer</a> algorithm to
+      <var>urlRecord</var>, with the <var>exclude fragment flag</var> set.
+
+      Add <var>new URL</var> to the <var>explicit URLs</var>.
+
+      </dd>
+
+      <dt>If <var>mode</var> is "fallback"</dt>
+
+      <dd>Let <var>part one</var> be the first token in <var>tokens</var>, and let
+      <var>part two</var> be the second token in <var>tokens</var>.
+
+      Let <var>urlRecordOne</var> be the result of <a lt="url parser">parsing</a>
+      <var>part one</var> with <var>base URL</var>.
+
+      Let <var>urlRecordTwo</var> be the result of <a lt="url parser">parsing</a>
+      <var>part two</var> with <var>base URL</var>.
+
+      If either <var>urlRecordOne</var> or <var>urlRecordTwo</var> is failure, then jump back to the
+      step labeled <var>Start of line</var>.
+
+      If the <a for="url">origin</a> of either <var>urlRecordOne</var> or <var>urlRecordTwo</var> is
+      not <a>same origin</a> with the manifest's URL <a for="url">origin</a>, then jump back to the
+      step labeled <var>Start of line</var>.
+
+      Let <var>part one path</var> be the <a>path</a> component of <var>urlRecordOne</var>.
+
+      If <var>manifest path</var> is not a <a>prefix match</a> for <var>part one path</var>, then
+      jump back to the step labeled <var>Start of line</var>.
+
+      Let <var>part one</var> be the result of applying the <a>URL serializer</a> algorithm to
+      <var>urlRecordOne</var>, with the <var>exclude fragment flag</var> set.
+
+      Let <var>part two</var> be the result of applying the <a>URL serializer</a> algorithm to
+      <var>urlRecordTwo</var>, with the <var>exclude fragment flag</var> set.
+
+      If <var>part one</var> is already in the <var>fallback URLs</var> mapping as a
+      <a>fallback namespace</a>, then jump back to the step labeled <var>Start of line</var>.
+
+      Otherwise, add <var>part one</var> to the <var>fallback URLs</var> mapping as a
+      <a>fallback namespace</a>, mapped to <var>part two</var> as the <a>fallback entry</a>.
+
+      </dd>
+
+      <dt>If <var>mode</var> is "online safelist"</dt>
+
+      <dd>
+
+      If the first item in <var>tokens</var> is a U+002A ASTERISK character (*), then
+      set <var>online safelist wildcard flag</var> to <i>open</i> and jump back
+      to the step labeled <var>Start of line</var>.
+
+      Otherwise, let <var>urlRecord</var> be the result of <a>parsing</a> the first item in
+      <var>tokens</var> with <var>base URL</var>.
+
+      If <var>urlRecord</var> is failure, then jump back to the step labeled <var>Start of line</var>.
+
+      If <var>urlRecord</var> has a different <a for="url">scheme</a> component than <var>base URL</var> (the
+      manifest's URL), then jump back to the step labeled <var>Start of line</var>.
+
+      Let <var>new URL</var> be the result of applying the <a>URL serializer</a> algorithm to
+      <var>urlRecord</var>, with the <var>exclude fragment flag</var> set.
+
+      Add <var>new URL</var> to the <var>online safelist namespaces</var>.
+
+      </dd>
+
+      <dt>If <var>mode</var> is "settings"</dt>
+
+      <dd>
+
+      If <var>tokens</var> contains a single token, and that token is a
+      <a>case-sensitive</a> match for the string "<code>prefer-online</code>", then
+      set <var>cache mode flag</var> to <i>prefer-online</i> and jump back to the
+      step labeled <var>Start of line</var>.
+
+      Otherwise, the line is an unsupported setting: do nothing; the line is ignored.
+
+      </dd>
+
+      <dt>If <var>mode</var> is "unknown"</dt>
+
+      <dd>
+
+      Do nothing. The line is ignored.
+
+      </dd>
+
+    </dl>
+
+    </li>
+
+    <li>Jump back to the step labeled <var>Start of line</var>. (That step jumps to the next, and last,
+    step when the end of the file is reached.)</li>
+
+    <li>Return the <var>explicit URLs</var> list, the <var>fallback URLs</var>
+    mapping, the <var>online safelist namespaces</var>, the <var>online safelist
+    wildcard flag</var>, and the <var>cache mode flag</var>.</li>
+
+  </ol>
+
+<h5 id="downloading-or-updating-an-application-cache">Downloading or updating an application cache</h5>
+
+  When the user agent is required (by other parts of this specification) to start the
+  <dfn>application cache download process</dfn> for an <a>absolute URL</a> purported to
+  identify a <a>manifest</a>, or for an <a>application
+  cache group</a>, potentially given a particular <a>cache host</a>, and potentially given
+  a <a>master</a> resource, the user agent must run the steps
+  below. These steps are always run <a>in parallel</a> with the <a>event loop</a>
+  <a>tasks</a>.
+
+  Some of these steps have requirements that only apply if the user agent <dfn>shows caching
+  progress</dfn>. Support for this is optional. Certain events
+  fired during the <a>application cache download process</a> allow the script to override the
+  display of such an interface. (Such events are delayed until after the <code>load</code> event has fired.)
+
+  User agents are encouraged not to show
+  prominent update progress notifications for applications that cancel the relevant events.
+
+  The <a>application cache download process</a> steps are as follows:
+
+  <ol>
+
+    <li>Optionally, wait until the permission to start the <a>application cache download
+    process</a> has been obtained from the user and until the user agent is confident that the
+    network is available. This could include doing nothing until the user explicitly opts-in to
+    caching the site, or could involve prompting the user for permission. The algorithm might never
+    get past this point. (This step is particularly intended to be used by user agents running on
+    severely space-constrained devices or in highly privacy-sensitive environments).</li>
+
+    <li>
+
+    Atomically, so as to avoid race conditions, perform the following substeps:
+
+    <ol>
+
+      <li>
+
+      Pick the appropriate substeps:
+
+      <dl class="switch">
+
+        <dt>If these steps were invoked with an <a>absolute URL</a> purported to identify a
+        <a>manifest</a></dt>
+
+        <dd>
+
+        Let <var>manifest URL</var> be that <a>absolute URL</a>.
+
+        If there is no <a>application cache group</a> identified by <var>manifest
+        URL</var>, then create a new <a>application cache group</a> identified by <var>manifest URL</var>. Initially, it has no <a>application caches</a>. One will be created later in this algorithm.
+
+        </dd>
+
+        <dt>If these steps were invoked with an <a>application cache group</a></dt>
+
+        <dd>
+
+        Let <var>manifest URL</var> be the <a>absolute URL</a> of the <a>manifest</a> used to identify the <a>application
+        cache group</a> to be updated.
+
+        If that <a>application cache group</a> is <a>obsolete</a>, then abort this instance of the
+        <a>application cache download process</a>. This can happen if another instance of this
+        algorithm found the manifest to be 404 or 410 while this algorithm was waiting in the first
+        step above.
+
+        </dd>
+
+      </dl>
+
+      </li>
+
+      <li>Let <var>cache group</var> be the <a>application cache group</a>
+      identified by <var>manifest URL</var>.</li>
+
+      <li>If these steps were invoked with a <a>master</a>
+      resource, then add the resource, along with the resource's {{Document}}, to <var>cache group</var>'s <a>list of pending
+      master entries</a>.</li>
+
+      <li>If these steps were invoked with a <a>cache host</a>, and the <a>status</a> of <var>cache group</var> is
+      <i>checking</i> or <i>downloading</i>, then <a>queue a post-load task</a> to <a>fire a
+      simple event</a> named <code>checking</code> that is
+      cancelable at the <code>ApplicationCache</code> singleton of that <a>cache host</a>. The
+      default action of this event must be, if the user agent <a>shows caching progress</a>,
+      the display of some sort of user interface indicating to the user that the user agent is
+      checking to see if it can download the application.</li>
+
+      <li>If these steps were invoked with a <a>cache host</a>, and the <a>status</a> of <var>cache group</var> is
+      <i>downloading</i>, then also <a>queue a post-load task</a> to <a>fire a simple
+      event</a> named <code>downloading</code> that is
+      cancelable at the <code>ApplicationCache</code> singleton of that <a>cache host</a>. The
+      default action of this event must be, if the user agent <a>shows caching progress</a>,
+      the display of some sort of user interface indicating to the user the application is being
+      downloaded.</li>
+
+      <li>If the <a>status</a> of the <var>cache
+      group</var> is either <i>checking</i> or <i>downloading</i>, then abort this instance of the
+      <a>application cache download process</a>, as an update is already in progress.</li>
+
+      <li>Set the <a>status</a> of <var>cache
+      group</var> to <i>checking</i>.
+
+      <li>For each <a>cache host</a> associated with an <a>application cache</a> in
+      <var>cache group</var>, <a>queue a post-load task</a> to <a>fire a simple
+      event</a> that is cancelable named <code>checking</code> at
+      the <code>ApplicationCache</code> singleton of the <a>cache host</a>. The default action
+      of these events must be, if the user agent <a>shows caching progress</a>, the display of
+      some sort of user interface indicating to the user that the user agent is checking for the
+      availability of updates.</li>
+
+    </ol>
+
+    <p class="note">
+  The remainder of the steps run <a>in parallel</a>.
+  </p>
+
+    If <var>cache group</var> already has an <a>application cache</a> in it, then
+    this is an <dfn>upgrade attempt</dfn>. Otherwise, this is a
+    <dfn>cache attempt</dfn>.
+
+    </li>
+
+    <li>If this is a <a>cache attempt</a>, then this
+    algorithm was invoked with a <a>cache host</a>; <a>queue a post-load task</a> to
+    <a>fire a simple event</a> named <code>checking</code> that
+    is cancelable at the <code>ApplicationCache</code> singleton of that <a>cache host</a>. The
+    default action of this event must be, if the user agent <a>shows caching progress</a>, the
+    display of some sort of user interface indicating to the user that the user agent is checking for
+    the availability of updates.</li>
+
+    <li>Let <var>request</var> be a new <a>request</a> whose
+    <a for="url">URL</a> is <var>manifest URL</var>, <a>client</a> is null, <a>destination</a> is "<code>subresource</code>",
+    <a>omit-<code>Origin</code>-header flag</a> is set, <a>referrer</a> is "<code>no-referrer</code>",
+    <a>synchronous flag</a> is set, <a>credentials
+    mode</a> is "<code>include</code>", and whose <a>use-URL-credentials
+    flag</a> is set.</li>
+
+    <li>
+
+    <i>Fetching the manifest</i>: Let <var>manifest</var> be the result of <a>fetching</a> <var>request</var>. HTTP caching semantics should be
+    honored for this request.
+
+    Parse <var>manifest</var>'s <a for="response">body</a> according to the
+    <a>rules for parsing manifests</a>, obtaining a list of
+    <a>explicit entries</a>, <a>fallback entries</a> and the <a>fallback namespaces</a> that map to them, entries for
+    the <a>online safelist</a>, and values for the
+    <a>online safelist wildcard flag</a>
+    and the <a>cache mode flag</a>.
+
+    <p class="note">
+  The <a>MIME type</a> of the resource is ignored &mdash; it is assumed to
+    be <code>text/cache-manifest</code>. In the future, if new manifest formats are supported, the
+    different types will probably be distinguished on the basis of the file signatures (for the
+    current format, that is the "<code>CACHE&nbsp;MANIFEST</code>" string at the top of the
+    file).
+  </p>
+
+    </li>
+
+    <li>
+
+    If <i>fetching the manifest</i> fails due to a 404 or 410 response status, then run these
+    substeps:
+
+    <ol>
+
+      <li>Mark <var>cache group</var> as <a>obsolete</a>. This <var>cache group</var> no
+      longer exists for any purpose other than the processing of {{Document}} objects
+      already associated with an <a>application cache</a> in the <var>cache
+      group</var>.</li>
+
+      <li>Let <var>task list</var> be an empty list of <a>tasks</a>.
+
+      <li>For each <a>cache host</a> associated with an <a>application cache</a> in
+      <var>cache group</var>, create a <a>task</a> to <a>fire
+      a simple event</a> named <code>obsolete</code> that is
+      cancelable at the <code>ApplicationCache</code> singleton of the <a>cache host</a>, and
+      append it to <var>task list</var>. The default action of these events must be, if the
+      user agent <a>shows caching progress</a>, the display of some sort of user interface
+      indicating to the user that the application is no longer available for offline use.</li>
+
+      <li>For each entry in <var>cache group</var>'s <a>list of pending master entries</a>, create a <a>task</a> to <a>fire a simple event</a> that is cancelable named
+      <code>error</code> (not <code>obsolete</code>!) at the <code>ApplicationCache</code>
+      singleton of the {{Document}} for this entry, if there still is one, and append it to
+      <var>task list</var>. The default action of this event must be, if the user agent
+      <a>shows caching progress</a>, the display of some sort of user interface indicating to
+      the user that the user agent failed to save the application for offline use.</li>
+
+      <li>If <var>cache group</var> has an <a>application cache</a> whose <a>completeness flag</a> is <i>incomplete</i>, then
+      discard that <a>application cache</a>.
+
+      <li>If appropriate, remove any user interface indicating that an update for this cache is in
+      progress.</li>
+
+      <li>Let the <a>status</a> of <var>cache
+      group</var> be <i>idle</i>.</li>
+
+      <li>For each <a>task</a> in <var>task list</var>, <a>queue that task as a post-load task</a>.</li>
+
+      <li>Abort the <a>application cache download process</a>.</li>
+
+    </ol>
+
+    </li>
+
+    <li>
+
+    Otherwise, if <i>fetching the manifest</i> fails in some other way (e.g., the server returns
+    another 4xx or 5xx response, or there is a DNS error, or the connection times out, or the user
+    cancels the download, or the parser for manifests fails when checking the magic signature), or
+    if the server returned a redirect, then run the <a>cache failure steps</a>. [[!HTTP]]
+
+    </li>
+
+    <li>
+
+    If this is an <a>upgrade attempt</a> and the newly
+    downloaded <var>manifest</var> is byte-for-byte identical to the manifest found in the
+    <a>newest</a> <a>application cache</a> in <var>cache
+    group</var>, or the response status is <code>304</code>, then run these substeps:
+
+    <ol>
+
+      <li>Let <var>cache</var> be the <a>newest</a>
+      <a>application cache</a> in <var>cache group</var>.</li>
+
+      <li>Let <var>task list</var> be an empty list of <a>tasks</a>.
+
+      <li>
+
+      For each entry in <var>cache group</var>'s <a>list of pending master entries</a>, wait for the
+      resource for this entry to have either completely downloaded or failed.
+
+      If the download failed (e.g., the server returns a 4xx or 5xx response, or there is a DNS
+      error, the connection times out, or the user cancels the download), or if the resource is
+      labeled with the "no-store" cache directive, then create a <a>task</a> to <a>fire a simple event</a> that is cancelable named
+      <code>error</code> at the <code>ApplicationCache</code>
+      singleton of the {{Document}} for this entry, if there still is one, and append it to
+      <var>task list</var>. The default action of this event must be, if the user agent <a>shows
+      caching progress</a>, the display of some sort of user interface indicating to the user
+      that the user agent failed to save the application for offline use.
+
+      Otherwise, associate the {{Document}} for this entry with <var>cache</var>; store the resource for this entry in <var>cache</var>, if it
+      isn't already there, and categorize its entry as a <a>master entry</a>. If applying the <a>URL parser</a>
+      algorithm to the resource's <a for="url">URL</a> results in a <a>resulting URL record</a> that has a
+      non-null <a for="url">fragment</a> component, the <a for="url">URL</a>
+      used for the entry in <var>cache</var> must instead be the <a>absolute URL</a>
+      obtained from applying the <a>URL serializer</a>
+      algorithm to the <a>resulting URL record</a> with the <var>exclude fragment flag</var> set
+      (application caches never include fragment identifiers).
+
+      </li>
+
+      <li>For each <a>cache host</a> associated with an <a>application cache</a> in
+      <var>cache group</var>, create a <a>task</a> to <a>fire
+      a simple event</a> that is cancelable named <code>noupdate</code> at the <code>ApplicationCache</code> singleton
+      of the <a>cache host</a>, and append it to <var>task list</var>. The default
+      action of these events must be, if the user agent <a>shows caching progress</a>, the
+      display of some sort of user interface indicating to the user that the application is up to
+      date.</li>
+
+      <li>Empty <var>cache group</var>'s <a>list of pending master entries</a>.</li>
+
+      <li>If appropriate, remove any user interface indicating that an update for this cache is in
+      progress.</li>
+
+      <li>Let the <a>status</a> of <var>cache
+      group</var> be <i>idle</i>.</li>
+
+      <li>For each <a>task</a> in <var>task list</var>, <a>queue that task as a post-load task</a>.</li>
+
+      <li>Abort the <a>application cache download process</a>.</li>
+
+    </ol>
+
+    </li>
+
+    <li>Let <var>new cache</var> be a newly created <a>application cache</a> in
+    <var>cache group</var>. Set its <a>completeness
+    flag</a> to <i>incomplete</i>.</li>
+
+    <li>For each entry in <var>cache group</var>'s <a>list of pending master entries</a>, associate the
+    {{Document}} for this entry with <var>new cache</var>.</li>
+
+    <li>Set the <a>status</a> of <var>cache
+    group</var> to <i>downloading</i>.</li>
+
+    <li>For each <a>cache host</a> associated with an <a>application cache</a> in <var>cache group</var>, <a>queue a post-load task</a> to <a>fire a simple
+    event</a> that is cancelable named <code>downloading</code>
+    at the <code>ApplicationCache</code> singleton of the <a>cache host</a>. The default action
+    of these events must be, if the user agent <a>shows caching progress</a>, the display of
+    some sort of user interface indicating to the user that a new version is being
+    downloaded.</li>
+
+    <li>Let <var>file list</var> be an empty list of URLs with flags.</li>
+
+    <li>Add all the URLs in the list of <a>explicit
+    entries</a> obtained by parsing <var>manifest</var> to <var>file list</var>,
+    each flagged with "explicit entry".</li>
+
+    <li>Add all the URLs in the list of <a>fallback
+    entries</a> obtained by parsing <var>manifest</var> to <var>file list</var>,
+    each flagged with "fallback entry".</li>
+
+    <li>If this is an <a>upgrade attempt</a>, then add all
+    the URLs of <a>master entries</a> in the <a>newest</a> <a>application cache</a> in <var>cache group</var> whose <a>completeness
+    flag</a> is <i>complete</i> to <var>file list</var>, each flagged with "master
+    entry".</li>
+
+    <li>If any URL is in <var>file list</var> more than once, then merge the entries into
+    one entry for that URL, that entry having all the flags that the original entries had.</li>
+
+    <li>
+
+    For each URL in <var>file list</var>, run the following steps. These steps may be
+    run in parallel for two or more of the URLs at a time. If, while running these steps, the
+    <code>ApplicationCache</code> object's <code>abort()</code> method
+    <a>sends a signal</a> to this instance of the <a>application
+    cache download process</a> algorithm, then run the <a>cache failure steps</a>
+    instead.
+
+    <ol>
+
+      <li>
+
+      If the resource URL being processed was flagged as neither an "explicit entry" nor or a
+      "fallback entry", then the user agent may skip this URL.
+
+      <p class="note">
+  This is intended to allow user agents to expire resources not listed in the
+      manifest from the cache. Generally, implementors are urged to use an approach that expires
+      lesser-used resources first.
+  </p>
+
+      </li>
+
+      <li>For each <a>cache host</a> associated with an <a>application cache</a> in
+      <var>cache group</var>, <a>queue a progress post-load task</a> to <a>fire</a> a <a>trusted</a>
+      event with the name <code>progress</code>, which does not
+      bubble, which is cancelable, and which uses the <code>ProgressEvent</code> interface, at the
+      <code>ApplicationCache</code> singleton of the <a>cache host</a>. The <code>lengthComputable</code> attribute must be set to
+      true, the <code>total</code> attribute must be set to the
+      number of files in <var>file list</var>, and the <code>loaded</code> attribute must be set to the number of files in
+      <var>file list</var> that have been either downloaded or skipped so far. The default
+      action of these events must be, if the user agent <a>shows caching progress</a>, the
+      display of some sort of user interface indicating to the user that a file is being downloaded
+      in preparation for updating the application. [[!XHR]]</li>
+
+      <li>Let <var>request</var> be a new <a>request</a> whose
+      <a for="url">URL</a> is URL, <a>client</a> is null, <a>destination</a> is
+      "<code>subresource</code>", <a for="request">origin</a> is
+      <var>manifest URL</var>'s <a for="concept">origin</a>, <a>referrer</a> is
+      "<code>no-referrer</code>", <a>synchronous flag</a> is set, <a>credentials mode</a> is
+      "<code>include</code>", <a>use-URL-credentials flag</a> is set, and <a>redirect mode</a> is
+      "<code>manual</code>".</li>
+
+      <li><a>Fetch</a> <var>request</var>. If this is an
+      <a>upgrade attempt</a>, then use the <a>newest</a> <a>application cache</a> in <var>cache
+      group</var> as an HTTP cache, and honor HTTP caching semantics (such as expiration, ETags, and
+      so forth) with respect to that cache. User agents may also have other caches in place that are
+      also honored.</li>
+
+      <li>
+
+      If the previous step fails (e.g., the server returns a 4xx or 5xx response, or there is a
+      DNS error, or the connection times out, or the user cancels the download), or if the server
+      returned a redirect, or if the resource is labeled with the "no-store" cache directive, then
+      run the first appropriate step from the following list: [[!HTTP]]
+
+      <dl class="switch">
+
+        <dt>If the URL being processed was flagged as an "explicit entry" or a "fallback entry"</dt>
+
+        <dd>
+
+        If these steps are being run in parallel for any other URLs in <var>file
+        list</var>, then abort these steps for those other URLs. Run the <a>cache failure
+        steps</a>.
+
+        <p class="note">
+  Redirects are fatal because they are either indicative of a network problem
+        (e.g., a captive portal); or would allow resources to be added to the cache under URLs that
+        differ from any URL that the networking model will allow access to, leaving orphan entries;
+        or would allow resources to be stored under URLs different than their true URLs. All of
+        these situations are bad.
+  </p>
+
+        </dd>
+
+        <dt>If the error was a 404 or 410 HTTP response</dt>
+
+        <dt>If the resource was labeled with the "no-store" cache directive</dt>
+
+        <dd>
+
+        Skip this resource. It is dropped from the cache.
+
+        </dd>
+
+        <dt>Otherwise</dt>
+
+        <dd>
+
+        Copy the resource and its metadata from the <a>newest</a> <a>application cache</a> in <var>cache group</var> whose <a>completeness
+        flag</a> is <i>complete</i>, and act as if that was the fetched resource, ignoring the
+        resource obtained from the network.
+
+        </dd>
+
+      </dl>
+
+      <p class="note">
+  These rules make errors for resources listed in the manifest fatal, while
+      making it possible for other resources to be removed from caches when they are removed from
+      the server, without errors, and making non-manifest resources survive server-side errors.
+  </p>
+
+      <p class="note">
+  Except for the "no-store" directive, HTTP caching rules that would cause a
+      file to be expired or otherwise not cached are ignored for the purposes of the
+      <a>application cache download process</a>.
+  </p>
+
+      </li>
+
+      <li>
+
+      Otherwise, the fetching succeeded. Store the resource in the <var>new
+      cache</var>.
+
+      If the user agent is not able to store the resource (e.g., because of quota restrictions),
+      the user agent may prompt the user or try to resolve the problem in some other manner (e.g.,
+      automatically pruning content in other caches). If the problem cannot be resolved, the user
+      agent must run the <a>cache failure steps</a>.
+
+      </li>
+
+      <li>If the URL being processed was flagged as an "explicit entry" in <var>file
+      list</var>, then categorize the entry as an <a>explicit
+      entry</a>.</li>
+
+      <li>If the URL being processed was flagged as a "fallback entry" in <var>file
+      list</var>, then categorize the entry as a <a>fallback
+      entry</a>.</li>
+
+      <li>If the URL being processed was flagged as an "master entry" in <var>file
+      list</var>, then categorize the entry as a <a>master
+      entry</a>.</li>
+
+      <li>As an optimization, if the resource is an HTML or XML file whose root element is an
+      <{html}> element with a <code>manifest</code> attribute
+      whose value doesn't match the manifest URL of the application cache being processed, then the
+      user agent should mark the entry as being <a>foreign</a>.
+
+    </ol>
+
+    </li>
+
+    <li>For each <a>cache host</a> associated with an <a>application cache</a> in <var>cache group</var>, <a>queue a progress post-load task</a> to <a>fire</a> a <a>trusted</a>
+    event with the name <code>progress</code>, which does not bubble,
+    which is cancelable, and which uses the <code>ProgressEvent</code> interface, at the
+    <code>ApplicationCache</code> singleton of the <a>cache host</a>. The <code>lengthComputable</code> attribute must be set to
+    true, the <code>total</code> and the <code>loaded</code> attributes must be set to the number of files in
+    <var>file list</var>. The default action of these events must be, if the user agent
+    <a>shows caching progress</a>, the display of some sort of user interface indicating to the
+    user that all the files have been downloaded. [[!XHR]]</li>
+
+    <li>Store the list of <a>fallback namespaces</a>,
+    and the URLs of the <a>fallback entries</a> that they map
+    to, in <var>new cache</var>.</li>
+
+    <li>Store the URLs that form the new <a>online
+    safelist</a> in <var>new cache</var>.</li>
+
+    <li>Store the value of the new <a>online
+    safelist wildcard flag</a> in <var>new cache</var>.</li>
+
+    <li>Store the value of the new <a>cache mode flag</a> in
+    <var>new cache</var>.</li>
+
+    <li>
+
+    For each entry in <var>cache group</var>'s <a>list of pending master entries</a>, wait for the
+    resource for this entry to have either completely downloaded or failed.
+
+    If the download failed (e.g., the server returns a 4xx or 5xx response, or there is a DNS
+    error, the connection times out, or the user cancels the download), or if the resource is
+    labeled with the "no-store" cache directive, then run these substeps:
+
+    <ol>
+
+      <li>Unassociate the {{Document}} for this entry from <var>new
+      cache</var>.</li>
+
+      <li><a>Queue a post-load task</a> to <a>fire a simple event</a> that is
+      cancelable named <code>error</code> at the
+      <code>ApplicationCache</code> singleton of the {{Document}} for this entry, if there
+      still is one. The default action of this event must be, if the user agent <a>shows caching
+      progress</a>, the display of some sort of user interface indicating to the user that the
+      user agent failed to save the application for offline use.
+
+      <li>
+
+      If this is a <a>cache attempt</a> and this entry is
+      the last entry in <var>cache group</var>'s <a>list of pending master entries</a>, then run these
+      further substeps:
+
+      <ol>
+
+        <li>Discard <var>cache group</var> and its only <a>application cache</a>,
+        <var>new cache</var>.
+
+        <li>If appropriate, remove any user interface indicating that an update for this cache is
+        in progress.</li>
+
+        <li>Abort the <a>application cache download process</a>.</li>
+
+      </ol>
+
+      </li>
+
+      <li>Otherwise, remove this entry from <var>cache group</var>'s <a>list of pending master entries</a>.</li>
+
+    </ol>
+
+    Otherwise, store the resource for this entry in <var>new cache</var>, if it isn't
+    already there, and categorize its entry as a <a>master
+    entry</a>.
+
+    </li>
+
+    <li>Let <var>request</var> be a new <a>request</a> whose
+    <a for="url">URL</a> is <var>manifest URL</var>, <a>client</a> is null, <a>destination</a> is "<code>subresource</code>",
+    <a>referrer</a> is "<code>no-referrer</code>",
+    <a>synchronous flag</a> is set, <a>credentials
+    mode</a> is "<code>include</code>", and whose <a>use-URL-credentials
+    flag</a> is set.</li>
+
+    <li>
+
+    Let <var>second manifest</var> be the result of <a>fetching</a> <var>request</var>. HTTP caching semantics should again
+    be honored for this request.
+
+    </li>
+
+    <li>
+
+    If the previous step failed for any reason, or if the fetching attempt involved a redirect,
+    or if <var>second manifest</var> and <var>manifest</var> are not byte-for-byte
+    identical, then schedule a rerun of the entire algorithm with the same parameters after a short
+    delay, and run the <a>cache failure steps</a>.
+
+    </li>
+
+    <li>
+
+    Otherwise, store <var>manifest</var> in <var>new cache</var>, if it's not
+    there already, and categorize its entry as <a>the
+    manifest</a>.
+
+    </li>
+
+    <li>Set the <a>completeness flag</a> of <var>new cache</var> to <i>complete</i>.</li>
+
+    <li>Let <var>task list</var> be an empty list of <a>tasks</a>.
+
+    <li>
+
+    If this is a <a>cache attempt</a>, then for each
+    <a>cache host</a> associated with an <a>application cache</a> in <var>cache
+    group</var>, create a <a>task</a> to <a>fire a simple event</a>
+    that is cancelable named <code>cached</code> at the
+    <code>ApplicationCache</code> singleton of the <a>cache host</a>, and append it to <var>task list</var>. The default action of these events must be, if the user agent
+    <a>shows caching progress</a>, the display of some sort of user interface indicating to
+    the user that the application has been cached and that they can now use it offline.
+
+    Otherwise, it is an <a>upgrade attempt</a>. For each
+    <a>cache host</a> associated with an <a>application cache</a> in <var>cache
+    group</var>, create a <a>task</a> to <a>fire a simple event</a>
+    that is cancelable named <code>updateready</code> at the
+    <code>ApplicationCache</code> singleton of the <a>cache host</a>, and append it to <var>task list</var>. The default action of these events must be, if the user agent
+    <a>shows caching progress</a>, the display of some sort of user interface indicating to
+    the user that a new version is available and that they can activate it by reloading the
+    page.
+
+    </li>
+
+    <li>If appropriate, remove any user interface indicating that an update for this cache is in
+    progress.</li>
+
+    <li>Set the <a>update status</a> of <var>cache
+    group</var> to <i>idle</i>.</li>
+
+    <li>For each <a>task</a> in <var>task list</var>, <a>queue that task as a post-load task</a>.</li>
+
+  </ol>
+
+  The <dfn>cache failure steps</dfn> are as follows:
+
+  <ol>
+
+    <li>Let <var>task list</var> be an empty list of <a>tasks</a>.
+
+    <li>
+
+    For each entry in <var>cache group</var>'s <a>list of pending master entries</a>, run the
+    following further substeps. These steps may be run in parallel for two or more entries at a
+    time.
+
+    <ol>
+
+      <li>Wait for the resource for this entry to have either completely downloaded or failed.
+
+      <li>Unassociate the {{Document}} for this entry from its <a>application
+      cache</a>, if it has one.</li>
+
+      <li>Create a <a>task</a> to <a>fire a simple event</a> that
+      is cancelable named <code>error</code> at the
+      <code>ApplicationCache</code> singleton of the {{Document}} for this entry, if there
+      still is one, and append it to <var>task list</var>. The default action of these
+      events must be, if the user agent <a>shows caching progress</a>, the display of some sort
+      of user interface indicating to the user that the user agent failed to save the application for
+      offline use.
+
+    </ol>
+
+    </li>
+
+    <li>For each <a>cache host</a> still associated with an <a>application cache</a>
+    in <var>cache group</var>, create a <a>task</a> to <a>fire
+    a simple event</a> that is cancelable named <code>error</code> at
+    the <code>ApplicationCache</code> singleton of the <a>cache host</a>, and append it to <var>task list</var>. The default action of these events must be, if the user agent
+    <a>shows caching progress</a>, the display of some sort of user interface indicating to the
+    user that the user agent failed to save the application for offline use.</li>
+
+    <li>Empty <var>cache group</var>'s <a>list of pending master entries</a>.</li>
+
+    <li>If <var>cache group</var> has an <a>application cache</a> whose <a>completeness flag</a> is <i>incomplete</i>, then discard
+    that <a>application cache</a>.
+
+    <li>If appropriate, remove any user interface indicating that an update for this cache is in
+    progress.</li>
+
+    <li>Let the <a>status</a> of <var>cache
+    group</var> be <i>idle</i>.</li>
+
+    <li>If this was a <a>cache attempt</a>, discard <var>cache group</var> altogether.
+
+    <li>For each <a>task</a> in <var>task list</var>, <a>queue that task as a post-load task</a>.</li>
+
+    <li>Abort the <a>application cache download process</a>.</li>
+
+  </ol>
+
+  Attempts to fetch resources as part of the <a>application cache download process</a> may
+  be done with cache-defeating semantics, to avoid problems with stale or inconsistent intermediary
+  caches.
+
+  <hr />
+
+  User agents may invoke the <a>application cache download process</a>, in the background,
+  for any <a>application cache group</a>, at any time (with no <a>cache host</a>). This
+  allows user agents to keep caches primed and to update caches even before the user visits a
+  site.
+
+  <hr />
+
+  Each {{Document}} has a list of <dfn>pending application cache download process
+  tasks</dfn> that is used to delay events fired by the algorithm above until the document's <code>load</code> event has fired. When the {{Document}} is created, the
+  list must be empty.
+
+  When the steps above say to <dfn lt="queue that task as a post-load task|queue a post-load task">queue a post-load task</dfn> <var>task</var>, where
+  <var>task</var> is a <a>task</a> that dispatches an event on a
+  target <code>ApplicationCache</code> object <var>target</var>, the user agent must run
+  the appropriate steps from the following list:
+
+  <dl>
+
+    <dt>If <var>target</var>'s <a>node document</a> is
+    <a>ready for post-load tasks</a></dt>
+
+    <dd><a lt="queue a task">Queue</a> the task <var>task</var>.</dd>
+
+    <dt>Otherwise</dt>
+
+    <dd>Add <var>task</var> to <var>target</var>'s <a>node document</a>'s list
+    of <a>pending application cache download process tasks</a>.</dd>
+
+  </dl>
+
+  When the steps above say to <dfn>queue a progress post-load task</dfn> <var>task</var>, where
+  <var>task</var> is a <a>task</a> that dispatches an event on a
+  target <code>ApplicationCache</code> object <var>target</var>, the user agent must run
+  the following steps:
+
+  <ol>
+
+    <li>If there is a <var>task</var> in <var>target</var>'s <a>node document</a>'s list
+    of <a>pending application cache download process tasks</a> that is labeled as a
+    <i>progress task</i>, then remove that task from the list.</li>
+
+    <li>Label <var>task</var> as a <i>progress task</i>.</li>
+
+    <li><a>Queue a post-load task</a> <var>task</var>.</li>
+
+  </ol>
+
+  The <a>task source</a> for these <a>tasks</a> is the
+  <a>networking task source</a>.
+
+<h5 id="the-application-cache-selection-algorithm">The application cache selection algorithm</h5>
+
+  When the <dfn lt="has an effect|application cache selection algorithm|application cache selection|cache selection">application cache selection algorithm</dfn>
+  algorithm is invoked with a {{Document}} <var>document</var> and optionally a
+  manifest <a for="url">URL</a> <var>manifest URL</var>, the user agent must run the first
+  applicable set of steps from the following list:
+
+  <dl class="switch">
+
+    <dt>If there is a <var>manifest URL</var>, and <var>document</var> was loaded
+    from an <a>application cache</a>, and the URL of the <a>manifest</a> of that cache's <a>application cache
+    group</a> is <em>not</em> the same as <var>manifest URL</var></dt>
+
+    <dd>
+
+    Mark the entry for the resource from which <var>document</var> was taken in the
+    <a>application cache</a> from which it was loaded as <a>foreign</a>.
+
+    Restart the current navigation from the top of the <a>navigation
+    algorithm</a>, undoing any changes that were made as part of the initial load (changes can be
+    avoided by ensuring that the step to <a>update the session history with the new page</a>
+    is only ever completed <em>after</em> this <a>application cache
+    selection algorithm</a> is run, though this is not required).
+
+    </dd>
+
+    <dt>If <var>document</var> was loaded from an <a>application cache</a>, and that
+    <a>application cache</a> still exists (it is not now <a>obsolete</a>)</dt>
+
+    <dd>
+
+    Associate <var>document</var> with the <a>application cache</a> from which it
+    was loaded. Invoke, in the background, the <a>application cache download process</a> for
+    that <a>application cache</a>'s <a>application cache group</a>, with <var>document</var> as the <a>cache host</a>.
+
+    </dd>
+
+    <dt>If <var>document</var>  was loaded using <code>GET</code>, and, there is a
+    <var>manifest URL</var>, and <var>manifest URL</var> has the <a>same origin</a> as
+    <var>document</var></dt>
+
+    <dd>
+
+    Invoke, in the background, the <a>application cache download process</a> for <var>manifest URL</var>, with <var>document</var> as the <a>cache host</a>
+    and with the resource from which <var>document</var> was parsed as the <a>master</a> resource.
+
+    If there are <a>relevant application caches</a> that
+    are identified by a URL with the <a>same origin</a> as the URL of <var>document</var>, and that have this URL as one of their entries, excluding entries
+    marked as <a>foreign</a>, then the user agent should use
+    the <a>most appropriate application cache</a> of those
+    that match as an HTTP cache for any subresource loads. User agents may also have other caches in
+    place that are also honored.
+
+    </dd>
+
+    <dt>Otherwise</dt>
+
+    <dd>
+
+    The {{Document}} is not associated with any <a>application cache</a>.
+
+    If there was a <var>manifest URL</var>, the user agent may report to the user that
+    it was ignored, to aid in application development.
+
+    </dd>
+
+  </dl>
+
+<h5 id="changes-to-the-networking-model">Changes to the networking model</h5>
+
+  When a <a>cache host</a> is associated with an <a>application cache</a> whose <a>completeness flag</a> is <i>complete</i>, any and all
+  loads for resources related to that <a>cache host</a> other than those for <a>child browsing contexts</a> must go through the following steps
+  instead of immediately invoking the mechanisms appropriate to that resource's scheme:
+
+  <ol>
+
+    <li>If the resource is not to be fetched using the GET method, or if applying the <a>URL
+    parser</a> algorithm to both its <a for="url">URL</a> and the <a>application cache</a>'s
+    <a>manifest</a>'s URL results in two <a>URL records</a> with different <a for="url">scheme</a> components,
+    then fetch the resource normally and abort these steps.</li>
+
+    <li>If the resource's URL is a <a>master entry</a>,
+    <a>the manifest</a>, <a>an explicit entry</a>, or <a>a fallback entry</a> in the <a>application cache</a>,
+    then get the resource from the cache (instead of fetching it), and abort these steps.</li>
+
+    <li>If there is an entry in the <a>application cache</a>'s <a>online safelist</a> that has the <a>same
+    origin</a> as the resource's URL and that is a <a>prefix match</a> for the resource's
+    URL, then fetch the resource normally and abort these steps.</li>
+
+    <li>
+
+    If the resource's URL has the <a>same origin</a> as the manifest's URL, and there is a
+    <a>fallback namespace</a> <var>f</var> in
+    the <a>application cache</a> that is a <a>prefix match</a> for the resource's URL,
+    then:
+
+    Fetch the resource normally. If this results in a redirect to a resource with another
+    <a for="concept">origin</a> (indicative of a captive portal), or a 4xx or 5xx status code, or if
+    there were network errors (but not if the user canceled the download), then instead get, from
+    the cache, the resource of the <a>fallback entry</a> corresponding to the
+    <a>fallback namespace</a> <var>f</var>. Abort these steps.
+
+    </li>
+
+    <li>If the <a>application cache</a>'s <a>online safelist wildcard flag</a> is
+    <i>open</i>, then fetch the resource normally and abort these steps.</li>
+
+    <li>Fail the resource load as if there had been a generic network error.</li>
+
+  </ol>
+
+  <p class="note">
+  The above algorithm ensures that so long as the <a>online safelist wildcard flag</a> is
+  <i>blocking</i>, resources that are not present in the <a>manifest</a> will always fail to load (at least, after the
+  <a>application cache</a> has been primed the first time), making the testing of offline
+  applications simpler.
+  </p>
+
+<h5 id="expiring-application-caches">Expiring application caches</h5>
+
+  As a general rule, user agents should not expire application caches, except on request from the
+  user, or after having been left unused for an extended period of time.
+
+  Application caches and cookies have similar implications with respect to privacy (e.g., if the
+  site can identify the user when providing the cache, it can store data in the cache that can be
+  used for cookie resurrection). Implementors are therefore encouraged to expose application caches
+  in a manner related to HTTP cookies, allowing caches to be expunged together with cookies and
+  other origin-specific data.
+
+
+<h5 id="disk-space">Disk space</h5>
+
+  User agents should consider applying constraints on disk usage of <a>application caches</a>, and care should be taken to ensure that the restrictions cannot
+  be easily worked around using subdomains.
+
+  User agents should allow users to see how much space each domain is using, and may offer the
+  user the ability to delete specific <a>application caches</a>.
+
+
+<h5 id="security-concerns-with-offline-applications-caches">Security concerns with offline applications caches</h5>
+
+  <em>This section is non-normative.</em>
+
+  The main risk introduced by offline application caches is that an injection attack can be
+  elevated into persistent site-wide page replacement. This attack involves using an injection
+  vulnerability to upload two files to the victim site. The first file is an application cache
+  manifest consisting of just a fallback entry pointing to the second file, which is an HTML page
+  whose manifest is declared as that first file. Once the user has been directed to that second
+  file, all subsequent accesses to any file covered by the given fallback namespace while either the
+  user or the site is offline will instead show that second file. Targeted denial-of-service
+  attacks or cookie bombing attacks (where the client is made to send so many cookies that the
+  server refuses to process the request) can be used to ensure that the site appears offline.
+
+  To mitigate this, manifests can only specify fallbacks that are in the same path as the
+  manifest itself. This means that a content injection upload vulnerability in a particular
+  directory on a server can only be escalated to a take-over of that directory and its
+  subdirectories. If there is no way to inject a file into the root directory, the entire site
+  cannot be taken over.
+
+  If a site has been attacked in this way, simply removing the offending manifest might eventually
+  clear the problem, since the next time the manifest is updated, a 404 error will be seen, and the
+  user agent will clear the cache. "Eventually" is the key word here, however; while the attack on
+  the user or server is ongoing, such that connections from an affected user to the affected site
+  are blocked, the user agent will simply assume that the user is offline and will continue to use
+  the hostile manifest. Unfortunately, if a cookie bombing attack has also been used, merely
+  removing the manifest is insufficient; in addition, the server has to be configured to return a
+  404 or 410 response instead of the 413 "Request Entity Too Large" response.
+
+  TLS does not inherently protect a site from this attack, since the attack relies on content
+  being served from the server itself. Not using application caches also does not prevent this
+  attack, since the attack relies on an attacker-provided manifest.
+
+<h5 id="application-cache-api">Application cache API</h5>
+
+  <pre class="idl" data-highlight="webidl" dfn-for="ApplicationCache">
+    [Exposed=(Window, SharedWorker)]
+    interface ApplicationCache : EventTarget {
+      // update status
+      const unsigned short UNCACHED = 0;
+      const unsigned short IDLE = 1;
+      const unsigned short CHECKING = 2;
+      const unsigned short DOWNLOADING = 3;
+      const unsigned short UPDATEREADY = 4;
+      const unsigned short OBSOLETE = 5;
+      readonly attribute unsigned short status;
+
+      // updates
+      void update();
+      void abort();
+      void swapCache();
+
+      // events
+      attribute EventHandler onchecking;
+      attribute EventHandler onerror;
+      attribute EventHandler onnoupdate;
+      attribute EventHandler ondownloading;
+      attribute EventHandler onprogress;
+      attribute EventHandler onupdateready;
+      attribute EventHandler oncached;
+      attribute EventHandler onobsolete;
+    };
+  </pre>
+
+  <dl class="domintro">
+
+    <dt><var>cache</var> = <var>window</var> . <code>applicationCache</code></dt>
+    <dd>
+
+    (In a window.) Returns the <code>ApplicationCache</code> object that applies to the
+    <a>active document</a> of that {{Window}}.
+
+    </dd>
+
+    <dt><var>cache</var> = <var>self</var> . <code>applicationCache</code></dt> <dd>
+
+    (In a shared worker.) Returns the <code>ApplicationCache</code> object that applies to the
+    current shared worker.
+
+    </dd>
+
+    <dt><var>cache</var> . <code>status</code></dt>
+    <dd>
+
+    Returns the current status of the application cache, as given by the constants defined
+    below.
+
+    </dd>
+
+    <dt><var>cache</var> . <code>update</code>()</dt>
+    <dd>
+
+    Invokes the <a>application cache download process</a>.
+
+    Throws an <code>InvalidStateError</code> exception if there is no application cache to
+    update.
+
+    </dd>
+
+    <dt><var>cache</var> . <code>abort</code>()</dt>
+    <dd>
+
+    Cancels the <a>application cache download process</a>.
+
+    </dd>
+
+    <dt><var>cache</var> . <code>swapCache</code>()</dt>
+    <dd>
+
+    Switches to the most recent application cache, if there is a newer one. If there isn't,
+    throws an <code>InvalidStateError</code> exception.
+
+    </dd>
+
+  </dl>
+
+
+  There is a one-to-one mapping from <a>cache hosts</a> to
+  <code>ApplicationCache</code> objects. The <dfn attribute for="Window"><code>applicationCache</code></dfn> attribute on <code>Window</code>
+  objects must return the <code>ApplicationCache</code> object associated with the
+  <code>Window</code> object's <a>active document</a>. The <dfn attribute for="SharedWorkerGlobalScope"><code>applicationCache</code></dfn> attribute
+  on <code>SharedWorkerGlobalScope</code> objects must return the <code>ApplicationCache</code>
+  object associated with the worker.
+
+  <p class="note">
+  A <code>Window</code> or <code>SharedWorkerGlobalScope</code> object has an
+  associated <code>ApplicationCache</code> object even if that <a>cache host</a> has no actual
+  <a>application cache</a>.
+  </p>
+
+  <hr />
+
+  The <dfn attribute for="ApplicationCache"><code>status</code></dfn> attribute, on getting, must
+  return the current state of the <a>application cache</a> that the
+  <code>ApplicationCache</code> object's <a>cache host</a> is associated with, if any. This
+  must be the appropriate value from the following list:
+
+  <dl>
+
+    <dt><dfn const for="ApplicationCache"><code>UNCACHED</code></dfn> (numeric value 0)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is not associated with
+    an <a>application cache</a> at this time.</dd>
+
+    <dt><dfn const for="ApplicationCache"><code>IDLE</code></dfn> (numeric value 1)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is associated with an
+    <a>application cache</a> whose <a>application cache group</a>'s <a>update status</a> is <i>idle</i>, and that <a>application
+    cache</a> is the <a>newest</a> cache in its
+    <a>application cache group</a>, and the <a>application cache group</a> is not marked
+    as <a>obsolete</a>.</dd>
+
+    <dt><dfn const for="ApplicationCache"><code>CHECKING</code></dfn> (numeric value 2)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is associated with an
+    <a>application cache</a> whose <a>application cache group</a>'s <a>update status</a> is <i>checking</i>.</dd>
+
+    <dt><dfn const for="ApplicationCache"><code>DOWNLOADING</code></dfn> (numeric value 3)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is associated with an
+    <a>application cache</a> whose <a>application cache group</a>'s <a>update status</a> is <i>downloading</i>.</dd>
+
+    <dt><dfn const for="ApplicationCache"><code>UPDATEREADY</code></dfn> (numeric value 4)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is associated with an
+    <a>application cache</a> whose <a>application cache group</a>'s <a>update status</a> is <i>idle</i>, and whose <a>application
+    cache group</a> is not marked as <a>obsolete</a>, but
+    that <a>application cache</a> is <em>not</em> the <a>newest</a> cache in its group.</dd>
+
+    <dt><dfn const for="ApplicationCache"><code>OBSOLETE</code></dfn> (numeric value 5)</dt>
+
+    <dd>The <code>ApplicationCache</code> object's <a>cache host</a> is associated with an
+    <a>application cache</a> whose <a>application cache group</a> is marked as <a>obsolete</a>.</dd>
+
+  </dl>
+
+
+  <hr />
+
+  If the <dfn method for="ApplicationCache"><code>update()</code></dfn> method is invoked, the user
+  agent must invoke the <a>application cache download process</a>, in the background, for the
+  <a>application cache group</a> of the <a>application cache</a> with which the
+  <code>ApplicationCache</code> object's <a>cache host</a> is associated, but without giving
+  that <a>cache host</a> to the algorithm. If there is no such <a>application cache</a>,
+  or if its <a>application cache group</a> is marked as <a>obsolete</a>, then the method must throw an
+  <code>InvalidStateError</code> exception instead.
+
+  If the <dfn method for="ApplicationCache"><code>abort()</code></dfn> method is invoked, the user
+  agent must <dfn lt="sends a signal|send a signal">send a signal</dfn> to the current <a>application cache download process</a>
+  for the <a>application cache group</a> of the <a>application cache</a> with which the
+  <code>ApplicationCache</code> object's <a>cache host</a> is associated, if any. If there is
+  no such <a>application cache</a>, or it does not have a current <a>application cache
+  download process</a>, then do nothing.
+
+  If the <dfn method for="ApplicationCache"><code>swapCache()</code></dfn> method is invoked,
+  the user agent must run the following steps:
+
+  <ol>
+
+    <li>Check that <code>ApplicationCache</code> object's <a>cache host</a> is associated
+    with an <a>application cache</a>. If it is not, then throw an
+    <code>InvalidStateError</code> exception and abort these steps.</li>
+
+    <li>Let <var>cache</var> be the <a>application cache</a> with which the
+    <code>ApplicationCache</code> object's <a>cache host</a> is associated. (By definition,
+    this is the same as the one that was found in the previous step.)</li>
+
+    <li>If <var>cache</var>'s <a>application cache group</a> is marked as <a>obsolete</a>, then unassociate the
+    <code>ApplicationCache</code> object's <a>cache host</a> from <var>cache</var> and
+    abort these steps. (Resources will now load from the network instead of the cache.)</li>
+
+    <li>Check that there is an application cache in the same <a>application cache group</a>
+    as <var>cache</var> whose <a>completeness
+    flag</a> is <i>complete</i> and that is <a>newer</a> than
+    <var>cache</var>. If there is not, then throw an <code>InvalidStateError</code>
+    exception and abort these steps.</li>
+
+    <li>Let <var>new cache</var> be the <a>newest</a> <a>application cache</a> in the same
+    <a>application cache group</a> as <var>cache</var> whose <a>completeness flag</a> is <i>complete</i>.</li>
+
+    <li>Unassociate the <code>ApplicationCache</code> object's <a>cache host</a> from <var>cache</var> and instead associate it with <var>new cache</var>.</li>
+
+  </ol>
+
+  The following are the <a>event handlers</a> (and their corresponding <a>event handler event types</a>) <span class="impl">that must be</span>
+  supported, as <a>event handler IDL attributes</a>, by all objects implementing the
+  <code>ApplicationCache</code> interface:
+
+  <table>
+    <thead>
+    <tr><th><a>Event handler</a> <th><a>Event handler event type</a>
+    <tbody>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onchecking</code></dfn> <td> <code>checking</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onerror</code></dfn> <td> <code>error</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onnoupdate</code></dfn> <td> <code>noupdate</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>ondownloading</code></dfn> <td> <code>downloading</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onprogress</code></dfn> <td> <code>progress</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onupdateready</code></dfn> <td> <code>updateready</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>oncached</code></dfn> <td> <code>cached</code>
+    <tr><td><dfn attribute for="ApplicationCache"><code>onobsolete</code></dfn> <td> <code>obsolete</code>
+  </table>
+
+
 
 <h4 id="other-elements-attributes-and-apis">Other elements, attributes and APIs</h4>
 

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -226,7 +226,7 @@
   contain a <a>valid URL potentially surrounded by spaces</a>.
 
   A <{base}> element, if it has an <{base/href}> attribute, must come before any other elements in
-  the tree that have attributes defined as taking <a for="url">URLs</a>.
+  the tree that have attributes defined as taking <a for="url">URLs</a> except the <{html}> element.
 
   <div class="impl">
     <p class="note">

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -5255,6 +5255,35 @@
     {{Document}} as the intended parent. Append it to the {{Document}} object. Put
     this element in the <a>stack of open elements</a>.
 
+    If the {{Document}} is being loaded as part of <a>navigation</a> of a <a>browsing context</a>, run these steps:
+
+    <ol>
+
+      <li>If the result of running <a>match service worker
+      registration</a> for <a>the <code>Document</code>'s address</a> is non-null, run the
+      <a>application cache selection algorithm</a> passing the
+      {{Document}} object with no manifest.</li>
+
+      <li>
+
+      Otherwise, run these substeps:
+
+      <ol>
+
+        <li>If the newly created element has a <{html/manifest}>
+        attribute whose value is not the empty string, then <a>parse</a> the value of that attribute, relative to the newly created element, and
+        if that is successful, run the <a>application cache selection algorithm</a> passing the {{Document}} object with the result of
+        applying the <a>URL serializer</a> algorithm to the
+        <a>resulting URL string</a> with the <i>exclude fragment flag</i> set.</li>
+
+        <li>Otherwise, run the <a>application cache selection algorithm</a> passing the {{Document}} object with no manifest.</li>
+
+      </ol>
+
+      </li>
+
+    </ol>
+
     Switch the <a>insertion mode</a> to "<a>before
     head</a>".
 
@@ -5276,6 +5305,10 @@
     Create an <{html}> element whose <a>node document</a> is the {{Document}} object. Append
     it to the {{Document}} object. Put this element in the <a>stack of open
     elements</a>.
+
+    If the {{Document}} is being loaded as part of <a>navigation</a> of a <a>browsing context</a>,
+    then: run the <a>application cache selection algorithm</a> with no manifest, passing it the
+    {{Document}} object.
 
     Switch the <a>insertion mode</a> to "<a>before head</a>", then reprocess the token.
 
@@ -8646,6 +8679,11 @@
     </ol>
 
     </li>
+
+    <li>If the {{Document}} has any <a>pending application cache download process
+    tasks</a>, then <a lt="queue a task">queue</a> each such <a>task</a> in the order they were added to the list of <a>pending
+    application cache download process tasks</a>, and then empty the list of <a>pending
+    application cache download process tasks</a>. The <a>task source</a> for these <a>tasks</a> is the <a>networking task source</a>.</li>
 
     <li>If the <code>Document</code>'s <a>print when loaded</a> flag is set, then run the
     <a>printing steps</a>.</li>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1,5 +1,5 @@
 <section>
-<!--
+<!-- Web App APIS - ASCII Art roolz
 ██      ██ ████████ ████████           ███    ████████  ████████           ███    ████████  ████  ██████
 ██  ██  ██ ██       ██     ██         ██ ██   ██     ██ ██     ██         ██ ██   ██     ██  ██  ██    ██
 ██  ██  ██ ██       ██     ██        ██   ██  ██     ██ ██     ██        ██   ██  ██     ██  ██  ██
@@ -2051,7 +2051,7 @@
        <var>realm execution context</var>.
   18. Replace the {{Document}}'s singleton objects with new instances of those objects, created in
        <var>window</var>'s <a>Realm</a>. (This includes in particular the
-       {{History}} and {{Navigator}} objects, the various {{BarProp}}
+       {{History}}, {{ApplicationCache}} and {{Navigator}} objects, the various {{BarProp}}
        objects, the two <code>Storage</code> objects, the various {{HTMLCollection}} objects, and
        objects defined by other specifications, like <code>Selection</code>. It also includes all
        the Web IDL prototypes in the JavaScript binding, including the {{Document}} object's


### PR DESCRIPTION
The attribute needs to be listed in the right section, with pointers to what to do instead

There are still things that browsers generally need to do until it actually disappears from the Web

Bring privacy considerations to the main section on that (as well, not instead).

Note that a substantial amount of advice and explanation, primarily
directed at application authors, was removed. Reviewers, please check
that nothing critical went with it.
