### PR TITLE
Revert minor breakages in syntax.include

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -141,19 +141,19 @@
     <tbody>
     <tr>
       <td> <code>-//W3C//DTD&nbsp;HTML&nbsp;4.0//EN</code>
-      <td> <code>https://www.w3.org/TR/REC-html40/strict.dtd</code>
+      <td> <code>http://www.w3.org/TR/REC-html40/strict.dtd</code>
       <td> Yes
     <tr>
       <td> <code>-//W3C//DTD&nbsp;HTML&nbsp;4.01//EN</code>
-      <td> <code>https://www.w3.org/TR/html4/strict.dtd</code>
+      <td> <code>http://www.w3.org/TR/html4/strict.dtd</code>
       <td> Yes
     <tr>
       <td> <code>-//W3C//DTD&nbsp;XHTML&nbsp;1.0&nbsp;Strict//EN</code>
-      <td> <code>https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd</code>
+      <td> <code>http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd</code>
       <td> No
     <tr>
       <td> <code>-//W3C//DTD&nbsp;XHTML&nbsp;1.1//EN</code>
-      <td> <code>https://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd</code>
+      <td> <code>http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd</code>
       <td> No
   </table>
 
@@ -1109,7 +1109,7 @@
 
 <h4 id="the-input-byte-stream">The <dfn>input byte stream</dfn></h4>
 
-  The stream of Unicode code points that comprizes the input to the tokenization stage will be
+  The stream of Unicode code points that comprises the input to the tokenization stage will be
   initially seen by the user agent as a stream of bytes (typically coming over the network or from
   the local file system). The bytes encode the actual characters according to a particular
   <i>character encoding</i>, which the user agent uses to decode the bytes into characters.
@@ -6820,7 +6820,7 @@
   This algorithm's name, the "adoption agency algorithm", comes from the way it
   causes elements to change parents, and is in contrast with other possible algorithms for dealing
   with misnested content, which included the "incest algorithm", the "secret affair algorithm", and
-  the "Heizenberg algorithm".
+  the "Heisenberg algorithm".
   </p>
 
 <h6 id="sec-the-text-insertion-mode"><dfn lt="the text insertion mode">The "text" insertion mode</dfn></h6>


### PR DESCRIPTION
* Fix broken system identifiers noted in #754
* That's not how you spell comprises (even in US English)
* That's not how you spell Heisenberg

I noticed these changes while reviewing a diff between HTML 5.0 and 5.1. They were all correct in HTML 5.0. They are specific to the W3C version of the standard.