### PR TITLE
Drop one bad example and replace another.

### DIFF
--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -2205,8 +2205,7 @@ path: includes/cldr.include
   form of a tooltip. When the user is unable to use a pointing device, then the user agent is
   expected to make the content available in some other fashion, e.g., by making the element a
   <i>focusable area</i> and always displaying the <a>advisory information</a> of the currently
-  <a>focused</a> element, or by showing the <a>advisory information</a> of the elements
-  under the user's finger on a touch device as the user pans around the screen.
+  <a>focused</a> element.
 
   U+000A LINE FEED (LF) characters are expected to cause line breaks in the tooltip; U+0009
   CHARACTER TABULATION (tab) characters are expected to render as a non-zero horizontal shift that

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -252,8 +252,7 @@ path: sections/semantics-common-idioms.include
 
       An element is said to be <dfn>being actively pointed at</dfn> while the user indicates the
       element using a pointing device while that pointing device is in the "down" state (e.g., for a
-      mouse, between the time the mouse button is pressed and the time it is depressed; for a finger
-      in a multitouch environment, while the finger is touching the display surface).
+      mouse, between the time the mouse button is pressed and the time it is depressed).
 
   : '':hover''
   :: The '':hover'' <a>pseudo-class</a> is defined to match an element

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -252,7 +252,8 @@ path: sections/semantics-common-idioms.include
 
       An element is said to be <dfn>being actively pointed at</dfn> while the user indicates the
       element using a pointing device while that pointing device is in the "down" state (e.g., for a
-      mouse, between the time the mouse button is pressed and the time it is depressed).
+      mouse, between the time the mouse button is pressed and the time it is depressed; for a remote
+      control on a television, the time during which the remote control is pointing at the element).
 
   : '':hover''
   :: The '':hover'' <a>pseudo-class</a> is defined to match an element


### PR DESCRIPTION
In the text describing the rendering of the title attribute, there's a misleading example which describes a UI that no mobile browser engine ships; this could confuse authors.

In the definition of "being actively pointed at," there are two examples (one mouse, one touch) to demonstrate the device independence of the concept. But the touch example is ambiguous because it's unclear which finger is doing the pointing. So I replaced this with an example which still demonstrates device independence but doesn't have the ambiguity.
