### PR TITLE
Added about:html-kind URL for MP4 media track integration.

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -3223,6 +3223,10 @@
   though unresolvable, <a scheme><code>about:</code></a> URL, for use in <a>DOCTYPE</a>s in <a>HTML documents</a>
   when needed for compatibility with XML tools. [[!RFC6694]]
 
+  This specification defines the URL <dfn><code>about:html-kind</code></dfn> as a reserved,
+  though unresolvable, <code data-x="about protocol">about:</code> URL, that is used as an
+  identifier for kinds of media tracks. [[!RFC6694]]
+
   This specification defines the URL <dfn scheme><code>about:srcdoc</code></dfn> as a reserved, though
   unresolvable, <a scheme><code>about:</code></a> URL, that is used as <a>the document's address</a> of
   <a lt="iframe srcdoc document"><code>iframe</code> <code>srcdoc</code> documents</a>. [[!RFC6694]]

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -10760,6 +10760,14 @@ red:89
   when the display is updated, since <code>timeupdate</code> events
   are rate-limited.)
 
+<h5 id="identifying-a-track-kind-through-a-url">Identifying a track kind through a URL</h5>
+
+  Other specifications or formats that need a <span>URL</span> to identify the return values of
+  the <code data-x="dom-AudioTrack-kind">AudioTrack.kind</code> or <code
+  data-x="dom-VideoTrack-kind">VideoTrack.kind</code> IDL attributes, or identify the <span
+  data-x="text track kind">kind of text track</span>, must use the <code>about:html-kind</code>
+  <span>URL</span>.
+
 <h5 id="user-interface">User interface</h5>
 
   The <dfn element-attr for="mediaelements,video,audio"><code>controls</code></dfn> attribute is a


### PR DESCRIPTION
MP4 media track integration change as per issue #557 aligning with the WHATWG change whatwg/html@56ea222
