### PR TITLE
Remove longdesc in favor of module

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -720,7 +720,7 @@
   Silver Ghost, <!-- see bug 19614 -->
   Silvia Pfeiffer,
   Šime Vidas, <!-- again in 5.1 -->
-  Simo Sutela, 
+  Simo Sutela,
   Simon Montagu,
   Simon Spiegel,
   skeww, <!-- on reddit -->
@@ -853,8 +853,6 @@
   <a href="https://www.flickr.com/photos/lenore-m/8631391979/">a work</a> by
   <a href="https://www.flickr.com/photos/lenore-m/">Lenore Edman</a>.
   (<a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a>)
-
-  The fancy image of the letter O with a child sitting in it reading a book is <a href="http://www.reusableart.com/drop_o.html">by Jessie Wilcox Smith</a> and is in the Public Domain.
 
   Parts of this specification are © Copyright 2004-2014 Apple Inc., Mozilla Foundation, and
   Opera Software ASA. You are granted a license to use, reproduce and create derivative works of

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -433,12 +433,6 @@
       <td><a>ID</a>*</td>
     </tr>
     <tr>
-      <th><code>longdesc</code></th>
-      <td><{img}></td>
-      <td>A link to a fuller description of the image</td>
-      <td><a>Valid non-empty URL potentially surrounded by spaces</a></td>
-    </tr>
-    <tr>
       <th><code>loop</code></th>
       <td><{audio}>; <{video}></td>
       <td>Whether to loop the <a>media resource</a></td>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -28,7 +28,6 @@
     <dd><a href="https://github.com/w3c/html/commit/4cdef0b0ecf4f1f3370f041170d781982f82ab4e">Removed <code>style scoped</code></a></dd>
 
   <dt>Changes related to other specifications</dt>
-    <dd><a href="https://github.com/w3c/html/issues/258">Integrate HTML longdesc</a></dd>
     <dd><a href="https://github.com/w3c/html/pull/431">Use closed blob from File API</a></dd>
     <dd><a href="https://github.com/w3c/html/issues/119">Integrate Resource Hints</a></dd>
     <dd><a href="https://github.com/w3c/html/issues/120">Update <code>HTMLAllCollection</code> to match Web IDL</a></dd>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -615,7 +615,6 @@
          <{img/crossorigin}>;
          <{common/usemap}>;
          <{img/ismap}>;
-         <{img/longdesc}>;
          <{media/width}>;
          <{media/height}></td>
      <td>{{HTMLImageElement}}</td>

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -219,8 +219,6 @@
   : <dfn element-attr for="input"><code>usemap</code></dfn> on <{input}> elements
   :: Use <code>img</code> instead of <code>input</code> for image maps.
 
-  : <dfn element-attr for="iframe,frame"><code>longdesc</code></dfn> on <{iframe}> and <{frame}> elements
-
   : <dfn element-attr for="img"><code>lowsrc</code></dfn> on <{img}> elements
   :: Use a progressive JPEG image (given in the <code>src</code> attribute), instead of using two
       separate images.
@@ -811,7 +809,6 @@
       attribute DOMString scrolling;
       attribute DOMString src;
       attribute DOMString frameBorder;
-      attribute DOMString longDesc;
       attribute boolean noResize;
       readonly attribute Document? contentDocument;
       readonly attribute WindowProxy? contentWindow;
@@ -830,10 +827,6 @@
 
   The <dfn attribute for="HTMLFrameElement"><code>frameBorder</code></dfn> IDL attribute of the
   <{frame}> element must <a>reflect</a> the element's <code>frameborder</code> content attribute.
-
-  The <dfn attribute for="HTMLFrameElement"><code>longDesc</code></dfn> IDL attribute of the
-  <{frame}> element must <a>reflect</a> the element's <{frame/longdesc}> content attribute, which
-  for the purposes of reflection is defined as containing a <a for="url">URL</a>.
 
   The <dfn attribute for="HTMLFrameElement"><code>noResize</code></dfn> IDL attribute of the
   <{frame}> element must <a>reflect</a> the element's <code>noresize</code> content attribute.
@@ -2622,7 +2615,6 @@
       attribute DOMString align;
       attribute DOMString scrolling;
       attribute DOMString frameBorder;
-      attribute DOMString longDesc;
 
       [TreatNullAs=EmptyString] attribute DOMString marginHeight;
       [TreatNullAs=EmptyString] attribute DOMString marginWidth;
