### PR TITLE
consolidate changes

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -1,230 +1,71 @@
 <section>
 <h2 class="no-num" id="changes">Changes</h2>
 
-  This section summarises substantial <em>substantive</em> changes between Public Working Drafts, as a guide for general review.
+  This section summarises substantial substantive changes between this specification and [[HTML5]].
 
-  Full details of all changes since 12 January 2016 are available from the
-  <a href="https://github.com/w3c/html/commits/master">commit log</a> of the
-  <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including
-  various editorial and linking fixes.
-
-<h3 id="changes-20160822">Changes since the <a href="http://www.w3.org/TR/2016/CR-html51-20160621/">Candidate recommendation of </a>
-
-<p>The following features, that were marked "at risk" were removed for lack of implementation:</p>
-<ul>
- <li>The <code>dialog</code> element</li>
- <li>The <code>registerContentHandler()</code>, <code>isContentHandlerRegistered()</code> and <code>isProtocolHandlerRegistered()</code> methods</li>
- <li>The <code>datetime</code> value for the <code>type</code> attribute of the <code>input</code> element</li>
- <li>unimplemented parts of the autofill mechanism</li>
- <li>The <code>label</code> element is no longer Reassociatable</li>
- <li>the <code>toolbar</code> type for the <code>menu</code> element</li>
- <li>the <code>inputmode</code> attribute</li>
-<ul>
-<p>The mention of <code>longdesc</code> at several places within the document was removed, since it is a separate W3C Recommendation</p>
+<h3>Features added</h3>
 
 
-<h3 id="changes-20160602">Changes between the <a href="http://www.w3.org/TR/2016/CR-html51-20160621/">Candidate recommendation of </a> and the <a href="https://www.w3.org/TR/2016/WD-html51-20160503/">3 May 2016 Public Working Draft</a>.</h3>
- <dl>
-  <dt>Changes to match implementation or reflect lack of it</dt>
-    <dd><a href="https://github.com/w3c/html/pull/453/commits/4459c0c6c442d3765ac2f8a1f505521db9f22343">Add <code>oncopy</code> /<code>oncut</code> /<code>onpaste</code> handling</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/285">Remove <code>usemap</code> attribute on <code>object</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/372">Remove <code>requestAutoComplete</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/pull/431">HTML Fragment serialisation doesn't throw</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/273">Allow <code>header</code> and <code>footer</code> elements to be nested if each level is within a sectioning element</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/330">Make the algorithm for forming a table closer to what implementations do with them</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/90">Remove <code>multiple</code> attribute on <code>input type="range"</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/420">Remove IntersectionObservers</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/374">Remove <code>canvasProxy</code>, <code>setContext</code> from <code>canvas</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/281">Make behaviour for fractional step values in <code>stepUp</code> and <code>stepDown</code> match reality</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/176">Allow empty <code>option</code> elements</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/148"><code>mousewheel</code> is now <code>wheel</code></dd>
-    <dd><a href="https://github.com/w3c/html/issues/40">Remove <code>appCache</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/246">Remove <code>MediaController</code> and <code>mediagroup</code> attribute</a></dd>
-    <dd><a href="https://github.com/w3c/html/commit/60215ae3f18bc364f8e6efd6701ef75369f0df5b">Change <code>menu</code>/<code>type</code> attribute token from <code>popup</code> to <code>context</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/256">Restore the <code>rev</code> attribute, used by RDFa, and e.g. Schema.org</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/169">Remove the nested <code>section</code> <code>h1</code> outline model</a></dd>
-    <dd><a href="https://github.com/w3c/html/commit/4cdef0b0ecf4f1f3370f041170d781982f82ab4e">Removed <code>style scoped</code></a></dd>
-
-  <dt>Changes related to other specifications</dt>
-    <dd><a href="https://github.com/w3c/html/pull/431">Use closed blob from File API</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/119">Integrate Resource Hints</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/120">Update <code>HTMLAllCollection</code> to match Web IDL</a></dd>
-    <dd><a href="https://github.com/w3c/html/pull/404/commits/19177e5919d616732667c8b13fcaa7c2fb0686c8">Integrate the encoding specification</a></dd>
-    <dd><a href="https://github.com/w3c/html/commit/1b70bac646e9ae3f7f7ac495032782f82685556b">Provide hooks to integrate CSP, and Realms from ECMAScript</a></dd>
-
-  <dt>Fixes for specification bugs</dt>
-    <dd><a href="https://github.com/w3c/html/issues/230"><code>value</code> attribute of <code>input  type="submit"</code> is translatable</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/159">added <code>requestAnimationFrame</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/commit/9a8cb41988eb45acf058c9cc7e1d7c3ab26955dc">Having <code>title</code>, or writing email to a friend is not sufficient to make an <code>img</code> conformant if the <code>img</code>/<code>alt</code> attribute is missing</a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/62">Fix the content model for <code>time</code></a></dd>
-    <dd><a href="https://github.com/w3c/html/issues/154">Add <code>HTMLMediaElement</code>/<code>srcObject</code></a></dd>
- </dl>
-
-<h3 id="changes-201605">Changes since the <a href="https://www.w3.org/TR/2016/WD-html51-20160412/">12 April 2016 Public Working Draft</a>.</h3>
-
-<dl>
-  <dt>Changes to match implementation or reflect lack of it</dt>
-   <dd><a href="https://github.com/w3c/html/issues/35">Removed <code>seamless</code> attribute on iframe</a></dd>
-   <dd><a href="https://github.com/w3c/html/issues/56">Removed table sorting</a></dd>
-   <dd><a href="https://github.com/w3c/html/commit/8e5a95a1baf1eb3563e8404e659dac0b69029128">Clarify that respecting user preferences for track selection is valid</a></dd>
-   <dd><a href="https://github.com/w3c/html/issues/177">Allow <code>figcaption</code> anywhere within a <code>figure</code> (not just first or last)</a></dd>
-   <dd><a href="https://github.com/w3c/html/issues/240">Remove special handling of <code>isindex</code> in form submission</a></dd>
-
-  <dt>Normative reference changes</dt>
-   <dd>Move from WCAG 1.0 to WCAG 2.0</dd>
-</dl>
-
-<h3 id="changes-201604">Changes between the <a href="https://www.w3.org/TR/2016/WD-html51-20160412/">12 April 2016 Public Working Draft</a> and the <a href="https://www.w3.org/TR/2016/WD-html51-20160310/">10 March 2016 Public Working Draft</a>.</h3>
-
-<dl>
- <dt><a href="https://github.com/w3c/html/pull/168"><code>accesskey</code> attribute only takes a single character</a></dt>
-  <dd>This is to match implementation in browsers better.</dd>
-
- <dt><a href="https://github.com/w3c/html/pull/157">Add a callout to detach a media object in the media element load algorithm</dt>
-  <dd>This is to synchronise with <a href="https://github.com/w3c/media-source/pull/56">MSE</a>.</dt>
-
- <dt><a href="https://github.com/w3c/html/pull/156">Remove microdata</a></dt>
-  <dd>There is a https://www.w3.org/TR/2013/NOTE-microdata-20131029/W3C Note describing Microdata as <a href="https://www.w3.org/TR/2013/NOTE-microdata-20131029/">an extension</a>.</dd>
-  <dd>Note that the attributes may be added back, referring to a Recommendation-track version of the extension, since there is a substantial amount of implementation.</dd>
-
-</dl>
-
-<h3 id="changes-201603">Changes between the <a href="https://www.w3.org/TR/2016/WD-html51-20160310/">10 March 2016 Public Working Draft</a> and the <a href="https://www.w3.org/TR/2015/WD-html51-20151008/">10 October 2015 Public Working Draft</a>.</h3>
-
-  Full details of all changes since 12 January 2016 are available from the <a href="https://github.com/w3c/html/commits/master">commit log</a> of the <a href="https://github.com/w3c/html/">w3c/html github repository</a>. Note that a large number of changes made between 10 October and 12 January were copied direct from the whatwg/html repository.
-
-<dl>
- <dt>Removed because implementation is not consistent and the idea didn't make sense</dt>
-  <dd><a href="https://github.com/w3c/html/pull/113"><code>form</code> attribute on <code>label</code> element</a>.</dd>
-
- <dt>Removed for lack of implementation and to potentially improve before re-adding</dt>
-  <dd><a href="https://github.com/w3c/html/pull/144"><code>accessKeyLabel</code> IDL attribute</a>.</dd>
-
- <dt>Removed for lack of implementation</dt>
-  <dd><a href="https://github.com/w3c/html/commit/7be30da673f145426765f506f50a82c134a0fc5b">Blank <code>alt</code> on <code>area</code> elements with duplicate <code>href</code> attributes is no longer conformant</a>.</dd>
-  <dd><a href="https://github.com/w3c/html/pull/87">Browsers don't know about the user's keyboard</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/1b918cf72fcbba011f83b92ab5d1f483fb1cafa3">Storage Mutex</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/c6fb03dc3d9396f3a3c7f62b1c5cba1ed73cd9c5"><code>navigator.yieldForStorageUpdates()</code></a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/7e8a5367d1e0d9c1b7e84d2c86e7821af0ff167a"><code>hreflang</code> and<code>type</code> attributes on <code>area</code> links</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/797b4d273955a0fe3cc2e2d0ca5d578f37c0f126"><code>document.cssElementMap</code> and <code>DOMElementMap</code> interface</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/a64aea7fdb221bba027d95dc3cabda09e0b3e5dc"><code>document.commands</code> IDL</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/d65089b6a7bee7d7418a721c182cdf22c44e2b1c">master commands concept in <code>menuitem</code></a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/389ec2620d89e9480ef8847bf016abdfa92427bc">Command API and related concepts</a></dd>
-
- <dt><a href="https://github.com/w3c/html/commit/80f19da3a6c4d9c657fbf352fbf06d0437645fc0">Focus navigation fixed</a></dt>
-  <dd>When navigating internally, the next search for a link etc starts from where the navigation moved to - no longer optionally.</dd>
-
- <dt><a href="https://github.com/w3c/html/commit/d808a3d69efc45ee6b74a72e6245cfc219a0341a"><code>main</code> refers to the <code>body</code></a></dt>
-  <dd>As opposed to be allowed multiple times in the page, for other elements</dd>
-
- <dt><a href="https://github.com/travisleithead/html/commit/31367d279a2ee2db0070eef46cd95d0a07b78f9c">More ways <code>p</code> can be automatigically closed</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/8700e2c36c4d06c8913f4feedaf841677536f177">redefine "fully active" for a document</a></dt>
-  <dd>Require that a document has its own browsing context to be fully active</dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/5e6f6aeaaf5c2a1ca77207cd3954370a83a1f2f0">change currentSrc for images which don't resolve</a></dt>
-  <dd>From the absolute URL to the URL given to the resolver</dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/528a22340a4bdc6ca0b0e190dfd239989123df9b"><code>a</code> is non-interactive if it has no <code>href</code> attribute</a></dt>
-
-  <dt>Fix Collections</dt>
- <dd><a href="https://github.com/whatwg/html/commit/b88afb63ad1d4b0def27c4561e267f15017bdc8a"><code>HTMLFormControlsCollection</code> not used for collections of <code>fieldset</code> elements</a></dd>
-  <dd>Instead <a href="https://github.com/whatwg/html/commit/934887d313305448b7ba6dd3af6f7434e1b600c8"><code>fieldset</code> makes an <code>HTMLCollection</code></a></dd>
- <dd><a href="https://github.com/whatwg/html/commit/f0ba7187bca710b7a58624728d2081b63a0f5ea6"><code>namedItem</code> is an HTMLCollection not HTMLOptionsCollection</a></dd>
-
- <dt>Supported tokens</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/399c565d4db8479a587014e9975e59cadb9fc110">Define supported tokens for link types and <code>dropzone</code> as those that have an impact on processing</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/f7a66ed52a93d3b63304f4a669e868684dc95b56">add supported tokens for rel</a></dd>
-
- <dt>Allow more cross-origin…</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/c89cb55ba2a5571628d101bfd20ba0a1d076c990">Enable cross-origin <code>track</code> and <code>EventSource</code></a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/083c57cc37998292381be3c94aeef483be7213fb">Allow cross-origin content for <code>ImageBitmap</code> in <code>canvas</code></a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/3dc7dc993e5faa35f3c56acdfc037ab1d7b7c438">let frameElement return null</a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/2b13d2b34f79e889c68b5f78c03c7f4cb22a747f">Transferable objects can go to different domains</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/a14ca08fae3b2d2feec88544dd24b2b3db21ae16">Make content of <code>time</code> consistent</a></dt>
-  <dd>There were contradictory requirements, now it is phrasing content, or text</dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/12db63c7c038b9d8f1d3501d6661d89d495abeac">Integration with the ES job queue</a></dt>
-  <dd>Defining EnqueueJob() and NextJob in a <a href="#integration-with-the-javascript-job-queue">monkeypatch</a> to ECMAScript.</dd>
-
- <dt>Add missing events</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/61ccc05b7437ba947390928f9e526da49550fed0">Events and APIs for tracking promise rejection</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/fda5ae368f14dc2161e8c92ad76be1bbd2ee526a"><code>event-source-error</code> error for media fetching</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/e88bcbd6920d46436ac2a7622e74c36db81727b7"><code>event-track-error</code> and <code>event-track-load</code></a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/32edd24d23efc1279929843cf9d693b7e097de4b">Make <code>navigator.javaEnabled()</code> a method</a></dt>
-
- <dt>Table cleanups</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/93cb3d61526cf956a739c57398760dc8a3a633bd">Add specific types for HTML table elements</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/da491d4c62c3efb73a96bce7071a0a0dcbfa95d8"><code>.tFoot</code> an <code>.createTFoot()</code> always insert at the end</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/94d55af9cda601ce675d15f6a0e52c9bb9c6afa9">Disallow <code>tfoot</code> before <code>tbody</code></a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/2b9320cf687778f0573fd4e98f6fcabdd164a8f2">Clear autoplay flag once autoplaying</a></dt>
-  <dd>Otherwise odd things happened if the network changed</dd>
-
- <dt>Cleaning up toBlob in <code>canvas</code></dt>
-  <dd><a href="https://github.com/whatwg/html/commit/8cee637caaed8512afb64c7c31a4e35060da3abe">Make the <code>toBlob()</code> callback non-nullable</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/6c334ac29cfe698fed5b5281dda4ff34c39112b9">Rename <code>fileCallback</code> to <code>blobcallback</code></a></dd>
-
- <dt>CSP hooks</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/479dfbf1ff68b746ed3f81cc7415165e3342709e">Add hooks for property on global object</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/920c9183a7990968ecac1aeedae22391f3438791">for inline events, styles</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/ee3486eb129bc350b5ca684d0c91dff23453ac1a">inline elements</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/7e8a5367d1e0d9c1b7e84d2c86e7821af0ff167a">update specification links</a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/2cdce89525618c4648be412e85e0ed0f8a7226d0">Flip modes (remote/local) in loading media resources</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/2c97ff8e46a86911f621ee4303d0fc18ddcb9b2b">make origin on HTMLHyperlinkElementUtils and Location readonly</a></dt>
-
- <dt><code>meta refresh</code> parsing</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/94750dc5f3ffca7c6b54a79b86526a39b2cbff14">Match Gecko better</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/0a3dcdfa15d73334ba6c2a0a12c2f139d526da5a">make <code>;</code> optional</a></dd>
-
- <dt>Clean up SVG in HTML</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/969c45b2478d1d2d3be8564ec85dc316a53c8bcf">describe the flavour of SVG used in browsers</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/f7ff53e761a9fc813d9765073e2752d42347f0b6">Make SVG <code>title</code> first child not last</a></dd>
-
- <dt>Scroll restoration</dt>
-  <dt><a href="https://github.com/whatwg/html/commit/dd6a34ec3c191ee1968a0fc8d174b4ce3b615916">Add scroll restoration preferences to history traversal</a></dt>
-  <dd><a href="https://github.com/whatwg/html/commit/017a842ec6c63e6ed4f26f77da41270688eab33e">Clarify manual scrolling restoration</a></dd>
+* The <{picture}> and <{img/srcset}> attributes allow responsive image selection.
+* The <{details}> and<{summary}> elements enable authors to provide extended information that users can choose whether to read.
+* The <{menuitem}> and <code>type="context"</code> attribute value enable authors to add functionality to the browser's context menu.
+* The {{requestAnimationFrame}} API allows for more efficient animation.
+* {{enqueueJob}} and {{nextJob}} help explain Promise resolution in terms of microtasks.
+* The <code>rev</code> attribute for links, primarily to support RDFa (previously defined in HTML 4).
+* <code>HTMLMediaElement</code> and <code>srcObject</code> objects.
+* Enable cross-origin <code>track</code> and <code>EventSource</code> and cross-origin content for <code>ImageBitmap</code> in <{canvas}>.
+* <code>event-source-error</code>, <code>event-track-error</code> and <code>event-track-load</code> events for media fetching.
+* <code>onrejectionhandled</code> and <code>onunhandledrejection</code> and APIs for tracking promise rejection.
+* <code>HTMLTableCaptionElement</code>, <code>HTMLTableSectionElement</code>, <code>HTMLTableRowElement</code>, for HTML table elements.
+* <code>history.scrollRestoration</code> to control where a users' view is directed when navigating through their history.
+* IDL <code>[SameObject]</code>, for some objects that return collections.
+* Add "noopener" to <code>rel</code> and <code>window</code> to allow for browsing contexts to be separated.
+* <code>nonce</code> attribute on <{script}> and <{style}> to support the use of Content Security Policy.
 
 
- <dt><a href="https://github.com/whatwg/html/commit/c84f4ca683216e5dfabfa948ce88e2ded1e0573c">Take account of <code>srclang</code> when rendering <code>track</code></a></dt>
+<h3>Features removed</h3>  
 
