### PR TITLE
Treat 'data:' documents as unique, opaque origins. (#597)

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -1794,6 +1794,7 @@
         <dt><dfn lt="forces content into a unique origin"></dfn>If the {{Document}}'s
         <a>active sandboxing flag set</a> has its <a>sandboxed origin browsing context flag</a>
         set</dt>
+        <dt>If the {{Document}} was generated from a <a scheme lt="data:"><code>data:</code> URL</a></dt>
         <dd>A unique <a>opaque origin</a> is assigned when the {{Document}} is created.</dd>
 
         <dt>If the {{Document}}'s <a for="url">URL</a>'s <a for="url">scheme</a> is a
@@ -1811,8 +1812,7 @@
         was created</a>.</dd>
 
         <dt>If the {{Document}} is a non-initial "<code>about:blank</code>" document</dt>
-        <dt>If the {{Document}} was generated from a <a scheme lt="data:"><code>data:</code> URL</a>
-        found in another {{Document}} or in a script</dt>
+
         <dd>The <a for="concept">origin</a> of the <a>incumbent settings object</a> when the
         <a>navigate</a> algorithm was invoked, or, if no <a for="concept">script</a> was involved,
         of the <a>node document</a> of the element that initiated the <a>navigation</a> to that
@@ -1829,9 +1829,7 @@
         <a>browsing context container</a>'s <a>node document</a>.</dd>
 
         <dt>If the {{Document}} was obtained in some other manner (e.g., a
-        <a scheme lt="data:"><code>data:</code> URL</a> typed in by the user or that was returned as
-        the location of a redirect, a {{Document}} created using the
-        {{DOMImplementation/createDocument()}} API, etc)</dt>
+        {{Document}} created using the {{DOMImplementation/createDocument()}} API, etc)</dt>
         <dd>The default behavior as defined in the DOM standard applies. [[!DOM]].
 
         <p class="note">The <a for="concept">origin</a> is a unique <a>opaque origin</a> assigned


### PR DESCRIPTION
This patch changes the handling of 'data:' URLs to which user agents
navigate. Rather than inheriting the origin of the settings object
responsible for the navigation, they will be treated as unique,
opaque origins.

This aligns the spec with the behavior found in Chrome, Safari,
Opera, and Edge.
- Upstream: whatwg/html@00769464e80149368672b894b50881134da4602f
