### PR TITLE
Fix erroroneous categories/parents for <style> in the element index

### DIFF
--- a/sections/elements.include
+++ b/sections/elements.include
@@ -1268,11 +1268,9 @@
     <tr>
      <th><{style}></th>
      <td>Embedded styling information</td>
-     <td><a lt="Metadata content">metadata</a>;
-         <a lt="Flow content">flow</a>*</td>
+     <td><a lt="Metadata content">metadata</a></td>
      <td><{head}>;
-         <{noscript}>*;
-         <a lt="flow content">flow</a>*</td>
+         <{noscript}>*</td>
      <td>varies*</td>
      <td><a lt="global attributes">globals</a>;
          <{style/media}>;


### PR DESCRIPTION
These were true when the index of elements was introduced, but obsoleted
when https://github.com/w3c/html/pull/318 removed the scoped
attribute.

Resolves https://github.com/w3c/html/issues/516

---

Notes:
- This commit is an exact duplicate of https://github.com/whatwg/html/commit/2acc1001fad91e5ee67e1a90e6607a614005d141
- I've read https://github.com/w3c/html/blob/master/CONTRIBUTING.md and it sounds like I don't need to sign anything / declare anything / sacrifice any goats unless I'm making a "substantive contribution". I'm assuming that this doesn't count and that I can just open the PR without any other rituals involved; let me know if this is wrong.
