### PR TITLE
Fix/clarification for tabindex section

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -791,7 +791,7 @@
   nothing.
 
   <p class="note">
-  This means that an element that is only focusable because of its <code>tabindex</code> attribute will fire a <code>click</code> event in response to a non-mouse activation (e.g., hitting the
+  This means that an element that is only focusable because of its <code>tabindex</code> attribute will not fire a <code>click</code> event in response to a non-mouse activation (e.g., hitting the
   "enter" key while the element is <a>focused</a>).
   </p>
 


### PR DESCRIPTION
- corrects what is presumably an accidental omission/typo (non-interactive elements forced into being focusable do not fire `click` as result of, say, ENTER key)

[edit] removed second commit, split out to separate PR
