### PR TITLE
the contexts in which this element can be used was unintemtially modified

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1499,7 +1499,7 @@
     <dd><a>Flow content</a>.</dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>Where <a>flow content</a> is expected.</dd>
+    <dd>Where <a>flow content</a> is expected, but with no <{article}>, <{aside}>, <{footer}>, <{header}> or <{nav}> element ancestors.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
@@ -1519,7 +1519,7 @@
     <dd>Uses <code>HTMLElement</code></dd>
   </dl>
 
-  The <{main}> element <a>represents</a> the main content of the body of a document or application.
+  The <{main}> element <a>represents</a> the main content of the <{body]> of a document or application.
 
   <p class="note">
     The <{main}> element is not <a>sectioning content</a> and has no effect on the document


### PR DESCRIPTION
this fixes the change
