### PR TITLE
Corrected ref to Server Sent Events REC. Removed BroadcastChannel.

### DIFF
--- a/sections/events.include
+++ b/sections/events.include
@@ -163,7 +163,7 @@
       <tr> <!-- message -->
         <td><dfn event for="global"><code>message</code></dfn></td>
         <td><code>MessageEvent</code></td>
-        <td>{{Window}}, <code>EventSource</code>, <code>WebSocket</code>, <code>MessagePort</code>, <code>BroadcastChannel</code>, <code>DedicatedWorkerGlobalScope</code>, {{Worker}}</td>
+        <td>{{Window}}, <code>EventSource</code>, <code>WebSocket</code>, <code>MessagePort</code>, <code>DedicatedWorkerGlobalScope</code>, {{Worker}}</td>
         <td>Fired at an object when it receives a message</td>
       </tr>
       <tr> <!-- offline -->

--- a/single-page.bs
+++ b/single-page.bs
@@ -575,6 +575,7 @@ urlPrefix: https://www.w3.org/TR/encoding/#; type: dfn; spec: ENCODING;
     url:utf-8-encoder; text: encoded as UTF-8
     urlPrefix: error; text: decoder error
 
+
 <!-- ************************************ FETCH ************************************************ -->
 
 urlPrefix: https://fetch.spec.whatwg.org/#; type: dfn; spec: FETCH;
@@ -794,6 +795,13 @@ spec:webidl; type:interface;
 
 <pre class="biblio">
 {
+  "EVENTSOURCE": {
+    "title": "Server-Sent Events",
+    "authors": [ "Ian Hickson" ],
+    "href": "https://www.w3.org/TR/eventsource/",
+    "status": "3 February 2015. REC",
+    "publisher": "W3C"
+  },
   "SRGB":  {
    "title": "Amendment 1 - Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB",
    "href": "https://webstore.iec.ch/publication/6168",


### PR DESCRIPTION
Server Sent Events (EVENTSOURCE) fixed to point at W3C REC instead of a red redirect warning notice. Spurious BroadcastEvent reference removed, details in Issue #388 
