### PR TITLE
Port https://github.com/whatwg/html/pull/2003 but retain/rewrite note

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -713,13 +713,6 @@
 
     </ul>
 
-    <p class="note">
-  One valid reason to ignore the platform conventions and always allow an element
-    to be focused (by setting its <a>tabindex focus flag</a>) would be if the user's only
-    mechanism for activating an element is through a keyboard action that triggers the focused
-    element.
-  </p>
-
     </dd>
 
     <dt>If the value is a negative integer</dt>
@@ -789,13 +782,10 @@
 
   </dl>
 
-  An element that has its <a>tabindex focus flag</a> set but does not otherwise have an
-  <a>activation behavior</a> defined has an <a>activation behavior</a> that does
-  nothing.
-
   <p class="note">
-  This means that an element that is only focusable because of its <code>tabindex</code> attribute will fire a <code>click</code> event in response to a non-mouse activation (e.g., hitting the
-  "enter" key while the element is <a>focused</a>).
+  In current user agent implementations, an element that is only focusable because of its <code>tabindex</code>
+  attribute will generally <em>not</em> fire a <code>click</code> event in response to a non-mouse activation
+  (e.g., hitting the "enter" key while the element is <a>focused</a>).
   </p>
 
   An element with the <code>tabindex</code> attribute specified is


### PR DESCRIPTION
- following discussion on https://github.com/whatwg/html/pull/1952 the subsequent PR https://github.com/whatwg/html/pull/2003 removed some of the wording which does not match current UA reality
- this PR keeps the note, slightly rewritten, to reinforce the current reality in UAs that generally `click` is NOT sent for non-mouse actions on elements which are merely forced to be focusable via `tabindex`

Closes https://github.com/w3c/html/issues/653