### PR TITLE
remove typo (superfluous less-than-character)

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -1023,7 +1023,7 @@
 
       <li>&#x231B; <a>Queue a task</a> to change the <a>current request</a>'s <a>current URL</a> to
       the empty string, and then, if the element has a
-      <code>src</code> attribute or it uses <code>srcset</code> or <code>picture</code><, <a>fire a simple
+      <code>src</code> attribute or it uses <code>srcset</code> or <code>picture</code>, <a>fire a simple
       event</a> named <code>error</code> at the <{img}>
       element.</li>
 


### PR DESCRIPTION
fix for https://github.com/w3c/html/issues/662 in HTML5.2