@@ -2635,10 +2627,6 @@
 
   The <dfn attribute for="HTMLIFrameElement"><code>frameBorder</code></dfn> IDL attribute of the
   <{iframe}> element must <a>reflect</a> the element's <{iframe/frameborder}> content attribute.
-
-  The <dfn attribute for="HTMLIFrameElement"><code>longDesc</code></dfn> IDL attribute of the
-  <{iframe}> element must <a>reflect</a> the element's <{iframe/longdesc}> content attribute,
-  which for the purposes of reflection is defined as containing a <a for="url">URL</a>.
 
   The <dfn attribute for="HTMLIFrameElement"><code>marginHeight</code></dfn> IDL attribute of the
   <{iframe}> element must <a>reflect</a> the element's <{iframe/marginheight}> content attribute.

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -578,7 +578,6 @@
     <dd><code>ismap</code> - Whether the image is a server-side image map</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
-    <dd><{img/longdesc}> - A url that provides a link to an expanded description of the image, defined in [[!html-longdesc]]</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd><a value for="role"><code>presentation</code></a> role only, for an
     <{img}> element whose <code>alt</code> attribute's value is empty (<code>alt=""</code>), otherwise
@@ -598,7 +597,6 @@
           attribute DOMString sizes;
           attribute DOMString? crossOrigin;
           attribute DOMString useMap;
-          attribute DOMString longDesc;
           attribute boolean isMap;
           attribute unsigned long width;
           attribute unsigned long height;
@@ -617,9 +615,8 @@
   and any previous sibling <{source}> elements'
   <code>srcset</code> attributes if the parent is a <{picture}> element,
   is the embedded content; the value of
-  the <dfn element-attr for="img"><code>alt</code></dfn> attribute and the content referred to by
-  the <{img/longdesc}> attribute are the
-  <{img}> element's <a>fallback content</a>, and provide equivalent content for
+  the <dfn element-attr for="img"><code>alt</code></dfn> attribute is the
+  <{img}> element's <a>fallback content</a>, and provides equivalent content for
   users and user agents who cannot process images or have image loading disabled.
 
   Requirements for alternative representations of the image are described
@@ -2167,9 +2164,6 @@
   The <dfn attribute for="HTMLImageElement"><code>isMap</code></dfn> IDL attribute must <a>reflect</a>
   the <code>ismap</code> content attribute.
 
-  The <dfn attribute for="HTMLImageElement"><code>longDesc</code></dfn> IDL attribute is defined in [[!html-longdesc]]. The IDL attribute must <a>reflect</a>
-  the <{img/longdesc}> content attribute.
-
   </div>
 
   <dl class="domintro">
@@ -2300,11 +2294,6 @@
   Authoring useful <code>alt</code> attribute content requires the author to
   carefully consider the context in which the image appears and the function that
   image may have in that context.
-
-  The <{img/longdesc}> attribute on images is likely to be read far less often by users
-  and is necessary for far fewer images. Nevertheless it provides an important way for
-  users who cannot see an image or cannot see it clearly, and user agents that cannot automatically process images,
-  to understand what it shows. The <{img/longdesc}> attribute's use cases are more fully described in [[!html-longdesc]]
 
   The guidance included here addresses the most common ways authors use images.
   Additional guidance and techniques are available in <a>Resources on Alternative Text for Images</a>.
@@ -2447,14 +2436,13 @@
   </div>
 
   <div class="example">
-    In the case where an image repeats the previous paragraph in graphical form. The
-    <{img/alt}> attribute content labels the image and the <{img/longdesc}> attribute identifies it as a description.
+    In the case where an image repeats the previous paragraph in graphical form. The <{img/alt}>
+    attribute content labels the image.
 
     <pre highlight="html">
       &lt;p id="graph7"&gt;According to a recent study Firefox has a 40% browser share,
         Internet Explorer has 25%, Chrome has 25%, Safari has 6% and Opera has 4%.&lt;/p&gt;
-      &lt;p&gt;&lt;img src="piechart.gif" alt="The browser shares as a pie chart."
-        longdesc="graph7"&gt;&lt;/p&gt;
+      &lt;p&gt;&lt;img src="piechart.gif" alt="The browser shares as a pie chart."&gt;&lt;/p&gt;
     </pre>
 
     It can be seen that when the image is not available, for example because the <code>src</code>
@@ -2480,7 +2468,7 @@
 
   <pre highlight="html">
   &lt;a href="#desc"&gt;</strong>&lt;img src="flowchart.gif"
