### PR TITLE
Fix all FATAL ERRORs when using the latest [evergreen] bikeshed in master branch

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -958,7 +958,7 @@
 
 <h3 id="the-window-object">The <code>Window</code> object</h3>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Window">
+  <pre class="idl" data-highlight="webidl">
     [PrimaryGlobal, LegacyUnenumerableNamedProperties]
     /*sealed*/ interface Window : EventTarget {
     // the current browsing context
@@ -1488,7 +1488,7 @@
 
   Each interface element is represented by a <code>BarProp</code> object:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="BarProp">
+  <pre class="idl" data-highlight="webidl">
     interface BarProp {
       readonly attribute boolean visible;
     };
@@ -2468,11 +2468,11 @@
 
 <h4 id="the-history-interface">The <code>History</code> interface</h4>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ScrollRestoration">
+  <pre class="idl" data-highlight="webidl">
     enum ScrollRestoration { "auto", "manual" };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="History">
+  <pre class="idl" data-highlight="webidl">
     interface History {
       readonly attribute unsigned long length;
       attribute ScrollRestoration scrollRestoration;
@@ -2985,7 +2985,7 @@
   <a>current entry</a> of the <a>browsing context</a>'s session history to be changed, by adding or
   replacing entries in the {{Window/history}} object.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Location">
+  <pre class="idl" data-highlight="webidl">
     interface Location {
       [Unforgeable] stringifier attribute USVString href;
       [Unforgeable] readonly attribute USVString origin;
@@ -4644,14 +4644,14 @@
 
 <h5 id="the-popstateevent-interface">The <code>PopStateEvent</code> interface</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="PopStateEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional PopStateEventInit eventInitDict), Exposed=(Window,Worker)]
     interface PopStateEvent : Event {
       readonly attribute any state;
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="PopStateEventInit">
+  <pre class="idl" data-highlight="webidl">
     dictionary PopStateEventInit : EventInit {
       any state = null;
     };
@@ -4675,7 +4675,7 @@
 
 <h5 id="the-hashchangeevent-interface">The <code>HashChangeEvent</code> interface</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HashChangeEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional HashChangeEventInit eventInitDict), Exposed=(Window,Worker)]
     interface HashChangeEvent : Event {
       readonly attribute USVString oldURL;
@@ -4683,7 +4683,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HashChangeEventInit">
+  <pre class="idl" data-highlight="webidl">
     dictionary HashChangeEventInit : EventInit {
       USVString oldURL = "";
       USVString newURL = "";
@@ -4712,14 +4712,14 @@
 
 <h5 id="the-pagetransitionevent-interface">The <code>PageTransitionEvent</code> interface</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="PageTransitionEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional PageTransitionEventInit eventInitDict), Exposed=(Window,Worker)]
     interface PageTransitionEvent : Event {
       readonly attribute boolean persisted;
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="PageTransitionEventInit">
+  <pre class="idl" data-highlight="webidl">
     dictionary PageTransitionEventInit : EventInit {
       boolean persisted = false;
     };
@@ -4949,7 +4949,7 @@
 
 <h5 id="the-beforeunloadevent-interface">The <code>BeforeUnloadEvent</code> interface</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="BeforeUnloadEvent">
+  <pre class="idl" data-highlight="webidl">
     interface BeforeUnloadEvent : Event {
       attribute DOMString returnValue;
     };
@@ -5017,7 +5017,7 @@
 
 <h4 id="browser-state">Browser state</h4>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorOnLine">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject, Exposed=(Window, Worker)]
     interface NavigatorOnLine {
       readonly attribute boolean onLine;

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -72,7 +72,7 @@
   The DOM specification defines a {{Document}} interface, which this specification extends
   significantly:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Document">
+  <pre class="idl" data-highlight="webidl">
     enum DocumentReadyState { "loading", "interactive", "complete" };
 
     typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
@@ -542,7 +542,7 @@
   <div class="impl">
     <h4 id="loading-xml-documents">Loading XML documents</h4>
 
-    <pre class="idl" data-highlight="webidl" dfn-for="XMLDocument">
+    <pre class="idl" data-highlight="webidl">
       partial interface XMLDocument {
         boolean load(DOMString url);
       };
@@ -696,7 +696,7 @@
   <span class="impl">and which must be used by elements that have no additional requirements,</span>
   is the {{HTMLElement}} interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLElement : Element {
       // metadata attributes
       attribute DOMString title;
@@ -723,7 +723,7 @@
     HTMLElement implements ElementContentEditable;
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLUnknownElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLUnknownElement : HTMLElement { };
   </pre>
 
@@ -1980,12 +1980,12 @@
     </pre>
   </div>
 
-<h5 id="the-xmlbase-attribute-xml-only">The <dfn element for="global"><code>xml:base</code></dfn> attribute (XML only)</h5>
+<h5 id="the-xmlbase-attribute-xml-only">The <code>xml:base</code> attribute (XML only)</h5>
 
-  The <code>xml:base</code> attribute is defined in XML Base. [[!XMLBASE]]
+  The <dfn element-attr for="global"><code>xml:base</code></dfn> attribute is defined in XML Base. [[!XMLBASE]]
 
-  The <code>xml:base</code> attribute may be used on <a>html elements</a> of <a>XML documents</a>.
-  Authors must not use the <code>xml:base</code> attribute on <a>html elements</a> in
+  The <{global/xml:base}> attribute may be used on <a>html elements</a> of <a>XML documents</a>.
+  Authors must not use the <{global/xml:base}> attribute on <a>html elements</a> in
   <a>HTML documents</a>.
 
 <h5 id="the-dir-attribute">The <code>dir</code> attribute</h5>

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -1744,7 +1744,7 @@
 
 <h4 id="making-document-regions-editable-the-contenteditable-content-attribute">Making document regions editable: The <code>contenteditable</code> content attribute</h4>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ElementContentEditable">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface ElementContentEditable {
       attribute DOMString contentEditable;
@@ -2333,7 +2333,7 @@
   {{DataTransfer}} objects are used to expose the <a>drag data store</a> that
   underlies a drag-and-drop operation.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DataTransfer">
+  <pre class="idl" data-highlight="webidl">
     interface DataTransfer {
       attribute DOMString dropEffect;
       attribute DOMString effectAllowed;
@@ -2645,7 +2645,7 @@
   Each {{DataTransfer}} object is associated with a {{DataTransferItemList}}
   object.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DataTransferItemList">
+  <pre class="idl" data-highlight="webidl">
     interface DataTransferItemList {
       readonly attribute unsigned long length;
       getter DataTransferItem (unsigned long index);
@@ -2795,7 +2795,7 @@
   Each {{DataTransferItem}} object is associated with a {{DataTransfer}}
   object.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DataTransferItem">
+  <pre class="idl" data-highlight="webidl">
     interface DataTransferItem {
       readonly attribute DOMString kind;
       readonly attribute DOMString type;
@@ -2913,7 +2913,7 @@
   The drag-and-drop processing model involves several events. They all use the
   {{DragEvent}} interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DragEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional DragEventInit eventInitDict)]
     interface DragEvent : MouseEvent {
       readonly attribute DataTransfer? dataTransfer;

--- a/sections/element-interfaces.include
+++ b/sections/element-interfaces.include
@@ -370,10 +370,6 @@
      </td><td> {{HTMLSourceElement}} : {{HTMLElement}}
 
     </td></tr><tr>
-     <td> <a element lt="picture source"><code>source</code></a>
-     </td><td> <a href='#Picture-HTMLSourceElement'><code>HTMLSourceElement</code></a> : {{HTMLElement}}
-
-    </td></tr><tr>
      <td> <{span}>
      </td><td> {{HTMLSpanElement}} : {{HTMLElement}}
 

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -1021,7 +1021,7 @@
          <a lt="Phrasing content">phrasing</a>;
          <a lt="Embedded content">embedded</a></td>
      <td><a lt="Phrasing content">phrasing</a></td>
-     <td><a element lt="picture source"><code>source</code></a>*; one <{img}>;
+     <td><{source}>*; one <{img}>;
          <a>script-supporting elements</a></td>
      <td><a lt="global attributes">globals</a></td>
      <td>{{HTMLPictureElement}}</td>
@@ -1218,30 +1218,20 @@
 
     <tr>
      <th><{source}></th>
-     <td>Media source for <{video}> or <{audio}></td>
+     <td>Media source for <{video}> or <{audio}> or as image source for <{picture}></td>
      <td>none</td>
      <td><{video}>;
          <{audio}>;
-         <{template}></td>
+         <{template}>;
+         <{picture}></td>
      <td>empty</td>
      <td><a lt="global attributes">globals</a>;
          <{source/src}>;
-         <{source/type}></td>
-     <td>{{HTMLSourceElement}}</td>
-    </tr>
-
-    <tr>
-     <th><a element lt="picture source"><code>source</code></a></th>
-     <td>Image source for <{img}></td>
-     <td>none</td>
-     <td><{picture}></td>
-     <td>empty</td>
-     <td><a lt="global attributes">globals</a>;
+         <{source/type}>;
          <{source/srcset}>;
          <{source/sizes}>;
-         <{source/media}>;
-         <{source/type}></td>
-     <td><a href='#Picture-HTMLSourceElement'><code>HTMLSourceElement</code></a></td>
+         <{source/media}></td>
+     <td>{{HTMLSourceElement}}</td>
     </tr>
 
     <tr>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -3879,7 +3879,7 @@
     {{HTMLAllCollection}} object consist of all the descendant elements of the root {{Document}}.
   </p>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLAllCollection">
+  <pre class="idl" data-highlight="webidl">
     [LegacyUnenumerableNamedProperties]
     interface HTMLAllCollection {
       readonly attribute unsigned long length;
@@ -3979,14 +3979,14 @@
   The <code>HTMLFormControlsCollection</code> interface is used for <a lt="collection">collections</a> of
   <a>listed elements</a> in <{form}> elements.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLFormControlsCollection">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLFormControlsCollection : HTMLCollection {
       // inherits length and item()
       getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="RadioNodeList">
+  <pre class="idl" data-highlight="webidl">
     interface RadioNodeList : NodeList {
       attribute DOMString value;
     };
@@ -4091,7 +4091,7 @@
   <{option}> elements. It is always rooted on a <{select}> element and has
   attributes and methods that manipulate that element's descendants.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLOptionsCollection">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLOptionsCollection : HTMLCollection {
       // inherits item(), namedItem()
       attribute unsigned long length; // shadows inherited length
@@ -4254,7 +4254,7 @@
   one for <dfn>getting the list of name-value pairs</dfn>, one for
   <dfn>setting names to certain values</dfn>, and one for <dfn>deleting names</dfn>.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DOMStringMap">
+  <pre class="idl" data-highlight="webidl">
     [OverrideBuiltins]
     interface DOMStringMap {
       getter DOMString (DOMString name);
@@ -4318,7 +4318,7 @@
   getting the list of name-element mappings, one for mapping a name to a certain element, and one
   for deleting mappings by name.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DOMElementMap">
+  <pre class="idl" data-highlight="webidl">
     interface DOMElementMap {
       getter Element (DOMString name);
       setter creator void (DOMString name, Element value);

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -323,7 +323,7 @@
 
 <h4 id="typographic-conventions">Typographic conventions</h4>
 
-  <div dfn-for="conventions">
+  <div>
     This is a definition, requirement, or explanation.
 
     <p class="note">This is a note.</p>
@@ -347,8 +347,8 @@
 
     <pre class="css" highlight="css">/* this is a CSS fragment */</pre>
 
-    The defining instance of a term is marked up like <dfn noexport>this</dfn>. Uses of that term
-    are marked up like <a>this</a> or like <a><i>this</i></a>.
+    The defining instance of a term is marked up like <dfn noexport>this</dfn>. 
+    Uses of that term are marked up like [=this=] or like <a><i>this</i></a>.
 
     The defining instance of an element, attribute, or API is marked up like
     <dfn element noexport><code>this</code></dfn>. References to that element, attribute, or API are

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -438,7 +438,7 @@
 
   The <{applet}> element must implement the <code>HTMLAppletElement</code> interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLAppletElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLAppletElement : HTMLElement {
       attribute DOMString align;
       attribute DOMString alt;
@@ -481,7 +481,7 @@
 
   The <{marquee}> element must implement the <code>HTMLMarqueeElement</code> interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLMarqueeElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLMarqueeElement : HTMLElement {
       attribute DOMString behavior;
       attribute DOMString bgColor;
@@ -696,7 +696,7 @@
 
   The <{frameset}> element must implement the <code>HTMLFrameSetElement</code> interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLFrameSetElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLFrameSetElement : HTMLElement {
       attribute DOMString cols;
       attribute DOMString rows;
@@ -789,7 +789,7 @@
 
   The <{frame}> element must implement the {{HTMLFrameElement}} interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLFrameElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLFrameElement : HTMLElement {
       attribute DOMString name;
       attribute DOMString scrolling;
@@ -845,7 +845,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLAnchorElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLAnchorElement {
       attribute DOMString coords;
       attribute DOMString charset;
@@ -862,7 +862,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLAreaElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLAreaElement {
       attribute boolean noHref;
     };
@@ -873,7 +873,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLBodyElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLBodyElement {
       [TreatNullAs=EmptyString] attribute DOMString text;
       [TreatNullAs=EmptyString] attribute DOMString link;
@@ -906,7 +906,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLBRElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLBRElement {
       attribute DOMString clear;
     };
@@ -917,7 +917,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableCaptionElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableCaptionElement {
       attribute DOMString align;
     };
@@ -928,7 +928,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableColElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableColElement {
       attribute DOMString align;
       attribute DOMString ch;
@@ -958,7 +958,7 @@
 
   The <{dir}> element must implement the <code>HTMLDirectoryElement</code> interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLDirectoryElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLDirectoryElement : HTMLElement {
       attribute boolean compact;
     };
@@ -969,7 +969,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLDivElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLDivElement {
       attribute DOMString align;
     };
@@ -980,7 +980,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLDListElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLDListElement {
       attribute boolean compact;
     };
@@ -991,7 +991,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLEmbedElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLEmbedElement {
       attribute DOMString align;
       attribute DOMString name;
@@ -1006,7 +1006,7 @@
 
   The <{font}> element must implement the <code>HTMLFontElement</code> interface.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLFontElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLFontElement : HTMLElement {
       [TreatNullAs=EmptyString] attribute DOMString color;
       attribute DOMString face;
@@ -1022,7 +1022,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLHeadingElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLHeadingElement {
       attribute DOMString align;
     };
@@ -1043,7 +1043,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLHRElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLHRElement {
       attribute DOMString align;
       attribute DOMString color;
@@ -1064,7 +1064,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLHtmlElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLHtmlElement {
       attribute DOMString version;
     };
@@ -1075,7 +1075,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLIFrameElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLIFrameElement {
       attribute DOMString align;
       attribute DOMString scrolling;
@@ -1106,7 +1106,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLImageElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLImageElement {
       attribute DOMString name;
       attribute DOMString lowsrc;
@@ -1131,7 +1131,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLInputElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLInputElement {
       attribute DOMString align;
       attribute DOMString useMap;
@@ -1146,7 +1146,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLLegendElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLLegendElement {
       attribute DOMString align;
     };
@@ -1157,7 +1157,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLLIElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLLIElement {
       attribute DOMString type;
     };
@@ -1168,7 +1168,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLLinkElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLLinkElement {
       attribute DOMString charset;
       attribute DOMString target;
@@ -1186,7 +1186,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLMenuElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLMenuElement {
       attribute boolean compact;
     };
@@ -1197,7 +1197,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLMetaElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLMetaElement {
       attribute DOMString scheme;
     };
@@ -1240,7 +1240,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLObjectElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLObjectElement {
       attribute DOMString align;
       attribute DOMString archive;
@@ -1279,7 +1279,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLOListElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLOListElement {
       attribute boolean compact;
     };
@@ -1290,7 +1290,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLParagraphElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLParagraphElement {
       attribute DOMString align;
     };
@@ -1301,7 +1301,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLParamElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLParamElement {
       attribute DOMString type;
       attribute DOMString valueType;
@@ -1322,7 +1322,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLPreElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLPreElement {
       attribute long width;
     };
@@ -1333,7 +1333,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLScriptElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLScriptElement {
       attribute DOMString event;
       attribute DOMString htmlFor;
@@ -1348,7 +1348,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableElement {
       attribute DOMString align;
       attribute DOMString border;
@@ -1383,7 +1383,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableSectionElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableSectionElement {
       attribute DOMString align;
       attribute DOMString ch;
@@ -1410,7 +1410,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableCellElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableCellElement {
       attribute DOMString align;
       attribute DOMString axis;
@@ -1452,7 +1452,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableDataCellElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableDataCellElement {
       attribute DOMString abbr;
     };
@@ -1463,7 +1463,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableRowElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLTableRowElement {
       attribute DOMString align;
       attribute DOMString ch;
@@ -1491,7 +1491,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLUListElement">
+  <pre class="idl" data-highlight="webidl">
     partial interface HTMLUListElement {
       attribute boolean compact;
       attribute DOMString type;
@@ -1515,7 +1515,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Document">
+  <pre class="idl" data-highlight="webidl">
     partial interface Document {
       [TreatNullAs=EmptyString] attribute DOMString fgColor;
       [TreatNullAs=EmptyString] attribute DOMString linkColor;
@@ -1614,7 +1614,7 @@
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Window">
+  <pre class="idl" data-highlight="webidl">
     partial interface Window {
       void captureEvents();
       void releaseEvents();
@@ -1629,7 +1629,7 @@
   The <dfn attribute for="Window"><code>external</code></dfn> attribute of the {{Window}} interface
   must return an instance of the {{External}} interface:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Extenal">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface External {
       void AddSearchProvider();

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -37,7 +37,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLHeadElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLHeadElement : HTMLElement {};
       </pre>
     </dd>
@@ -109,7 +109,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-hightlight="webidl" dfn-for="HTMLTitleElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTitleElement : HTMLElement {
           attribute DOMString text;
         };
@@ -202,7 +202,7 @@
     <dd><a>Global aria-* attributes</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLBaseElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLBaseElement : HTMLElement {
           attribute DOMString href;
           attribute DOMString target;
@@ -350,7 +350,7 @@
     <dd>For <code>role</code> value </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLLinkElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLLinkElement : HTMLElement {
           attribute DOMString href;
           attribute DOMString? crossOrigin;
@@ -778,7 +778,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLMetaElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLMetaElement : HTMLElement {
           attribute DOMString name;
           attribute DOMString httpEquiv;
@@ -1496,7 +1496,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLStyleElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLStyleElement : HTMLElement {
           attribute DOMString media;
           attribute DOMString nonce;

--- a/sections/semantics-edits.include
+++ b/sections/semantics-edits.include
@@ -181,7 +181,7 @@
   The <{ins}> and <{del}> elements <span class="impl">must</span> implement the
   {{HTMLModElement}} interface:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLModElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLModElement : HTMLElement {
       attribute DOMString cite;
       attribute DOMString dateTime;

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -420,7 +420,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd>Zero or more <a element lt="picture source"><code>source</code></a> elements, followed by one <{img}> element, optionally intermixed with <a>script-supporting elements</a>.</dd>
+    <dd>Zero or more <{source}> elements, followed by one <{img}> element, optionally intermixed with <a>script-supporting elements</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -445,8 +445,8 @@
   <p class="note">
     The <{picture}> element is somewhat different
     from the similar-looking <code>video</code> and <{audio}> elements.
-    While all of them contain <a element lt="picture source"><code>source</code></a> elements,
-    the <a element lt="picture source"><code>source</code></a> element's <code>src</code> attribute has no meaning
+    While all of them contain <{source}> elements,
+    the <{source}> element's <{source/src}> attribute has no meaning
     when the element is nested within a <{picture}> element,
     and the resource selection algorithm is different.
     As well, the <{picture}> element itself does not display anything;
@@ -454,7 +454,7 @@
     that enables it to choose from multiple <a for="url">URLs</a>.
   </p>
 
-<h4 id="the-source-element-when-used-with-the-picture-element">The <dfn element for="picture" lt="picture source"><code>source</code></dfn> element when used with the <{picture}> element</h4>
+<h4 id="the-source-element">The <dfn element "picture source"><code>source</code></dfn> element</h4>
 
   <dl class="element">
     <dt><a>Categories</a>:</dt>
@@ -491,9 +491,6 @@
       </pre>
     </dd>
   </dl>
-
-<!--  The authoring requirements in this section only apply if the <a element lt="picture source"><code>source</code></a> element has
-  a parent that is a <{picture}> element. -->
 
   The <{source}> element allows authors to specify multiple alternative <a>source sets</a> for 
   <{img}> elements or multiple alternative <a>media resources</a> for <a>media elements</a>. It does 
@@ -541,20 +538,142 @@
 
     The <code>src</code> attribute must not be present.
     </dd>
-    <dt></dt>
-    <dd>
+    <dt><{source}> element's parent is a <a>media element</a></dt>
+    <dd>The <dfn element-attr for="source"><code>src</code></dfn> attribute gives the address of the
+    <a>media resource</a>. The value must be a <a>valid non-empty URL potentially surrounded
+    by spaces</a>. This attribute must be present.
+
+    <p class="note">
+      Dynamically modifying a <{source}> element and its attribute when the
+    element is already inserted in a <code>video</code> or <{audio}> element will have no
+    effect. To change what is playing, just use the <code>src</code> attribute
+    on the <a>media element</a> directly, possibly making use of the <code>canPlayType()</code> method to pick from amongst available
+    resources. Generally, manipulating <{source}> elements manually after the document has
+    been parsed is an unnecessarily complicated approach.
+    </p>
+
+    The <{source/type}> content attribute gives the type of the
+    <a>media resource</a>, to help the user agent determine if it can play this <a>media
+    resource</a> before fetching it. If specified, its value must be a <a>valid MIME
+    type</a>. The <code>codecs</code> parameter, which certain MIME types define, might be
+    necessary to specify exactly how the resource is encoded. [[!RFC6381]]
+
+    <div class="example">
+      The following list shows some examples of how to use the <code>codecs=</code> MIME
+      parameter in the <{source/type}> attribute.
+
+      : H.264 Constrained baseline profile video (main and extended video compatible) level 3 and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'&gt;
+      </pre>
+
+      : H.264 Extended profile video (baseline-compatible) level 3 and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.58A01E, mp4a.40.2"'&gt;
+      </pre>
+
+      : H.264 Main profile video level 3 and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.4D401E, mp4a.40.2"'&gt;
+      </pre>
+
+      : H.264 &quot;High&quot; profile video (incompatible with main, baseline, or extended profiles) level 3 and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.64001E, mp4a.40.2"'&gt;
+      </pre>
+
+      : MPEG-4 Visual Simple Profile Level 0 video and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="mp4v.20.8, mp4a.40.2"'&gt;
+      </pre>
+
+      : MPEG-4 Advanced Simple Profile Level 0 video and Low-Complexity AAC audio in MP4 container
+      :: <pre highlight="html">
+  &lt;source src='video.mp4' type='video/mp4; codecs="mp4v.20.240, mp4a.40.2"'&gt;
+      </pre>
+
+      : MPEG-4 Visual Simple Profile Level 0 video and AMR audio in 3GPP container
+      :: <pre highlight="html">
+  &lt;source src='video.3gp' type='video/3gpp; codecs="mp4v.20.8, samr"'&gt;
+      </pre>
+
+      : Theora video and Vorbis audio in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='video.ogv' type='video/ogg; codecs="theora, vorbis"'&gt;
+      </pre>
+
+      : Theora video and Speex audio in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='video.ogv' type='video/ogg; codecs="theora, speex"'&gt;
+      </pre>
+
+      : Vorbis audio alone in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='audio.ogg' type='audio/ogg; codecs=vorbis'&gt;
+      </pre>
+
+      : Speex audio alone in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='audio.spx' type='audio/ogg; codecs=speex'&gt;
+      </pre>
+
+      : FLAC audio alone in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='audio.oga' type='audio/ogg; codecs=flac'&gt;
+      </pre>
+
+      : Dirac video and Vorbis audio in Ogg container
+      :: <pre highlight="html">
+  &lt;source src='video.ogv' type='video/ogg; codecs="dirac, vorbis"'&gt;
+      </pre>
+
+    </div>
+    
+    The <{source/srcset}>, <{source/sizes}>, and <{source/media}> attributes must not be present.
     </dd>
   </dl>
-    
-  <div class="impl">
-
-  The IDL attributes <dfn attribute for="HTMLSourceElement"><code>srcset</code></dfn>,
+  
+  If a <{source}> element is inserted as a child of a <a>media element</a> that has no 
+  <{source/src}> attribute and whose <code>networkState</code> has the value 
+  <code>NETWORK_EMPTY</code>, the user agent must invoke the <a>media element</a>'s 
+  <a>resource selection algorithm</a>.
+  
+  The IDL attributes 
+  <dfn attribute for="HTMLSourceElement"><code>src</code></dfn>,
+  <dfn attribute for="HTMLSourceElement"><code>type</code></dfn>,
+  <dfn attribute for="HTMLSourceElement"><code>srcset</code></dfn>,
   <dfn attribute for="HTMLSourceElement"><code>sizes</code></dfn> and
   <dfn attribute for="HTMLSourceElement"><code>media</code></dfn> must <a>reflect</a> the
   respective content attributes of the same name.
 
-  </div>
+  <div class="example">
+    If the author isn't sure if user agents will all be able to render the media resources
+    provided, the author can listen to the <code>error</code> event on the last
+    <{source}> element and trigger fallback behavior:
 
+    <pre highlight="html">
+&lt;script&gt;
+  function fallback(video) {
+    // replace &lt;video&gt; with its contents
+    while (video.hasChildNodes()) {
+      if (video.firstChild instanceof HTMLSourceElement)
+        video.removeChild(video.firstChild);
+      else
+        video.parentNode.insertBefore(video.firstChild, video);
+    }
+    video.parentNode.removeChild(video);
+  }
+&lt;/script&gt;
+&lt;video controls autoplay&gt;
+  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'&gt;
+  &lt;source src='video.ogv' type='video/ogg; codecs="theora, vorbis"'
+          onerror="fallback(parentNode)"&gt;
+  ...
+&lt;/video&gt;
+    </pre>
+
+  </div>
+  
 <h4 id="the-img-element">The <dfn element><code>img</code></dfn> element</h4>
 
   <dl class="element">
@@ -5491,136 +5610,9 @@ zero or more <{track}> elements, then
 <h4 id="the-source-element">The <dfn element for="media"><code>source</code></dfn> element</h4>
 
 
-  The <dfn element-attr for="source"><code>src</code></dfn> attribute gives the address of the
-  <a>media resource</a>. The value must be a <a>valid non-empty URL potentially surrounded
-  by spaces</a>. This attribute must be present.
-
-  <p class="note">
-    Dynamically modifying a <{source}> element and its attribute when the
-  element is already inserted in a <code>video</code> or <{audio}> element will have no
-  effect. To change what is playing, just use the <code>src</code> attribute
-  on the <a>media element</a> directly, possibly making use of the <code>canPlayType()</code> method to pick from amongst available
-  resources. Generally, manipulating <{source}> elements manually after the document has
-  been parsed is an unnecessarily complicated approach.
-  </p>
-
-  The <dfn element-attr for="source"><code>type</code></dfn> content attribute gives the type of the
-  <a>media resource</a>, to help the user agent determine if it can play this <a>media
-  resource</a> before fetching it. If specified, its value must be a <a>valid MIME
-  type</a>. The <code>codecs</code> parameter, which certain MIME types define, might be
-  necessary to specify exactly how the resource is encoded. [[!RFC6381]]
-
-  <div class="example">
-    The following list shows some examples of how to use the <code>codecs=</code> MIME
-    parameter in the <code>type</code> attribute.
-
-    <dl>
-
-    <dt>H.264 Constrained baseline profile video (main and extended video compatible) level 3 and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>H.264 Extended profile video (baseline-compatible) level 3 and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="avc1.58A01E, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>H.264 Main profile video level 3 and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="avc1.4D401E, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>H.264 &quot;High&quot; profile video (incompatible with main, baseline, or extended profiles) level 3 and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="avc1.64001E, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>MPEG-4 Visual Simple Profile Level 0 video and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="mp4v.20.8, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>MPEG-4 Advanced Simple Profile Level 0 video and Low-Complexity AAC audio in MP4 container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.mp4' type='video/mp4; codecs="mp4v.20.240, mp4a.40.2"'&gt;
-    </pre></dd>
-
-    <dt>MPEG-4 Visual Simple Profile Level 0 video and AMR audio in 3GPP container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.3gp' type='video/3gpp; codecs="mp4v.20.8, samr"'&gt;
-    </pre></dd>
-
-    <dt>Theora video and Vorbis audio in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.ogv' type='video/ogg; codecs="theora, vorbis"'&gt;
-    </pre></dd>
-
-    <dt>Theora video and Speex audio in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.ogv' type='video/ogg; codecs="theora, speex"'&gt;
-    </pre></dd>
-
-    <dt>Vorbis audio alone in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='audio.ogg' type='audio/ogg; codecs=vorbis'&gt;
-    </pre></dd>
-
-    <dt>Speex audio alone in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='audio.spx' type='audio/ogg; codecs=speex'&gt;
-    </pre></dd>
-
-    <dt>FLAC audio alone in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='audio.oga' type='audio/ogg; codecs=flac'&gt;
-    </pre></dd>
-
-    <dt>Dirac video and Vorbis audio in Ogg container</dt>
-    <dd><pre highlight="html">
-&lt;source src='video.ogv' type='video/ogg; codecs="dirac, vorbis"'&gt;
-    </pre></dd>
-
-    </dl>
-
-  </div>
-
-  If a <code>source</code> element is inserted as a child of a <a>media element</a> that
-  has no <code>src</code> attribute and whose <code>networkState</code> has the value <code>NETWORK_EMPTY</code>, the user agent must invoke the <a>media element</a>'s <a>resource selection
-  algorithm</a>.
-
-  The IDL attributes <dfn attribute for="HTMLSourceElement"><code>src</code></dfn> and
-  <dfn attribute for="HTMLSourceElement"><code>type</code></dfn> must <a>reflect</a> the respective
-  content attributes of the same name.
-
-  <div class="example">
-    If the author isn't sure if user agents will all be able to render the media resources
-    provided, the author can listen to the <code>error</code> event on the last
-    <{source}> element and trigger fallback behavior:
-
-    <pre highlight="html">
-&lt;script&gt;
-  function fallback(video) {
-    // replace &lt;video&gt; with its contents
-    while (video.hasChildNodes()) {
-      if (video.firstChild instanceof HTMLSourceElement)
-        video.removeChild(video.firstChild);
-      else
-        video.parentNode.insertBefore(video.firstChild, video);
-    }
-    video.parentNode.removeChild(video);
-  }
-&lt;/script&gt;
-&lt;video controls autoplay&gt;
-  &lt;source src='video.mp4' type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'&gt;
-  &lt;source src='video.ogv' type='video/ogg; codecs="theora, vorbis"'
-          onerror="fallback(parentNode)"&gt;
-  ...
-&lt;/video&gt;
-    </pre>
-
-  </div>
-
+  
+  
+  
 <h4 id="the-track-element">The <dfn element><code>track</code></dfn> element</h4>
 
   <dl class="element">

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -454,7 +454,7 @@
     that enables it to choose from multiple <a for="url">URLs</a>.
   </p>
 
-<h4 id="the-source-element">The <dfn element "picture source"><code>source</code></dfn> element</h4>
+<h4 id="the-source-element">The <dfn element><code>source</code></dfn> element</h4>
 
   <dl class="element">
     <dt><a>Categories</a>:</dt>
@@ -817,7 +817,7 @@
   all <a>image candidate strings</a> for that
   element must have the <a>width descriptor</a> specified.
 
-  If an <a>image candidate string</a> for a <code>source</code> or
+  If an <a>image candidate string</a> for a <{source}> or
   <{img}> element has the <a>width descriptor</a> specified, all other
   <a>image candidate strings</a> for that element must also
   have the <a>width descriptor</a> specified.
@@ -948,8 +948,8 @@
 
     <li>The element is <a for="document">inserted into</a> or <a for="document">removed from</a> a <code>picture</code> parent element.</li>
 
-    <li>The element's parent is a <{picture}> element and a
-    <code>source</code> element is inserted as a previous sibling.</li>
+    <li>The element's parent is a <{picture}> element and a <{source}> element is inserted as a 
+    previous sibling.</li>
 
     <li>The element's parent is a <{picture}> element and a
     <{source}> element that was a previous sibling is <a>removed</a>.</li>
@@ -5606,12 +5606,6 @@ zero or more <{track}> elements, then
   constructor is found.
 
   </div>
-
-<h4 id="the-source-element">The <dfn element for="media"><code>source</code></dfn> element</h4>
-
-
-  
-  
   
 <h4 id="the-track-element">The <dfn element><code>track</code></dfn> element</h4>
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -431,7 +431,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLPictureElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLPictureElement : HTMLElement {};
       </pre>
     </dd>
@@ -458,28 +458,32 @@
 
   <dl class="element">
     <dt><a>Categories</a>:</dt>
-    <dd>Same as for the <{source}> element.</dd>
+    <dd>None.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>As a child of a <{picture}> element, before the <{img}> element.</dd>
+    <dd>As a child of a <a>media element</a>, before any <a>flow content</a> or <{track}> elements.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd>Same as for the <{source}> element.</dd>
+    <dd><a>Nothing</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>No <a>end tag</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><code>srcset</code> - Images to use in different situations
-    (e.g., high-resolution displays, small monitors, etc)</dd>
-    <dd><code>sizes</code> - Image sizes between breakpoints</dd>
-    <dd><code>media</code> - Applicable media</dd>
+    <dd><code>src</code> - Address of the resource</dd>
     <dd><code>type</code> - Type of embedded resource</dd>
+    <dd><code>srcset</code> - Images to use in different situations (e.g., high-resolution displays,
+    small monitors, etc)</dd>
+    <dd><code>sizes</code> - Image sizes between breakpoints</dd>
+    <dd><code>media</code> - Applicable media</dd>   
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
     <dd>None</dd>
     <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLSourceElement" id='Picture-HTMLSourceElement'>
-        partial interface HTMLSourceElement {
+      <pre class="idl" data-highlight="webidl">
+        interface HTMLSourceElement : HTMLElement {
+          attribute DOMString src;
+          attribute DOMString type;
           attribute DOMString srcset;
           attribute DOMString sizes;
           attribute DOMString media;
@@ -488,59 +492,60 @@
     </dd>
   </dl>
 
-  The authoring requirements in this section only apply if the <a element lt="picture source"><code>source</code></a> element has
-  a parent that is a <{picture}> element.
+<!--  The authoring requirements in this section only apply if the <a element lt="picture source"><code>source</code></a> element has
+  a parent that is a <{picture}> element. -->
 
-  The <a element lt="picture source"><code>source</code></a> element allows authors to specify multiple alternative
-  <a>source sets</a> for <{img}> elements.
-  It does not <a>represent</a> anything on its own.
+  The <{source}> element allows authors to specify multiple alternative <a>source sets</a> for 
+  <{img}> elements or multiple alternative <a>media resources</a> for <a>media elements</a>. It does 
+  not <a>represent</a> anything on its own.
+  
+  The <dfn element-attr for="source"><code>type</code></dfn> attribute may be present. If present,
+  the value must be a <a>valid MIME type</a>.
+  
+  The remainder of the requirements depend on whether the parent is a <{picture}> element or a 
+  <a>media element</a>:
+  
+  <dl class="switch">
+    <dt><{source}> element's parent is a <{picture}> element</dt>
+    <dd>The <dfn element-attr for="source"><code>srcset</code></dfn> content attribute must be 
+    present, and must consist of one or more <a>image candidate strings</a>, each separated from the 
+    next by a U+002C COMMA character (,). If an <a>image candidate string</a> contains no 
+    descriptors and no <a>space characters</a> after the URL, the following 
+    <a>image candidate string</a>, if there is one, must begin with one or more 
+    <a>space characters</a>.
 
-  The <dfn element-attr for="source"><code>srcset</code></dfn> content attribute must be present,
-  and must consist of one or more <a>image candidate strings</a>,
-  each separated from the next by a U+002C COMMA character (,).
-  If an <a>image candidate string</a> contains no descriptors
-  and no <a>space characters</a> after the URL,
-  the following <a>image candidate string</a>, if there is one,
-  must begin with one or more <a>space characters</a>.
+    If the <{source/srcset}> attribute has any <a>image candidate strings</a> using a 
+    <a>width descriptor</a>, the 
+    <dfn element-attr for="source"><code>sizes</code></dfn> content attribute must also be present,
+    and the value must be a <a>valid source size list</a>.
 
-  If the <{source/srcset}> attribute has any
-  <a>image candidate strings</a> using a <a>width descriptor</a>,
-  the <dfn element-attr for="source"><code>sizes</code></dfn> content attribute must also be present,
-  and the value must be a <a>valid source size list</a>.
+    The <dfn element-attr for="source"><code>media</code></dfn> content attribute may also be present.
+    If present, the value must contain a <a>valid media query list</a>.
 
-  The <dfn element-attr for="source"><code>media</code></dfn> content attribute may also be present.
-  If present, the value must contain a <a>valid media query list</a>.
+    The <{source/type}> gives the type of the images in the <a>source set</a>, to allow the user 
+    agent to skip to the next <{source}> element if it does not support the given type.
 
-  The <dfn element-attr for="source" lt='picture source type'><code>type</code></dfn> content attribute may also be present.
-  If present, the value must be a <a>valid mime type</a>.
-  It gives the type of the images in the <a>source set</a>,
-  to allow the user agent to skip to the next <{source}> element
-  if it does not support the given type.
+    <p class="note">
+      If the <{source/type}> attribute is <em>not</em> specified, the user agent will not select a 
+      different <{source}> element if it finds that it does not support the image format after 
+      fetching it.
+    </p>
 
-  <p class="note">
-    If the <code>type</code> attribute
-  is <em>not</em> specified, the user agent will not select a different
-  <{source}> element if it finds that it does not support
-  the image format after fetching it.
-  </p>
+    When a <{source}> element has a following sibling <{source}> element or <{img}> element with a
+    <code>srcset</code> attribute specified, it must have at least one of the following:
 
-  When a <a element lt="picture source"><code>source</code></a> element has a following sibling
-  <a element lt="picture source"><code>source</code></a> element or <{img}> element with a
-  <code>srcset</code> attribute specified, it must have
-  at least one of the following:
+    * A <{source/media}> attribute specified with a value that, after 
+        <a>stripping leading and trailing whitespace</a>, is not the empty string and is not an 
+        <a>ASCII case-insensitive</a> match for the string "<code>all</code>".
+    * A <{source/type}> attribute specified.
 
-  <ul>
-
-    <li>A <code>media</code> attribute specified with a value that,
-    after <a>stripping leading and trailing whitespace</a>,
-    is not the empty string and is not an <a>ASCII case-insensitive</a> match for the string "<code>all</code>".</li>
-
-    <li>A <code>type</code> attribute specified.</li>
-
-  </ul>
-
-  The <code>src</code> attribute must not be present.
-
+    The <code>src</code> attribute must not be present.
+    </dd>
+    <dt></dt>
+    <dd>
+    </dd>
+  </dl>
+    
   <div class="impl">
 
   The IDL attributes <dfn attribute for="HTMLSourceElement"><code>srcset</code></dfn>,
@@ -589,7 +594,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLImageElement">
+      <pre class="idl" data-highlight="webidl">
         [NamedConstructor=Image(optional unsigned long width, optional unsigned long height)]
         interface HTMLImageElement : HTMLElement {
           attribute DOMString alt;
@@ -3470,7 +3475,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLIFrameElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLIFrameElement : HTMLElement {
           attribute DOMString src;
           attribute DOMString srcdoc;
@@ -3997,7 +4002,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLEmbedElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLEmbedElement : HTMLElement {
           attribute DOMString src;
           attribute DOMString type;
@@ -4346,7 +4351,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLObjectElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLObjectElement : HTMLElement {
           attribute DOMString data;
           attribute DOMString type;
@@ -4968,7 +4973,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLParamElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLParamElement : HTMLElement {
           attribute DOMString name;
           attribute DOMString value;
@@ -5080,7 +5085,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLVideoElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLVideoElement : HTMLMediaElement {
           attribute unsigned long width;
           attribute unsigned long height;
@@ -5412,7 +5417,7 @@ zero or more <{track}> elements, then
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-    <pre class="idl" data-highlight="webidl" dfn-for="HTMLAudioElement">
+    <pre class="idl" data-highlight="webidl">
       [NamedConstructor=Audio(optional DOMString src)]
       interface HTMLAudioElement : HTMLMediaElement {};
     </pre>
@@ -5485,36 +5490,6 @@ zero or more <{track}> elements, then
 
 <h4 id="the-source-element">The <dfn element for="media"><code>source</code></dfn> element</h4>
 
-  <dl class="element">
-    <dt><a>Categories</a>:</dt>
-    <dd>None.</dd>
-    <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>As a child of a <a>media element</a>, before any <a>flow content</a>
-  or <{track}> elements.</dd>
-    <dt><a>Content model</a>:</dt>
-    <dd><a>Nothing</a>.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>No <a>end tag</a></dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>src</code> - Address of the resource</dd>
-    <dd><code>type</code> - Type of embedded resource</dd>
-    <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
-    <dd>None</dd>
-    <dt>Allowed <a href="#state-and-property-attributes">ARIA state and property attributes</a>:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dt><a>DOM interface</a>:</dt>
-    <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLSourceElement">
-        interface HTMLSourceElement : HTMLElement {
-          attribute DOMString src;
-          attribute DOMString type;
-        };
-      </pre>
-    </dd>
-  </dl>
-
-  The <{source}> element allows authors to specify multiple alternative <a>media resources</a> for <a>media elements</a>. It does not <a>represent</a> anything on its own.
 
   The <dfn element-attr for="source"><code>src</code></dfn> attribute gives the address of the
   <a>media resource</a>. The value must be a <a>valid non-empty URL potentially surrounded
@@ -5670,7 +5645,7 @@ zero or more <{track}> elements, then
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTrackElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTrackElement : HTMLElement {
           attribute DOMString kind;
           attribute DOMString src;
@@ -5891,15 +5866,15 @@ zero or more <{track}> elements, then
   {{HTMLMediaElement}} objects (<{audio}> and <{video}>, in this specification) are simply known as
   <dfn lt="media element|media elements">media elements</dfn>.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="CanPlayTypeResult">
+  <pre class="idl" data-highlight="webidl">
     enum CanPlayTypeResult { "" /* empty string */, "maybe", "probably" };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="MediaProvider">
+  <pre class="idl" data-highlight="webidl">
     typedef (MediaStream or MediaSource or Blob) MediaProvider;
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLMediaElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLMediaElement : HTMLElement {
 
       // error state
@@ -6020,7 +5995,7 @@ zero or more <{track}> elements, then
 
   </div>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="MediaError">
+  <pre class="idl" data-highlight="webidl">
     interface MediaError {
       const unsigned short MEDIA_ERR_ABORTED = 1;
       const unsigned short MEDIA_ERR_NETWORK = 2;
@@ -8671,7 +8646,7 @@ zero or more <{track}> elements, then
   The <code>AudioTrackList</code> and <code>VideoTrackList</code> interfaces are used by
   attributes defined in the previous section.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="AudioTrackList">
+  <pre class="idl" data-highlight="webidl">
     interface AudioTrackList : EventTarget {
       readonly attribute unsigned long length;
       getter AudioTrack (unsigned long index);
@@ -8683,7 +8658,7 @@ zero or more <{track}> elements, then
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="AudioTrack">
+  <pre class="idl" data-highlight="webidl">
     interface AudioTrack {
       readonly attribute DOMString id;
       readonly attribute DOMString kind;
@@ -8693,7 +8668,7 @@ zero or more <{track}> elements, then
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="VideoTrackList">
+  <pre class="idl" data-highlight="webidl">
     interface VideoTrackList : EventTarget {
       readonly attribute unsigned long length;
       getter VideoTrack (unsigned long index);
@@ -8706,7 +8681,7 @@ zero or more <{track}> elements, then
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="VideoTrack">
+  <pre class="idl" data-highlight="webidl">
     interface VideoTrack {
       readonly attribute DOMString id;
       readonly attribute DOMString kind;
@@ -9905,7 +9880,7 @@ zero or more <{track}> elements, then
 
 <h6 id="text-track-api">Text track API</h6>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TextTrackList">
+  <pre class="idl" data-highlight="webidl">
     interface TextTrackList : EventTarget {
       readonly attribute unsigned long length;
       getter TextTrack (unsigned long index);
@@ -9970,7 +9945,7 @@ zero or more <{track}> elements, then
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TextTrack">
+  <pre class="idl" data-highlight="webidl">
     enum TextTrackMode { "disabled",  "hidden",  "showing" };
 
     enum TextTrackKind { "subtitles",  "captions",  "descriptions",  "chapters",  "metadata" };
@@ -10180,11 +10155,11 @@ zero or more <{track}> elements, then
   the {{TextTrack}} object represents, as defined by the following list:
 
   <dl>
-    <dt>"<dfn enum for="TextTrackMode"><code>disabled</code></dfn>"</dt>
+    <dt>"<dfn enum-value for="TextTrackMode"><code>disabled</code></dfn>"</dt>
     <dd>The <a mode for="track" lt="disabled">text track disabled</a> mode.</dd>
-    <dt>"<dfn enum for="TextTrackMode"><code>hidden</code></dfn>"</dt>
+    <dt>"<dfn enum-value for="TextTrackMode"><code>hidden</code></dfn>"</dt>
     <dd>The <a mode for="track" lt="hidden">text track hidden</a> mode.</dd>
-    <dt>"<dfn enum for="TextTrackMode"><code>showing</code></dfn>"</dt>
+    <dt>"<dfn enum-value for="TextTrackMode"><code>showing</code></dfn>"</dt>
     <dd>The <a mode for="track" lt="showing">text track showing</a> mode.</dd>
   </dl>
 
@@ -10329,7 +10304,7 @@ zero or more <{track}> elements, then
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TextTrackCueList">
+  <pre class="idl" data-highlight="webidl">
     interface TextTrackCueList {
       readonly attribute unsigned long length;
       getter TextTrackCue (unsigned long index);
@@ -10383,7 +10358,7 @@ zero or more <{track}> elements, then
 
   <hr />
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TextTrackCue">
+  <pre class="idl" data-highlight="webidl">
     interface TextTrackCue : EventTarget {
       readonly attribute TextTrack? track;
 
@@ -10478,7 +10453,7 @@ zero or more <{track}> elements, then
   appropriate to expose the data in the cues of a <a>media-resource-specific text track</a>,
   the {{DataCue}} object is used. [[INBANDTRACKS]]
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DataCue">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(double startTime, double endTime, ArrayBuffer data)]
     interface DataCue : TextTrackCue {
       attribute ArrayBuffer data;
@@ -10921,7 +10896,7 @@ red:89
   Objects implementing the <code>TimeRanges</code> interface
   represent a list of ranges (periods) of time.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TimeRanges">
+  <pre class="idl" data-highlight="webidl">
     interface TimeRanges {
       readonly attribute unsigned long length;
       double start(unsigned long index);
@@ -11007,7 +10982,7 @@ red:89
 
 <h5 id="the-trackevent-interface">The <code>TrackEvent</code> interface</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="TrackEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional TrackEventInit eventInitDict)]
     interface TrackEvent : Event {
       readonly attribute (VideoTrack or AudioTrack or TextTrack)? track;
@@ -11589,7 +11564,7 @@ red:89
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLMapElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLMapElement : HTMLElement {
           attribute DOMString name;
           [SameObject] readonly attribute HTMLCollection areas;
@@ -11710,7 +11685,7 @@ red:89
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLAreaElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLAreaElement : HTMLElement {
           attribute DOMString alt;
           attribute DOMString coords;

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -837,7 +837,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLFormElement">
+      <pre class="idl" data-highlight="webidl">
         [OverrideBuiltins]
         interface HTMLFormElement : HTMLElement {
           attribute DOMString acceptCharset;
@@ -1180,7 +1180,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLLabelElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLLabelElement : HTMLElement {
           readonly attribute HTMLFormElement? form;
           attribute DOMString htmlFor;
@@ -1411,7 +1411,7 @@ part of the form.</p>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLInputElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLInputElement : HTMLElement {
           attribute DOMString accept;
           attribute DOMString alt;
@@ -7329,7 +7329,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLButtonElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLButtonElement : HTMLElement {
           attribute boolean autofocus;
           attribute boolean disabled;
@@ -7567,7 +7567,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLSelectElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLSelectElement : HTMLElement {
           attribute DOMString autocomplete;
           attribute boolean autofocus;
@@ -8057,7 +8057,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDataListElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDataListElement : HTMLElement {
           [SameObject] readonly attribute HTMLCollection options;
         };
@@ -8164,7 +8164,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLOptGroupElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLOptGroupElement : HTMLElement {
           attribute boolean disabled;
           attribute DOMString label;
@@ -8275,7 +8275,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLOptionElement">
+      <pre class="idl" data-highlight="webidl">
         [NamedConstructor=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
         interface HTMLOptionElement : HTMLElement {
           attribute boolean disabled;
@@ -8480,7 +8480,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTextAreaElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTextAreaElement : HTMLElement {
           attribute DOMString autocomplete;
           attribute boolean autofocus;
@@ -8894,7 +8894,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLOutputElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLOutputElement : HTMLElement {
           [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
           readonly attribute HTMLFormElement? form;
@@ -9081,7 +9081,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLProgressElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLProgressElement : HTMLElement {
           attribute double value;
           attribute double max;
@@ -9245,7 +9245,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLMeterElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLMeterElement : HTMLElement {
           attribute double value;
           attribute double min;
@@ -9639,7 +9639,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLFieldSetElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLFieldSetElement : HTMLElement {
           attribute boolean disabled;
           readonly attribute HTMLFormElement? form;
@@ -9826,7 +9826,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLLegendElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLLegendElement : HTMLElement {
           readonly attribute HTMLFormElement? form;
         };
@@ -12162,7 +12162,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   The {{HTMLInputElement/setRangeText()}} method uses the following enumeration:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="SelectionMode">
+  <pre class="idl" data-highlight="webidl">
     enum SelectionMode {
       "select",
       "start",
@@ -12393,7 +12393,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
     <dl class="switch">
 
-      <dt>If the fourth argument's value is "<dfn enum for="SelectionMode"><code>select</code></dfn>"</dt>
+      <dt>If the fourth argument's value is "<dfn enum-value for="SelectionMode"><code>select</code></dfn>"</dt>
 
       <dd>
 
@@ -12403,7 +12403,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
       </dd>
 
-      <dt>If the fourth argument's value is "<dfn enum for="SelectionMode"><code>start</code></dfn>"</dt>
+      <dt>If the fourth argument's value is "<dfn enum-value for="SelectionMode"><code>start</code></dfn>"</dt>
 
       <dd>
 
@@ -12411,7 +12411,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
       </dd>
 
-      <dt>If the fourth argument's value is "<dfn enum for="SelectionMode"><code>end</code></dfn>"</dt>
+      <dt>If the fourth argument's value is "<dfn enum-value for="SelectionMode"><code>end</code></dfn>"</dt>
 
       <dd>
 
@@ -12419,7 +12419,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
       </dd>
 
-      <dt>If the fourth argument's value is "<dfn enum for="SelectionMode"><code>preserve</code></dfn>" (the default)</dt>
+      <dt>If the fourth argument's value is "<dfn enum-value for="SelectionMode"><code>preserve</code></dfn>" (the default)</dt>
 
       <dd>
 
@@ -12873,7 +12873,7 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
   the <a>validity states</a> of the element.
   This object is <a>live</a>.
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ValidityState">
+  <pre class="idl" data-highlight="webidl">
     interface ValidityState {
       readonly attribute boolean valueMissing;
       readonly attribute boolean typeMismatch;

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -32,7 +32,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLParagraphElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLParagraphElement : HTMLElement {};
       </pre>
     </dd>
@@ -190,7 +190,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLHRElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLHRElement : HTMLElement {};
       </pre>
     </dd>
@@ -296,7 +296,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLPreElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLPreElement : HTMLElement {};
       </pre>
     </dd>
@@ -411,7 +411,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLQuoteElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLQuoteElement : HTMLElement {
           attribute DOMString cite;
         };
@@ -704,7 +704,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLOListElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLOListElement : HTMLElement {
           attribute boolean reversed;
           attribute long start;
@@ -916,7 +916,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLUListElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLUListElement : HTMLElement {};
       </pre>
     </dd>
@@ -994,7 +994,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLLIElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLLIElement : HTMLElement {
           attribute long value;
         };
@@ -1106,7 +1106,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDListElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDListElement : HTMLElement {};
       </pre>
     </dd>
@@ -1905,7 +1905,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDivElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDivElement : HTMLElement {};
       </pre>
     </dd>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -28,7 +28,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDetailsElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDetailsElement : HTMLElement {
           attribute boolean open;
         };
@@ -220,7 +220,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLMenuElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLMenuElement : HTMLElement {
           attribute DOMString type;
           attribute DOMString label;
@@ -446,7 +446,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLMenuItemElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLMenuItemElement : HTMLElement {
           attribute DOMString type;
           attribute DOMString label;
@@ -760,7 +760,7 @@
 
 <h5 id="the-relatedevent-interfaces">The <code>RelatedEvent</code> interfaces</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="RelatedEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional RelatedEventInit eventInitDict)]
     interface RelatedEvent : Event {
       readonly attribute EventTarget? relatedTarget;
@@ -1061,7 +1061,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDialogElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDialogElement : HTMLElement {
           attribute boolean open;
           attribute DOMString returnValue;

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -119,7 +119,7 @@
 
 <h4 id="api-for-a-and-area-elements">API for <{a}> and <{area}> elements</h4>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLHyperlinkElementUtils">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface HTMLHyperlinkElementUtils {
       stringifier attribute USVString href;

--- a/sections/semantics-root.include
+++ b/sections/semantics-root.include
@@ -29,7 +29,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLHtmlElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLHtmlElement : HTMLElement {};
       </pre>
     </dd>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -60,7 +60,7 @@
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLScriptElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLScriptElement : HTMLElement {
           attribute DOMString src;
           attribute DOMString type;
@@ -1262,7 +1262,7 @@ o............A....e
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTemplateElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTemplateElement : HTMLElement {
           readonly attribute DocumentFragment content;
         };
@@ -1527,7 +1527,7 @@ o............A....e
 
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLCanvasElement">
+      <pre class="idl" data-highlight="webidl">
         typedef (CanvasRenderingContext2D or WebGLRenderingContext) RenderingContext;
 
         interface HTMLCanvasElement : HTMLElement {

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -48,7 +48,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLBodyElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLBodyElement : HTMLElement {
         };
         HTMLBodyElement implements WindowEventHandlers;
@@ -830,7 +830,7 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLHeadingElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLHeadingElement : HTMLElement {};
       </pre>
     </dd>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -29,7 +29,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableElement : HTMLElement {
           attribute HTMLTableCaptionElement? caption;
           HTMLTableCaptionElement createCaption();
@@ -637,7 +637,7 @@ side in the right column.&lt;/p&gt;
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableCaptionElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableCaptionElement : HTMLElement {};
       </pre>
     </dd>
@@ -730,7 +730,7 @@ the cell that corresponds to the values of the two dice.
     <dd><a>Global aria-* attributes</a></dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableColElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableColElement : HTMLElement {
           attribute unsigned long span;
         };
@@ -833,7 +833,7 @@ the cell that corresponds to the values of the two dice.
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableSectionElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableSectionElement : HTMLElement {
           [SameObject] readonly attribute HTMLCollection rows;
           HTMLElement insertRow(optional long index = -1);
@@ -1076,7 +1076,7 @@ the cell that corresponds to the values of the two dice.
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableRowElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableRowElement : HTMLElement {
           readonly attribute long rowIndex;
           readonly attribute long sectionRowIndex;
@@ -1234,7 +1234,7 @@ the cell that corresponds to the values of the two dice.
 
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableDataCellElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableDataCellElement : HTMLTableCellElement {};
       </pre>
     </dd>
@@ -1287,7 +1287,7 @@ the cell that corresponds to the values of the two dice.
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableHeaderCellElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTableHeaderCellElement : HTMLTableCellElement {
           attribute DOMString scope;
           attribute DOMString abbr;
@@ -1465,7 +1465,7 @@ the cell that corresponds to the values of the two dice.
   The <code>td</code> and <{th}> elements implement interfaces that inherit from the
   <code>HTMLTableCellElement</code> interface:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="HTMLTableCellElement">
+  <pre class="idl" data-highlight="webidl">
     interface HTMLTableCellElement : HTMLElement {
       attribute unsigned long colSpan;
       attribute unsigned long rowSpan;

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -45,7 +45,7 @@
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLAnchorElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLAnchorElement : HTMLElement {
           attribute DOMString target;
           attribute DOMString download;
@@ -1790,7 +1790,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLDataElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLDataElement : HTMLElement {
           attribute DOMString value;
         };
@@ -1855,7 +1855,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLTimeElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLTimeElement : HTMLElement {
           attribute DOMString dateTime;
         };
@@ -3061,7 +3061,7 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLSpanElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLSpanElement : HTMLElement {};
       </pre>
     </dd>
@@ -3110,7 +3110,7 @@ wormhole connection.&lt;/mark&gt;&lt;/p&gt;
     <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
-      <pre class="idl" data-highlight="webidl" dfn-for="HTMLBRElement">
+      <pre class="idl" data-highlight="webidl">
         interface HTMLBRElement : HTMLElement {};
       </pre>
     </dd>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -456,7 +456,7 @@
     <tr> <td> <code>show</code> <td> <a>XLink namespace</a> <td> <code>xlink:show</code>
     <tr> <td> <code>title</code> <td> <a>XLink namespace</a> <td> <code>xlink:title</code>
     <tr> <td> <code>type</code> <td> <a>XLink namespace</a> <td> <code>xlink:type</code>
-    <tr> <td> <code>base</code> <td> <a>XML namespace</a>  <td> <code>xml:base</code>
+    <tr> <td> <code>base</code> <td> <a>XML namespace</a>  <td> <{global/xml:base}>
     <tr> <td> <{global/lang}> <td> <a>XML namespace</a> <td> <{xml/lang|xml:lang}>
     <tr> <td> <code>space</code> <td> <a>XML namespace</a> <td> <code>xml:space</code>
     <tr> <td> <code>xmlns</code> <td> <a>XMLNS namespace</a> <td> <code>xmlns</code>

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -944,7 +944,7 @@
 
 <h6 id="the-errorevent-interface">The <code>ErrorEvent</code> interface</h6>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ErrorEvent">
+  <pre class="idl" data-highlight="webidl">
     [Constructor(DOMString type, optional ErrorEventInit eventInitDict), Exposed=(Window, Worker)]
     interface ErrorEvent : Event {
       readonly attribute DOMString message;
@@ -955,7 +955,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ErrorEventInit">
+  <pre class="idl" data-highlight="webidl">
     dictionary ErrorEventInit : EventInit {
       DOMString message = "";
       DOMString filename = "";
@@ -1575,7 +1575,7 @@
   The {{EventHandler}} callback function type represents a callback used for event handlers. It is
   represented in Web IDL as follows:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="EventHandlerNonNull">
+  <pre class="idl" data-highlight="webidl">
     [TreatNonObjectAsNull]
     callback EventHandlerNonNull = any (Event event);
     typedef EventHandlerNonNull? EventHandler;
@@ -1601,7 +1601,7 @@
 
   For historical reasons, the {{GlobalEventHandlers/onerror}} handler has different arguments:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="OnErrorEventHandlerNonNull">
+  <pre class="idl" data-highlight="webidl">
     [TreatNonObjectAsNull]
     callback OnErrorEventHandlerNonNull = any ((Event or DOMString) event, optional DOMString source, optional unsigned long lineno, optional unsigned long column, optional any error);
     typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;
@@ -1609,7 +1609,7 @@
 
   Similarly, the {{OnBeforeUnloadEventHandler/onbeforeunload}} handler has a different return value:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="OnBeforeUnloadEventHandlerNonNull">
+  <pre class="idl" data-highlight="webidl">
     [TreatNonObjectAsNull]
     callback OnBeforeUnloadEventHandlerNonNull = DOMString? (Event event);
     typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
@@ -1845,7 +1845,7 @@
 
 <h6 id="idl-definitions">IDL definitions</h6>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="GlobalEventHandlers">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface GlobalEventHandlers {
       attribute EventHandler onabort;
@@ -1911,7 +1911,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="WindowEventHandlers">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface WindowEventHandlers {
       attribute EventHandler onafterprint;
@@ -1932,7 +1932,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="DocumentAndElementEventHandlers">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface DocumentAndElementEventHandlers {
       attribute EventHandler oncopy;
@@ -1989,7 +1989,7 @@
     {{WindowOrWorkerGlobalScope}} { … };</code> along with an appropriate reference.
   </p>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="WindowOrWorkerGlobalScope">
+  <pre class="idl" data-highlight="webidl">
     typedef (DOMString or Function) TimerHandler;
 
     [NoInterfaceObject, Exposed=(Window, Worker)]
@@ -3286,7 +3286,7 @@
   method).
   </p>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="WindowModal">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface WindowModal {
       readonly attribute any dialogArguments;
@@ -3352,7 +3352,7 @@
   which represents the identity and state of the user agent (the client), and allows Web pages to
   register themselves as potential protocol and content handlers:
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Navigator">
+  <pre class="idl" data-highlight="webidl">
     interface Navigator {
       // objects implementing this interface also implement the interfaces given below
     };
@@ -3369,7 +3369,7 @@
 
 <h5 id="client-identification">Client identification</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorID">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject, Exposed=(Window, Worker)]
     interface NavigatorID {
       [Exposed=Window] readonly attribute DOMString appCodeName; // constant "Mozilla"
@@ -3467,7 +3467,7 @@
 
 <h5 id="language-preferences">Language preferences</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorLanguage">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject, Exposed=(Window, Worker)]
     interface NavigatorLanguage {
       readonly attribute DOMString? language;
@@ -3549,7 +3549,7 @@
 
 <h5 id="custom-scheme-and-content-handlers-the-registerprotocolhandler-and-registercontenthandler-methods">Custom scheme and content handlers: the <code>registerProtocolHandler()</code> and <code>registerContentHandler()</code> methods</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorContentUtils">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface NavigatorContentUtils {
       // content handler registration
@@ -4104,7 +4104,7 @@
 
 <h5 id="cookies">Cookies</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorCookies">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
     interface NavigatorCookies {
       readonly attribute boolean cookieEnabled;
@@ -4122,7 +4122,7 @@
 
 <h5 id="plugins">Plugins</h5>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="NavigatorPlugins">
+  <pre class="idl" data-highlight="webidl">
     [NoInterfaceObject]
       interface NavigatorPlugins {
       [SameObject] readonly attribute PluginArray plugins;
@@ -4131,7 +4131,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="PluginArray">
+  <pre class="idl" data-highlight="webidl">
     interface PluginArray {
       void refresh(optional boolean reload = false);
       readonly attribute unsigned long length;
@@ -4140,7 +4140,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="MimeTypeArray">
+  <pre class="idl" data-highlight="webidl">
     interface MimeTypeArray {
       readonly attribute unsigned long length;
       getter MimeType? item(unsigned long index);
@@ -4148,7 +4148,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="Plugin">
+  <pre class="idl" data-highlight="webidl">
     interface Plugin {
       readonly attribute DOMString name;
       readonly attribute DOMString description;
@@ -4159,7 +4159,7 @@
     };
   </pre>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="MimeType">
+  <pre class="idl" data-highlight="webidl">
     interface MimeType {
       readonly attribute DOMString type;
       readonly attribute DOMString description;
@@ -4529,7 +4529,7 @@
 
 <h3 id="webappapis-images">Images</h3>
 
-  <pre class="idl" data-highlight="webidl" dfn-for="ImageBitmap">
+  <pre class="idl" data-highlight="webidl">
     [Exposed=(Window, Worker)]
     interface ImageBitmap {
       readonly attribute unsigned long width;


### PR DESCRIPTION
This addresses the master branch only (see issue https://github.com/w3c/html/issues/707). Note, only FATAL ERRORs are addressed--there are still numerous WARNING-level issues to tackle. These will be addressed by https://github.com/w3c/html/issues/726.

The most substantive change is to merge the multiple definitions of the `<source>` element back into one. This is in alignment with the WHATWG. It never made sense to try to track two separate definitions of the `<source>` element, and this change fixes that by merging them.

Other minor changes include how IDL blocks don't need to use the `for` attribute, and some typos and duplicated information. The spec is still not using the latest bikeshed to build from (it's using the dated snapshot). We may not want to freshen that snapshot in the build system until all the warnings are also fixed.