### PR TITLE
Tweak viewport meta warning

### DIFF
--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -823,9 +823,11 @@
   
   <div class="warning">
   
-  <p>Developers should not use the <code>user-scalable=no</code> or <code>maximum-scale=1.0</code>
-  values in the <code>content</code> attribute as their use hinders users' ability to zoom the 
-  content to a size that is legible for their needs.</p>
+  <p><a href="https://www.w3.org/TR/css-device-adapt-1/#viewport-meta"><code>&lt;meta name="viewport" content="..."></code></a>
+  allows authors to define specific viewport characteristics (such as the layout viewport's width and zoom factor)
+  for their documents. Among these is the ability to prevent or restrict users from being able to zoom, using
+  <code>content</code> values such as <code>user-scalable=no</code> or <code>maximum-scale=1.0</code>. Authors should not suppress
+  or limit the ability of users to resize a document, as this causes accessibility and usability issues.</p>
   
   <div class="example">
   The following examples illustrate code that should be avoided:
@@ -839,11 +841,13 @@
   </pre>
   </div>
   
-  <p>The use of these values could be appropriate in specific use cases, for example in a map application where 
-  zooming is handled via scripting or for a game application where a fixed viewport is required. 
-  In general however, their use will not be appropriate and HTML conformance checking tools should 
-  display a warning if developers use these values.</p>
-  
+  <p>There may be specific use cases where preventing users from zooming may be appropriate, such as map applications – 
+  where custom zoom functionality is handled via scripting.
+  However, in general this practice should be avoided, and HTML conformance checking tools should display a warning if
+  they encounter these values.</p>
+
+  <p>Note that most user agents now allow users to always zoom, regardless of any
+  <code>&lt;meta name="viewport" content="..."></code> restrictions – either by default, or as a setting/option (which may however not be immediately apparent to users).</p>
   </div>
 
   If a <{meta}> element has a <dfn element-attr for="meta"><code>name</code></dfn>


### PR DESCRIPTION
- introduce the actual name="viewport" meta, as this only applies in
  this specific case
- link to CSS device adaptation, currently still the only "official"
  (non-Apple) doc where this is documented
- expand/rewrite advice
- include note about UAs ignoring these values (either with an opt-in
  setting or outright)