- <dt>Windows without browsing context</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/1cf14758fda3d7c157c0a89334bd3bc0cad7686e"><code>window.open()</code> can return null</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/2992ea921bc75e44157451a37a807a8ce0b9a884">Add "noopener" to <code>rel</code> and <code>window</code></a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/68390cea99f9f19881a16e1c8adaf1b130b4d1cc">Move HTTPS state from <code>window</code> to <code>document</code></a></dt>
-
- <dt>Drop some IDL attributes</dt>
-  <dd><a href="https://github.com/whatwg/html/commit/9b13dfc443a70bcb383e8cb9b6c0a9765b11b680"><code>[Exposed=Window]</code> for HTMLHyperLinkElementUtils</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/1b4b0eff5a51769e13a9b6cbb10c2dea3742f3a5"><code>[Exposed=Window, Worker]</code> for DOMStringMap</a></dd>
-  <dd><a href="https://github.com/whatwg/html/commit/260b66f352b34143c29bf3b2f5a17f9b5c34c1e1">IDL Date</a></dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/0618fbe2b73747e06d035c2f361658f95b03ae97">Add IDL <code>[SameObject]</code> for some objects that return collections</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/6c635b1ca71ab6b12d1e3ad2438457778554eabd">Make script IDL attributes reflect</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/4080cef60e16ea9e4af10d28130b2040ec9fcc30">Remove "no exception" step from HAVE_METADATA</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/d152cb6ca1ece1161d35bd1c5fd927d1070a10e6">Fix mismatched HTMLMediaElement currentTime exception</a></dt>
-  <dd>If there is a current media controller it can still throw…</dd>
-
- <dt><a href="https://github.com/whatwg/html/commit/4b3e06eaa750f129f25999c742dfc782daa085c9"><code>setInterval()</code> timers clear too</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/a6329a8cac60e07241b9a64bd89755250e2dab9b">Cleanup Fullscreen</a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/b00d85bd72c1582840f820ffd54161afbf232e16">rename <code>menu type="popup"</code> as <code>menu type="context"</code></a></dt>
-
- <dt><a href="https://github.com/whatwg/html/commit/06b0238b34c7dfd2f74c4dee6ed8410e9d79b992">Support <code>width="0"</code></a></dt>
-  <dd>For <code>img</code> and related elements, but not table cells</dd>
-
-</dl>
+* <code>appCache</code>.
+* Media Controllers.
+* The <code>command</code> API.
+* The <code>usemap</code> attribute on <{object}>.
+* The <code>accessKeyLabel</code> IDL attribute.
+* The <code>form</code> attribute is no longer valid for <{label}>.
+* The <code>multiple</code> attribute on <code>input type="range"</code>.
+* <code>hreflang</code> and<code>type</code> attributes on <{area}>.
+* The use of nested <{section}> elements each with an <{h1}> to create an outline.
+* Special handling of <code>isindex</code> in form submission.
+* <code>navigator.yieldForStorageUpdates()</code> and the Storage mutex.
+* Disallow <code>tfoot</code> before <code>tbody</code>.
+* <code>[Exposed=Window]</code> for HTMLHyperLinkElementUtils</a>, <code>[Exposed=Window, Worker]</code> for DOMStringMap</a> and IDL <code>Date</code>.
 
 
-<h3 id="changed-201510">A <a href="https://www.w3.org/html/landscape/#differences-between-w3c-html-5.1-and-w3c-html-5.0">description of substantial changes</a> between the HTML 5.0 Recommendation of 2014 and the HTML 5.1 draft as it was in August 2015 is available as part of a separate document, that is no longer maintained.</h3>
+<h3>Changes to existing features</h3>
+
+* The <{global/accesskey}> takes a single character as a value (as in HTML 4).
+* <{header}> and <{footer}> elements can be nested, if each level is within a sectioning element.
+* <{option}> elements can be empty.
+* The <code>mousewheel</code> event is called <code>wheel</code>.
+* The <{input/value}> attribute of <code>input type="submit"</code> is translatable.
+* A <{figcaption}> can appear anywhere within a <{figure}>.
+* Having <code>title</code>, or writing email to a friend does not make an <{img}> missing <{img/alt}> conformant.
+* The content of <{time}> is phrasing content, or text.
+* Blank <code>alt</code> on <code>area</code> elements with duplicate <code>href</code> attributes is no longer conformant.
+* When navigating internally, the next search for a link etc starts from where the navigation moved to.
+* <{img}> and related elements support <code>width="0"</code>.
+* <code>.tFoot</code> and <code>.createTFoot()</code> always insert at the end of a table
+* <code>fieldset</code> and <code>namedItem</code> make <code>HTMLCollection</code>s not <code>HTMLFormControlsCollection</code>s and <code>HTMLOptionsCollection</code>s.
+* {{frameElement}} can return <code>null</code>.
+* For images which don't resolve {{currentSrc}} is the URL given to the resolver, not necessarily the absolute URL.
+* {{script}} IDL attributes reflect.
+* <code>meta refresh</code> allows <code>;</code> or <code>url=</code> to be optional.
+* <code>navigator.javaEnabled()</code> is a method.
+* <code>fileCallback</code> is called <code>blobcallback</code>.
+* The <code>toBlob()</code> callback is non-nullable.
+* <code>origin</code> on {{HTMLHyperlinkElementUtils}} and {{Location}} is readonly.
+* The first <code>title</code> child of an SVG is its title, not the last.
+* <code>window.open()</code> can return <code>null</code>
+
+
 
 </section>


### PR DESCRIPTION
simplify to a list of added/removed/modified features between HTML 5.1
and HTML 5.

I'd love this to be more comprehensive for HTML 5.2.