-    alt="Flowchart: Dealing with a broken lamp." longdesc="#desc"&gt;&lt;/a&gt;
+    alt="Flowchart: Dealing with a broken lamp."&gt;&lt;/a&gt;
 
   ...
 
@@ -2522,7 +2510,7 @@
   &lt;figure&gt;
   &lt;figcaption&gt;Rainfall Data&lt;/figcaption&gt;
   &lt;img src="rainchart.gif" alt="Bar chart: average rainfall by Country and Season.
-  Full description in Table below." longdesc="table-4"&gt;
+  Full description in Table below."&gt;
   &lt;table id="table-4"&gt;
   &lt;caption&gt;Rainfall in millimetres by Country and Season.&lt;/caption&gt;
   &lt;tr&gt;&lt;td&gt;&lt;th scope="col"&gt;UK &lt;th scope="col"&gt;Japan&lt;th scope="col"&gt;Australia&lt;/tr&gt;
@@ -2648,16 +2636,6 @@ Only <img width="21" height="18" src="images/euro.png" alt="euro " />5.99!
     </pre>
   </div>
 
-  <div class="example">
-    Where the design of the illuminated letter is important, the primary text alternative in
-    is the character that the image represents, and <{img/longdesc}> can provide a link to a more detailed description:
-    <img width="24" height="32" src="images/drop_o.jpg" alt="O" longdesc="http://www.reusableart.com/drop_o.html"/>nce upon a time and a long long time ago...
-    <pre highlight="html">
-&lt;p&gt;&lt;img src="initials/story-o.jpg" <mark>alt="O"</mark> longdesc="letters/story-0.html"&gt;nce
-  upon a time and a long long time ago...
-    </pre>
-  </div>
-
 <h6 id="images-that-include-text">Images that include text</h6>
 
   Sometimes, an image consists of a graphics such as a chart and associated text.
@@ -2723,7 +2701,7 @@ Only <img width="21" height="18" src="images/euro.png" alt="euro " />5.99!
   &lt;p&gt;A poem by Alfred Lord Tennyson&lt;/p&gt;
   &lt;/header&gt;
 
-  &lt;img src="shalott.jpeg" alt="Painting - a young woman with long hair, sitting in a wooden boat. Full description below." longdesc="#des"&gt;
+  &lt;img src="shalott.jpeg" alt="Painting - a young woman with long hair, sitting in a wooden boat. Full description below."&gt;
   &lt;p&gt;&lt;a href="#des"&gt;Description of the painting&lt;/a&gt;.&lt;/p&gt;
 
   &lt;!-- Full Recitation of Alfred, Lord Tennyson's Poem.  --&gt;
@@ -2778,7 +2756,7 @@ Only <img width="21" height="18" src="images/euro.png" alt="euro " />5.99!
   &lt;header&gt;&lt;h1&gt;The Lady of Shalott&lt;/h1&gt;
   &lt;p&gt;A poem by Alfred Lord Tennyson&lt;/p&gt;&lt;/header&gt;
   &lt;figure&gt;
-  &lt;img src="shalott.jpeg" alt="Painting: a woman in a white flowing dress, sitting in a small boat." longdesc="https://bit.ly/5HJvVZ"&gt;
+  &lt;img src="shalott.jpeg" alt="Painting: a woman in a white flowing dress, sitting in a small boat."&gt;
   &lt;p&gt;&lt;a href="https://bit.ly/5HJvVZ"&gt;About this painting.&lt;/a&gt;&lt;/p&gt;
   &lt;/figure&gt;
   &lt;!-- Full Recitation of Alfred, Lord Tennyson's Poem.  --&gt;

--- a/single-page.bs
+++ b/single-page.bs
@@ -753,14 +753,6 @@ urlPrefix: https://www.w3.org/TR/workers/#; spec: WORKERS;
     text: worker processing model; url: processing-model; type: dfn
     text: WorkerGlobalScope; url: workerglobalscope; type: interface
 
-<!--  ****** Longdesc - HTML extension ****** -->
-
-<!-- NOT USED urlPrefix: https://www.w3.org/TR/html-longdesc/#widl-description-longdesc; type: attribute; for: img;
-    text: longDesc -->
-
-urlPrefix: https://www.w3.org/TR/html-longdesc/; type: element-attr; for: img;
-    text: longdesc
-
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
Per this decision https://lists.w3.org/Archives/Public/public-html/2016Aug/0013.html removing longdesc from HTML 5.1.
