### PR TITLE
Disambiguate focusable/non-focusable in default value

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -803,8 +803,8 @@
 
   The <dfn attribute for="HTMLElement"><code>tabIndex</code></dfn> IDL attribute must
   <a>reflect</a> the value of the <code>tabindex</code> content
-  attribute. Its default value is 0 for elements that are focusable and -1 for elements that
-  are not focusable.
+  attribute. Its default value is 0 for elements that are focusable and are included in the
+  <a>sequential focus navigation order</a>, and -1 for all other elements.
 
   <p class="warning">
   Most current browsers instead give the {{HTMLElement/tabIndex}} IDL attribute a value of 0 for some list of elements that are by default a <a>focusable area</a>, and -1 for other elements, if there is no <{global/tabindex}> content attribute set. This behaviour is not well-defined and will hopefully be improved in the future.</p>


### PR DESCRIPTION
As the concepts get a bit convoluted (once you realise that
tabindex="-1" also means "focusable", but not part of the sequential
focus navigation order), this is a fairly crude initial attempt at
disambiguating this (as per
https://github.com/w3c/html/issues/635#issuecomment-255610109 comment)
