### PR TITLE
Add the <iframe> allowpaymentrequest attribute

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1358,6 +1358,11 @@
 
       * <dfn>Is environment settings object a secure context?</dfn>
 
+  : Payment Request API
+  :: The following term is defined in the <cite>Payment Request API</cite> specification: [[!PAYMENT-REQUEST]]
+
+      * <dfn><code>PaymentRequest</code></dfn> interface
+
   : MathML
   :: While support for MathML as a whole is not required by this specification (though it is
       encouraged, at least for Web browsers), certain features depend upon small parts of MathML

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3584,6 +3584,9 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd><{iframe/sandbox}> - Security rules for nested content</dd>
     <dd><code>allowfullscreen</code> - Whether to allow the <code>iframe</code>'s
     contents to use <code>requestFullscreen()</code></dd>
+    <dd><{iframe/allowpaymentrequest}> - Whether the <code>iframe</code>'s
+    contents are allowed to use the <a><code>PaymentRequest</code></a> interface
+    to make payment requests</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
     <dt>Allowed <a href="#aria-role-attribute">ARIA role attribute</a> values:</dt>
@@ -3601,6 +3604,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
           attribute DOMString name;
           [SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
           attribute boolean allowFullscreen;
+          attribute boolean allowPaymentRequest;
           attribute DOMString width;
           attribute DOMString height;
           readonly attribute Document? contentDocument;
@@ -4024,6 +4028,14 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
 
   <hr />
 
+  The <dfn element-attr for="iframe"><code>allowpaymentrequest</code></dfn>
+  attribute is a <a>boolean attribute</a>. When specified, it indicates that
+  {{Document}} objects in the <{iframe}> element's <a>browsing context</a>
+  are to be allowed to use the <a><code>PaymentRequest</code></a> interface
+  to make payment requests.
+
+  <hr />
+
   The <{iframe}> element supports <a>dimension attributes</a> for cases where the
   embedded content has specific dimensions (e.g., ad units have well-defined dimensions).
 
@@ -4065,6 +4077,9 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   The <dfn attribute for="HTMLIFrameElement"><code>allowFullscreen</code></dfn> IDL attribute
   must <a>reflect</a> the <code>allowfullscreen</code>
   content attribute.
+
+  The <dfn attribute for="HTMLIFrameElement"><code>allowPaymentRequest</code></dfn> IDL
+  attribute must <a>reflect</a> the <code>allowpaymentrequest</code> content attribute.
 
   The <dfn attribute for="HTMLIFrameElement"><code>contentDocument</code></dfn> IDL attribute must
   return the {{Document}} object of the <a>active document</a> of the <{iframe}> element's


### PR DESCRIPTION
The `allowpaymentrequest` attribute is used by the Payment Request API to determine if Document objects in an `iframe` element's browsing context are to be allowed to make payment requests.

See https://github.com/w3c/browser-payment-api/issues/311
See also https://github.com/w3c/browser-payment-api/pull/359