### PR TITLE
syntax.include sync

### DIFF
--- a/includes/entities.include
+++ b/includes/entities.include
@@ -1,9 +1,7 @@
-﻿<div>
-
-<table>
+﻿<table>
   <thead>
     <tr>
-      <th>Name</th>
+      <th> Name</th>
       <th> Character(s)</th>
       <th> Glyph </th>
     </tr>
@@ -2242,5 +2240,3 @@
     <tr id="entity-zwnj"> <td> <code>zwnj;</code> </td> <td> U+0200C </td> <td> <span class="glyph">‌</span> </td> </tr>
   </tbody>
 </table>
-
-</div>

--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -3133,7 +3133,7 @@
 
       If the <var>replacement flag</var> is set or the <a>browsing context</a>'s
       <a>session history</a> contains only one {{Document}}, and that was the
-      <code>about:blank</code> {{Document}} created when the <a>browsing context</a> was created,
+      <a scheme><code>about:blank</code></a> {{Document}} created when the <a>browsing context</a> was created,
       then the navigation must be done with <a>replacement enabled</a>.
 
   The <dfn attribute for="Location"><code>href</code></dfn> attribute's getter must run these steps:

--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -1391,7 +1391,7 @@
     <{form}>, <{frameset}>, <{img}>, or <{object}> elements that
     have a <code>name</code> content attribute whose value is <var>name</var>, or</li>
 
-    <li><a>html elements</a> that have an <{global/id}> content attribute
+    <li><a>HTML elements</a> that have an <{global/id}> content attribute
     whose value is <var>name</var>.</li>
 
   </ul>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -304,7 +304,7 @@
       that is a child of the [=document element=]. [[!SVG]]
   2. Otherwise, let |value| be the [=child text content=] of the <{title}> element, or the empty
       string if the <{title}> element is null.
-  3. [=Strip and collapse whitespace=] in |value|.
+  3. [=Strip and collapse white space=] in |value|.
   4. Return |value|.
 
   On setting, the steps corresponding to the first matching condition in the following list must be 
@@ -740,17 +740,17 @@
   The [=space characters=] are always allowed between elements. User agents represent these
   characters between elements in the source markup as {{Text}} nodes in the DOM. Empty {{Text}} 
   nodes and {{Text}} nodes consisting of just sequences of those characters are considered 
-  <dfn>inter-element whitespace</dfn>.
+  <dfn>inter-element white space</dfn>.
 
-  [=Inter-element whitespace=], comment nodes, and processing instruction nodes must be ignored when 
+  [=Inter-element white space=], comment nodes, and processing instruction nodes must be ignored when 
   establishing whether an element's contents match the element's content model or not, and must
   be ignored when following algorithms that define document and element semantics.
 
   <p class="note">Thus, an element |A| is said to be <i>preceded or followed</i> by a second element
   |B| if |A| and |B| have the same parent node and there are no other element nodes or {{Text}}
-  nodes (other than [=inter-element whitespace=]) between them. Similarly, a node is the
+  nodes (other than [=inter-element white space=]) between them. Similarly, a node is the
   <i>only child</i> of an element if that element contains no other nodes other than
-  [=inter-element whitespace=], comment nodes, and processing instruction nodes.</p>
+  [=inter-element white space=], comment nodes, and processing instruction nodes.</p>
 
   Authors must not use [=HTML elements=] anywhere except where they are explicitly allowed, as
   defined for each element, or as explicitly required by other specifications. For XML compound
@@ -783,7 +783,7 @@
 <h5 id="the-nothing-content-model">The "nothing" content model</h5>
 
   When an element's content model is <dfn>nothing</dfn>, the element must contain no {{Text}} nodes
-  (other than [=inter-element whitespace=]) and no element nodes.
+  (other than [=inter-element white space=]) and no element nodes.
 
   <p class="note">Most HTML elements whose content model is "nothing" are also, for convenience,
   [=void elements=] (elements that have no [=end tag=] in the [[#syntax|HTML syntax]]). However, 
@@ -1062,7 +1062,7 @@
 
   <dfn id="text-content" lt="text|text content">Text</dfn>, in the context of content models, means
   either nothing, or {{Text}} nodes. [=Text=] is sometimes used as a content model on its own, but 
-  is also [=phrasing content=], and can be [=inter-element whitespace=] (if the {{Text}} nodes are 
+  is also [=phrasing content=], and can be [=inter-element white space=] (if the {{Text}} nodes are 
   empty or contain just [=space characters=]).
 
   {{Text}} nodes and attribute values must consist of [=Unicode characters=], must not contain
@@ -1220,7 +1220,7 @@
     <li><{ul}> (if the element's children include at least one <{li}> element)
     <li><{var}>
     <li><{video}>
-    <li>[=text=] that is not [=inter-element whitespace=]
+    <li>[=text=] that is not [=inter-element white space=]
   </ul>
 
 <h6 id="script-supporting-elements">Script-supporting elements</h6>
@@ -1284,7 +1284,7 @@
   <div class="example">
     In the following example, there are two paragraphs in a section. There is also a heading, which 
     contains phrasing content that is not a paragraph. Note how the comments and
-    [=inter-element whitespace=] do not form paragraphs.
+    [=inter-element white space=] do not form paragraphs.
 
     <pre highlight="html">
       &lt;section>
@@ -1327,7 +1327,7 @@
   [=phrasing content=] nodes uninterrupted by other types of content, in an element that accepts
   content other than [=phrasing content=] as well as [=phrasing content=], let |first| be the first 
   node of the run, and let |last| be the last node of the run. For each such run that consists of at 
-  least one node that is neither [=embedded content=] nor [=inter-element whitespace=], a paragraph 
+  least one node that is neither [=embedded content=] nor [=inter-element white space=], a paragraph 
   exists in the original DOM from immediately before |first| to immediately after |last|. 
   (Paragraphs can thus span across <{a}>, <{ins}>, <{del}>, and <{map}> elements.)
 
@@ -1625,7 +1625,7 @@
 
   The XML specification also allows the use of the <{xml/space|xml:space}> attribute in the
   [=XML namespace=] on any element in an [=XML document=]. This attribute has no effect on
-  [=HTML elements=], as the default behavior in HTML is to preserve whitespace. [[!XML]]
+  [=HTML elements=], as the default behavior in HTML is to preserve white space. [[!XML]]
 
   <p class="note">There is no way to serialize the <{xml/space|xml:space}> attribute on
   [=HTML elements=] in the <code>[[#text-html|text/html]]</code> syntax.</p>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -8,6 +8,7 @@
 ██     ██ ██     ██ ██     ██
 ████████   ███████  ██     ██
 -->
+<!-- This section ostensibly kept up to date by travil@microsoft.com -->
 
 <h2 id="dom">Semantics, structure, and APIs of HTML documents</h2>
 

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -13,7 +13,7 @@
 
 <h3 id="the-hidden-attribute">The <dfn element-attr for="global"><code>hidden</code></dfn> attribute</h3>
 
-  All <a>html elements</a> may have the <{global/hidden}> content attribute set. The
+  All <a>HTML elements</a> may have the <{global/hidden}> content attribute set. The
   <{global/hidden}> attribute is a <a>boolean attribute</a>. When specified on an element, it
   indicates that the element is not yet, or is no longer, directly relevant to the page's current
   state, or that it is being used to declare content to be reused by other parts of the page as
@@ -1653,7 +1653,7 @@
 
 <h4 id="the-accesskey-attribute">The <code>accesskey</code> attribute</h4>
 
-  All <a>html elements</a> may have the <dfn element-attr for="global"><code>accesskey</code></dfn>
+  All <a>HTML elements</a> may have the <dfn element-attr for="global"><code>accesskey</code></dfn>
   content attribute set. The <{global/accesskey}> attribute's value is used
   by the user agent as a guide for creating a keyboard shortcut that activates or focuses the
   element.
@@ -1846,7 +1846,7 @@
 
   Authors are encouraged to set the 'white-space' property on <a>editing
   hosts</a> and on markup that was originally created through these editing mechanisms to the
-  value ''pre-wrap''. Default HTML whitespace handling is not well suited to WYSIWYG editing, and line
+  value ''pre-wrap''. Default HTML white space handling is not well suited to WYSIWYG editing, and line
   wrapping will not work correctly in some corner cases if 'white-space' is left at its default
   value.
 
@@ -3839,7 +3839,7 @@
 
 <h4 id="the-draggable-attribute">The <code>draggable</code> attribute</h4>
 
-  All <a>html elements</a> may have the <dfn element-attr for="global"><code>draggable</code></dfn> content attribute set. The
+  All <a>HTML elements</a> may have the <dfn element-attr for="global"><code>draggable</code></dfn> content attribute set. The
   <{global/draggable}> attribute is an <a>enumerated attribute</a>. It has three states. The first
   state is <i>true</i> and it has the keyword <code>true</code>. The second state is <i>false</i>
   and it has the keyword <code>false</code>. The third state is <i>auto</i>; it has no keywords but
@@ -3885,7 +3885,7 @@
 
 <h4 id="the-dropzone-attribute">The <code>dropzone</code> attribute</h4>
 
-  All <a>html elements</a> may have the <dfn element-attr for="global"><code>dropzone</code></dfn> content attribute set. When specified,
+  All <a>HTML elements</a> may have the <dfn element-attr for="global"><code>dropzone</code></dfn> content attribute set. When specified,
   its value must be an <a>unordered set of unique space-separated tokens</a> that are
   <a>ASCII case-insensitive</a>. The allowed values are the following:
 

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -2241,7 +2241,7 @@
       are all converted to <a>ASCII lowercase</a> by the API.
 
       <p class="note">
-  Strings that contain <a>space characters</a>
+  Strings that contain [=space characters=]
       cannot be used with the <{global/dropzone}> attribute, so authors are
       encouraged to use only <a>MIME types</a> or custom strings (without
       spaces).

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -454,7 +454,7 @@
       <{menu}> (if the <{menu/type}> attribute is in the <a state for="menu">toolbar</a> state);
       <{ol}> (if the element's children include at least one <{li}> element);
       <{ul}> (if the element's children include at least one <{li}> element);
-      <a>Text</a> that is not <a>inter-element whitespace</a>
+      <a>Text</a> that is not <a>inter-element white space</a>
 
     </td>
     </tr>

--- a/sections/iana.include
+++ b/sections/iana.include
@@ -27,11 +27,11 @@
       : <code>charset</code>
       :: The <code>charset</code> parameter may be provided to specify the
           <a>document's character encoding</a>, overriding any
-          <a>character encoding declarations</a> in the document other than a Byte Order Mark (BOM).
+          [=character encoding declarations=] in the document other than a Byte Order Mark (BOM).
           The parameter's value must be one of the <a lt="character encoding">labels</a> of the <a>character encoding</a>
           used to serialize the file. [[!ENCODING]]
   : Encoding considerations:
-  :: 8bit (see the section on <a>character encoding declarations</a>)
+  :: 8bit (see the section on [=character encoding declarations=])
   : Security considerations:
   :: Entire novels have been written about the security considerations that apply to HTML documents.
       Many are listed in this document, to which the reader is referred for more details. Some

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1823,19 +1823,19 @@
       <var>result</var> and advance <var>position</var> to the next character in <var>input</var>.
   4. Return <var>result</var>.
 
-  The step <dfn>skip whitespace</dfn> means that the user agent must
+  The step <dfn>skip white space</dfn> means that the user agent must
   <a>collect a sequence of characters</a> that are [=space characters=]. The collected characters
   are not used.
 
   When a user agent is to <dfn lt="stripped line breaks|strip line breaks">strip line breaks</dfn> from a string, the user agent must remove
   any U+000A LINE FEED (LF) and U+000D CARRIAGE RETURN (CR) characters from that string.
 
-  When a user agent is to <dfn lt="strip leading and trailing whitespace|stripping leading and trailing whitespace|leading and trailing whitespace stripped">strip leading and trailing whitespace</dfn> from a string, the
+  When a user agent is to <dfn lt="strip leading and trailing white space|stripping leading and trailing white space|leading and trailing white space stripped">strip leading and trailing white space</dfn> from a string, the
   user agent must remove all [=space characters=] that are at the start or end of the string.
 
-  When a user agent is to <dfn lt="stripping and collapsing whitespace|strip and collapse whitespace">strip and collapse whitespace</dfn> in a string, it must replace any
+  When a user agent is to <dfn lt="stripping and collapsing white space|strip and collapse white space">strip and collapse white space</dfn> in a string, it must replace any
   sequence of one or more consecutive [=space characters=] in that string with a single U+0020
-  SPACE character, and then <a>strip leading and trailing whitespace</a> from that string.
+  SPACE character, and then <a>strip leading and trailing white space</a> from that string.
 
   When a user agent has to <dfn lt="strictly splitting the string|strictly split a string|strictly split">strictly split a string</dfn> on a particular delimiter character
   <var>delimiter</var>, it must use the following algorithm:
@@ -1852,7 +1852,7 @@
 
   <p class="note">
     For the special cases of splitting a string <a lt="split a string on spaces">on spaces</a> and <a lt="split a string on commas">on commas</a>, this
-    algorithm does not apply (those algorithms also perform <a lt="strip leading and trailing whitespace">whitespace trimming</a>).
+    algorithm does not apply (those algorithms also perform <a lt="strip leading and trailing white space">white space trimming</a>).
   </p>
 
 <h4 id="sec-boolean-attributes">Boolean attributes</h4>
@@ -1862,7 +1862,7 @@
 
   If the attribute is present, its value must either be the empty string or a value that is an
   <a>ASCII case-insensitive</a> match for the attribute's canonical name, with no leading or
-  trailing whitespace.
+  trailing white space.
 
   <p class="note">
     The values "true" and "false" are not allowed on <a>boolean attributes</a>. To represent a false value,
@@ -1896,7 +1896,7 @@
 
   If an enumerated attribute is specified, the attribute's value must be an
   <a>ASCII case-insensitive</a> match for one of the given keywords that are not said to be
-  non-conforming, with no leading or trailing whitespace.
+  non-conforming, with no leading or trailing white space.
 
   When the attribute is specified, if its value is an <a>ASCII case-insensitive</a> match for one of
   the given keywords then that keyword's state is the state that the attribute represents. If the
@@ -1932,7 +1932,7 @@
   2. Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the
       start of the string.
   3. Let <var>sign</var> have the value "positive".
-  4. <a>Skip whitespace</a>.
+  4. <a>Skip white space</a>.
   5. If <var>position</var> is past the end of <var>input</var>, return an error.
   6. If the character indicated by <var>position</var> (the first character) is a U+002D
       HYPHEN-MINUS character (-):
@@ -2017,7 +2017,7 @@
   3. Let <var>value</var> have the value 1.
   4. Let <var>divisor</var> have the value 1.
   5. Let <var>exponent</var> have the value 1.
-  6. <a>Skip whitespace</a>.
+  6. <a>Skip white space</a>.
   7. If <var>position</var> is past the end of <var>input</var>, return an error.
   8. If the character indicated by <var>position</var> is a U+002D HYPHEN-MINUS character (-):
       1. Change <var>value</var> and <var>divisor</var> to -1.
@@ -2100,7 +2100,7 @@
   1. Let <var>input</var> be the string being parsed.
   2. Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start
       of the string.
-  3. <a>Skip whitespace</a>.
+  3. <a>Skip white space</a>.
   4. If <var>position</var> is past the end of <var>input</var>, return an error.
   5. If the character indicated by <var>position</var> is a U+002B PLUS SIGN character (+),
       advance <var>position</var> to the next character.
@@ -2210,7 +2210,7 @@
               2. Let <var>fraction</var> be the result of interpreting <var>s</var> as a base-ten
                   integer, and then dividing that number by 10<sup><var>length</var></sup>.
               3. Increment <var>value</var> by <var>fraction</var>.
-      8. <a>Skip whitespace</a>.
+      8. <a>Skip white space</a>.
       9. If the character at <var>position</var> is a U+0025 PERCENT SIGN character (%), then set
           <var>unit</var> to <i>percentage</i>.
 
@@ -2940,11 +2940,11 @@
         but are parsed for future compatibility and to avoid misinterpreting ISO8601 durations
         that would be valid in other contexts.
       </p>
-  5. <a>Skip whitespace</a>.
+  5. <a>Skip white space</a>.
   6. If <var>position</var> is past the end of <var>input</var>, then fail.
   7. If the character in <var>input</var> pointed to by <var>position</var> is a U+0050 LATIN
       CAPITAL LETTER P character, then advance <var>position</var> to the next character, set
-      <var>M-disambiguator</var> to <i>months</i>, and <a>skip whitespace</a>.
+      <var>M-disambiguator</var> to <i>months</i>, and <a>skip white space</a>.
   8. Run the following substeps in a loop, until a step requiring the loop to be broken or the
       entire algorithm to fail is reached:
       1. Let <var>units</var> be undefined. It will be assigned one of the following values:
@@ -2955,7 +2955,7 @@
       3. If <var>position</var> is past the end of <var>input</var>, then break the loop.
       4. If the character in <var>input</var> pointed to by <var>position</var> is a U+0054 LATIN
           CAPITAL LETTER T character, then advance <var>position</var> to the next character, set
-          <var>M-disambiguator</var> to <i>minutes</i>, <a>skip whitespace</a>, and return to the
+          <var>M-disambiguator</var> to <i>minutes</i>, <a>skip white space</a>, and return to the
           top of the loop.
       5. Set <var>next character</var> to the character in <var>input</var> pointed to by
           <var>position</var>.
@@ -2982,7 +2982,7 @@
           4. Let <var>fraction</var> be the result of interpreting <var>s</var> as a base-ten
               integer, and then dividing that number by 10<sup><var>length</var></sup>.
           5. Increment <var>N</var> by <var>fraction</var>.
-          6. <a>Skip whitespace</a>.
+          6. <a>Skip white space</a>.
           7. If <var>position</var> is past the end of <var>input</var>, then fail.
           8. Set <var>next character</var> to the character in <var>input</var> pointed to by
               <var>position</var>, and advance <var>position</var> to the next character.
@@ -2993,7 +2993,7 @@
           Otherwise, run these substeps:
 
           1. If <var>next character</var> is a <a>space character</a>, then
-              <a>skip whitespace</a>, set <var>next character</var> to the character in
+              <a>skip white space</a>, set <var>next character</var> to the character in
               <var>input</var> pointed to by <var>position</var>, and advance <var>position</var>
               to the next character.
           2. If <var>next character</var> is a U+0059 LATIN CAPITAL LETTER Y character, or a
@@ -3045,7 +3045,7 @@
               <var>units</var> to <i>seconds</i>.
           5. Forcibly, <var>units</var> is now <i>seconds</i>. Add the product of <var>N</var> and
               <var>multiplier</var> to <var>seconds</var>.
-      14. <a>Skip whitespace</a>.
+      14. <a>Skip white space</a>.
 
   9. If <var>component count</var> is zero, fail.
   10. If <var>months</var> is not zero, fail.
@@ -3162,7 +3162,7 @@
 
   1. Let <var>input</var> be the string being parsed.
   2. If <var>input</var> is the empty string, then return an error.
-  3. <a>Strip leading and trailing whitespace</a> from <var>input</var>.
+  3. <a>Strip leading and trailing white space</a> from <var>input</var>.
   4. If <var>input</var> is an <a>ASCII case-insensitive</a> match for the string
       "<code>transparent</code>", then return an error.
   5. If <var>input</var> is an <a>ASCII case-insensitive</a> match for one of the
@@ -3244,11 +3244,11 @@
   2. Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start
       of the string.
   3. Let <var>tokens</var> be an ordered list of tokens, initially empty.
-  4. <a>Skip whitespace</a>
+  4. <a>Skip white space</a>
   5. While <var>position</var> is not past the end of <var>input</var>:
       1. <a>Collect a sequence of characters</a> that are not [=space characters=].
       2. Append the string collected in the previous step to <var>tokens</var>.
-      3. <a>Skip whitespace</a>
+      3. <a>Skip white space</a>
   6. Return <var>tokens</var>.
 
 <h4 id="comma-separated-tokens">Comma-separated tokens</h4>
@@ -3260,7 +3260,7 @@
 
   <p class="example">
     For instance, the string "<code>&nbsp;a&nbsp;,b,d&nbsp;d&nbsp;</code>" consists of four tokens:
-    "a", "b", the empty string, and "d&nbsp;d". Leading and trailing whitespace around each token
+    "a", "b", the empty string, and "d&nbsp;d". Leading and trailing white space around each token
     doesn't count as part of the token, and the empty string can be a token.
   </p>
 
@@ -3279,7 +3279,7 @@
       step.
   5. <a>Collect a sequence of characters</a> that are not U+002C COMMA characters (,). Let
       <var>s</var> be the resulting sequence (which might be the empty string).
-  6. <a>Strip leading and trailing whitespace</a> from <var>s</var>.
+  6. <a>Strip leading and trailing white space</a> from <var>s</var>.
   7. Append <var>s</var> to <var>tokens</var>.
   8. If <var>position</var> is not past the end of <var>input</var>, then the character at
       <var>position</var> is a U+002C COMMA character (,); advance <var>position</var> past that
@@ -3327,10 +3327,10 @@
   the empty string.
 
   A string is a <dfn>valid URL potentially surrounded by spaces</dfn> if, after
-  <a>stripping leading and trailing whitespace</a> from it, it is a <a>valid URL</a>.
+  <a>stripping leading and trailing white space</a> from it, it is a <a>valid URL</a>.
 
   A string is a <dfn>valid non-empty URL potentially surrounded by spaces</dfn> if, after
-  <a>stripping leading and trailing whitespace</a> from it, it is a <a>valid non-empty URL</a>.
+  <a>stripping leading and trailing white space</a> from it, it is a <a>valid non-empty URL</a>.
 
   This specification defines the URL <dfn scheme><code>about:legacy-compat</code></dfn> as a reserved,
   though unresolvable, <a scheme><code>about:</code></a> URL, for use in [=DOCTYPE=]s in <a>HTML documents</a>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1824,17 +1824,17 @@
   4. Return <var>result</var>.
 
   The step <dfn>skip whitespace</dfn> means that the user agent must
-  <a>collect a sequence of characters</a> that are <a>space characters</a>. The collected characters
+  <a>collect a sequence of characters</a> that are [=space characters=]. The collected characters
   are not used.
 
   When a user agent is to <dfn lt="stripped line breaks|strip line breaks">strip line breaks</dfn> from a string, the user agent must remove
   any U+000A LINE FEED (LF) and U+000D CARRIAGE RETURN (CR) characters from that string.
 
   When a user agent is to <dfn lt="strip leading and trailing whitespace|stripping leading and trailing whitespace|leading and trailing whitespace stripped">strip leading and trailing whitespace</dfn> from a string, the
-  user agent must remove all <a>space characters</a> that are at the start or end of the string.
+  user agent must remove all [=space characters=] that are at the start or end of the string.
 
   When a user agent is to <dfn lt="stripping and collapsing whitespace|strip and collapse whitespace">strip and collapse whitespace</dfn> in a string, it must replace any
-  sequence of one or more consecutive <a>space characters</a> in that string with a single U+0020
+  sequence of one or more consecutive [=space characters=] in that string with a single U+0020
   SPACE character, and then <a>strip leading and trailing whitespace</a> from that string.
 
   When a user agent has to <dfn lt="strictly splitting the string|strictly split a string|strictly split">strictly split a string</dfn> on a particular delimiter character
@@ -2151,7 +2151,7 @@
 
   A <dfn>valid list of floating-point numbers</dfn> is a number of
   <a>valid floating-point numbers</a> separated by U+002C COMMA characters, with no other characters
-  (e.g. no <a>space characters</a>). In addition, there might be restrictions on the number of
+  (e.g. no [=space characters=]). In addition, there might be restrictions on the number of
   floating-point numbers that can be given, or on the range of values allowed.
 
   The <dfn>rules for parsing a list of floating-point numbers</dfn> are as follows:
@@ -2161,19 +2161,19 @@
       the string.
   3. Let <var>numbers</var> be an initially empty list of floating-point numbers. This list will be
       the result of this algorithm.
-  4. <a>Collect a sequence of characters</a> that are <a>space characters</a>, U+002C COMMA, or
+  4. <a>Collect a sequence of characters</a> that are [=space characters=], U+002C COMMA, or
       U+003B SEMICOLON characters. This skips past any leading delimiters.
   5. While <var>position</var> is not past the end of <var>input</var>:
-      1. <a>Collect a sequence of characters</a> that are not <a>space characters</a>, U+002C COMMA,
+      1. <a>Collect a sequence of characters</a> that are not [=space characters=], U+002C COMMA,
           U+003B SEMICOLON, <a>ASCII digits</a>, U+002E FULL STOP, or U+002D HYPHEN-MINUS
           characters. This skips past leading garbage.
-      2. <a>Collect a sequence of characters</a> that are not <a>space characters</a>, U+002C COMMA,
+      2. <a>Collect a sequence of characters</a> that are not [=space characters=], U+002C COMMA,
           or U+003B SEMICOLON characters, and let <var>unparsed number</var> be the result.
       3. Let <var>number</var> be the result of parsing <var>unparsed number</var> using the
           <a>rules for parsing floating-point number values</a>.
       4. If <var>number</var> is an error, set <var>number</var> to zero.
       5. Append <var>number</var> to <var>numbers</var>.
-      6. <a>Collect a sequence of characters</a> that are <a>space characters</a>, U+002C COMMA, or
+      6. <a>Collect a sequence of characters</a> that are [=space characters=], U+002C COMMA, or
           U+003B SEMICOLON characters. This skips past the delimiter.
   6. Return <var>numbers</var>.
 
@@ -2201,9 +2201,9 @@
           integer in base ten, and increment <var>value</var> by that integer.
       7. If the character at <var>position</var> is a U+002E FULL STOP character (.), run these
           substeps:
-          1. <a>Collect a sequence of characters</a> consisting of <a>space characters</a> and
+          1. <a>Collect a sequence of characters</a> consisting of [=space characters=] and
               <a>ASCII digits</a>. Let <var>s</var> be the resulting sequence.
-          2. Remove all <a>space characters</a> in <var>s</var>.
+          2. Remove all [=space characters=] in <var>s</var>.
           3. If <var>s</var> is not the empty string, run these subsubsteps:
               1. Let <var>length</var> be the number of characters in <var>s</var> (after the
                   spaces were removed).
@@ -2886,14 +2886,14 @@
 
     A <dfn>duration time component</dfn> is a string consisting of the following components:
 
-      1. Zero or more <a>space characters</a>.
+      1. Zero or more [=space characters=].
       2. One or more <a>ASCII digits</a>, representing a number of time units, scaled by the
           <a>duration time component scale</a> specified (see below) to represent a number of
           seconds.
       3. If the <a>duration time component scale</a> specified is 1 (i.e., the units are seconds),
          then, optionally, a U+002E FULL STOP character (.) followed by one, two, or three
          <a>ASCII digits</a>, representing a fraction of a second.
-      4. Zero or more <a>space characters</a>.
+      4. Zero or more [=space characters=].
       5. One of the following characters, representing the
           <dfn>duration time component scale</dfn> of the time unit used in the numeric part of
           the <a>duration time component</a>:
@@ -2918,7 +2918,7 @@
           : U+0073 LATIN SMALL LETTER S character
           :: Seconds. The scale is 1.
 
-      6. Zero or more <a>space characters</a>.
+      6. Zero or more [=space characters=].
 
       <p class="note">
         This is not based on any of the formats in ISO 8601. It is intended to be a more
@@ -3214,11 +3214,11 @@
 <h4 id="space-separated-tokens">Space-separated tokens</h4>
 
   A <dfn>set of space-separated tokens</dfn> is a string containing zero or more words (known as
-  tokens) separated by one or more <a>space characters</a>, where words consist of any string of one
-  or more characters, none of which are <a>space characters</a>.
+  tokens) separated by one or more [=space characters=], where words consist of any string of one
+  or more characters, none of which are [=space characters=].
 
   A string containing a <a>set of space-separated tokens</a> may have leading or trailing
-  <a>space characters</a>.
+  [=space characters=].
 
   An <dfn>unordered set of unique space-separated tokens</dfn> is a
   <a>set of space-separated tokens</a> where none of the tokens are duplicated.
@@ -3246,7 +3246,7 @@
   3. Let <var>tokens</var> be an ordered list of tokens, initially empty.
   4. <a>Skip whitespace</a>
   5. While <var>position</var> is not past the end of <var>input</var>:
-      1. <a>Collect a sequence of characters</a> that are not <a>space characters</a>.
+      1. <a>Collect a sequence of characters</a> that are not [=space characters=].
       2. Append the string collected in the previous step to <var>tokens</var>.
       3. <a>Skip whitespace</a>
   6. Return <var>tokens</var>.
@@ -3255,8 +3255,8 @@
 
   A <dfn>set of comma-separated tokens</dfn> is a string containing zero or more tokens each
   separated from the next by a single U+002C COMMA character (,), where tokens consist of any string
-  of zero or more characters, neither beginning nor ending with <a>space characters</a>, nor
-  containing any U+002C COMMA characters (,), and optionally surrounded by <a>space characters</a>.
+  of zero or more characters, neither beginning nor ending with [=space characters=], nor
+  containing any U+002C COMMA characters (,), and optionally surrounded by [=space characters=].
 
   <p class="example">
     For instance, the string "<code>&nbsp;a&nbsp;,b,d&nbsp;d&nbsp;</code>" consists of four tokens:
@@ -3313,7 +3313,7 @@
   <code>&lt;media-query-list&gt;</code> production of the Media Queries specification. [[!MEDIAQ]]
 
   A string <dfn lt="match the environment|matches the environment">matches the environment</dfn> of the user if it is the empty string, a string
-  consisting of only <a>space characters</a>, or is a media query list that matches the user's
+  consisting of only [=space characters=], or is a media query list that matches the user's
   environment according to the definitions given in the Media Queries specification. [[!MEDIAQ]]
 
 <h3 id="infrastructure-urls">URLs</h3>
@@ -3333,7 +3333,7 @@
   <a>stripping leading and trailing whitespace</a> from it, it is a <a>valid non-empty URL</a>.
 
   This specification defines the URL <dfn scheme><code>about:legacy-compat</code></dfn> as a reserved,
-  though unresolvable, <a scheme><code>about:</code></a> URL, for use in <a>DOCTYPE</a>s in <a>HTML documents</a>
+  though unresolvable, <a scheme><code>about:</code></a> URL, for use in [=DOCTYPE=]s in <a>HTML documents</a>
   when needed for compatibility with XML tools. [[!RFC6694]]
 
   This specification defines the URL <dfn><code>about:html-kind</code></dfn> as a reserved,
@@ -3694,11 +3694,11 @@
   2. <i>Loop</i>: Find the first seven characters in <var>s</var> after <var>position</var> that
       are an <a>ASCII case-insensitive</a> match for the word "<code>charset</code>". If no such
       match is found, return nothing and abort these steps.
-  3. Skip any <a>space characters</a> that immediately follow the word "<code>charset</code>"
+  3. Skip any [=space characters=] that immediately follow the word "<code>charset</code>"
       (there might not be any).
   4. If the next character is not a U+003D EQUALS SIGN (=), then move <var>position</var> to point
       just before that next character, and jump back to the step labeled <i>loop</i>.
-  5. Skip any <a>space characters</a> that immediately follow the equals sign (there might not be
+  5. Skip any [=space characters=] that immediately follow the equals sign (there might not be
       any).
   6. Process the next character as follows:
       <dl class="switch">

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1791,6 +1791,9 @@
   The <dfn>lowercase ASCII letters</dfn> are the characters in the range U+0061 LATIN SMALL LETTER A
   to U+007A LATIN SMALL LETTER Z.
 
+  The <dfn>ASCII letters</dfn> are the characters that are either [=uppercase ASCII letters=] or
+  [=lowercase ASCII letters=].
+
   The <dfn>ASCII digits</dfn> are the characters in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT
   NINE (9).
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -114,7 +114,7 @@
   those that the resource needs to have available to be correctly processed. Which resources are
   considered critical or not is defined by the specification that defines the resource's format.
 
-<h4 id="xml">XML</h4>
+<h4 id="xml">XML compatibility</h4>
 
   To ease migration from HTML to XHTML, user agents conforming to this specification will place
   elements in HTML in the <code>http://www.w3.org/1999/xhtml</code> namespace, at least for the

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -482,7 +482,7 @@
   <a lt="attribute">Attributes</a> are placed inside the start tag, and consist of a
   <a lt="attribute names">name</a> and a <a lt="attribute values">value</a>, separated by an
   "<code>=</code>" character. The attribute value can remain <a>unquoted</a> if it doesn't contain
-  <a>space characters</a> or any of <code>"</code> <code>'</code> <code>`</code> <code>=</code>
+  [=space characters=] or any of <code>"</code> <code>'</code> <code>`</code> <code>=</code>
   <code>&lt;</code> or <code>&gt;</code>. Otherwise, it has to be quoted using either single or
   double quotes. The value, along with the "<code>=</code>" character, can be omitted altogether if
   the value is the empty string.

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -212,7 +212,7 @@
   * Authors can extend APIs using the JavaScript prototyping mechanism. This is widely used by
     script libraries, for instance.
 
-<h3 id="html-vs-xhtml">HTML vs XHTML</h3>
+<h3 id="html-vs-xhtml">HTML vs XML Syntax</h3>
 
   <em>This section is non-normative.</em>
 

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -567,8 +567,8 @@
   because the source contains a number of spaces (represented here by "&#x2423;") and line breaks
   ("&#x23CE;") that all end up as {{Text}} nodes in the DOM. However, for historical
   reasons not all of the spaces and line breaks in the original markup appear in the DOM. In
-  particular, all the whitespace before <{head}> start tag ends up being dropped silently, and all
-  the whitespace after the <{body}> end tag ends up placed at the end of the <{body}>.
+  particular, all the white space before <{head}> start tag ends up being dropped silently, and all
+  the white space after the <{body}> end tag ends up placed at the end of the <{body}>.
 
   The <{head}> element contains a <{title}> element, which itself
   contains a {{Text}} node with the text "Sample page". Similarly, the <{body}> element

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -42,7 +42,7 @@
   useful width.
 
   <p class="note">
-    In <a href="#syntax">the HTML syntax</a>, specifying a <a>DOCTYPE</a> that is an <a>obsolete permitted
+    In <a href="#syntax">the HTML syntax</a>, specifying a [=DOCTYPE=] that is an <a>obsolete permitted
     DOCTYPE</a> will also trigger a warning.
   </p>
 

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -721,7 +721,7 @@
   <a attribute for="GlobalEventHandlers"><code>onresize</code></a>, and
   <a attribute for="GlobalEventHandlers"><code>onscroll</code></a> <a>event handlers</a> of the
   {{Window}} object, exposed on the <{frameset}> element, replace the generic <a>event handlers</a>
-  with the same names normally supported by <a>html elements</a>.
+  with the same names normally supported by <a>HTML elements</a>.
 
   <hr />
 

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -764,7 +764,7 @@
 
   Similarly, if the [=nested browsing context=]'s [=session history=] contained
   only one {{Document}} when the <a>process the <code>frame</code> attributes</a>
-  algorithm was invoked, and that was the [=<code>about:blank</code>=] {{Document}} created
+  algorithm was invoked, and that was the <a scheme><code>about:blank</code></a> {{Document}} created
   when the [=nested browsing context=] was created, then any [=navigation=] required of the
   user agent in that algorithm must be completed with [=replacement enabled=].
 

--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -61,7 +61,7 @@
 
   The CSS rules given in these subsections are, except where otherwise specified, expected to be
   used as part of the user-agent level style sheet defaults for all documents that contain
-  <a>html elements</a>.
+  <a>HTML elements</a>.
 
   Some rules are intended for the author-level zero-specificity presentational hints part of the
   CSS cascade; these are explicitly called out as <dfn>presentational hints</dfn>.
@@ -437,7 +437,7 @@
     <li>Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the
     start of the string.</li>
 
-    <li><a>Skip whitespace</a>.</li>
+    <li><a>Skip white space</a>.</li>
 
     <li>If <var>position</var> is past the end of <var>input</var>, there is no <a>presentational hint</a>. Abort these steps.</li>
 
@@ -1022,7 +1022,7 @@ path: includes/cldr.include
 <h4 id="margin-collapsing-quirks">Margin collapsing quirks</h4>
 
   A node is <dfn>substantial</dfn> if it is a text node
-  that is not <a>inter-element whitespace</a>, or if it is an element node.
+  that is not <a>inter-element white space</a>, or if it is an element node.
 
   A node is <dfn>blank</dfn> if it is an element that contains no
   <a>substantial</a> nodes.

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -1136,7 +1136,7 @@
         3. Let <var>input</var> be the value of the element's <code>content</code> attribute.
         4. Let <var>position</var> point at the first character of <var>input</var>.
         5. <a>Skip whitespace</a>.
-        6. <a>Collect a sequence of characters</a> that are not <a>space characters</a>.
+        6. <a>Collect a sequence of characters</a> that are not [=space characters=].
         7. Let <var>candidate</var> be the string that resulted from the previous step.
         8. If <var>candidate</var> is the empty string, abort these steps.
         9. Set the <a>pragma-set default language</a> to <var>candidate</var>.
@@ -1160,7 +1160,7 @@
 
       For <{meta}> elements with an <code>http-equiv</code> attribute in the <a state for="http-equiv">encoding declaration state</a>, the <code>content</code> attribute must have a value that is an
       <a>ASCII case-insensitive</a> match for a string that consists of: the literal string
-      "<code>text/html;</code>", optionally followed by any number of <a>space characters</a>,
+      "<code>text/html;</code>", optionally followed by any number of [=space characters=],
       followed by the literal string "<code>charset=</code>", followed by one of the <a lt="character encoding">labels</a>
       of the <a>character encoding</a> of the <a>character encoding declaration</a>.
 
@@ -1283,7 +1283,7 @@
 
       * just a <a>valid non-negative integer</a>, or
       * a <a>valid non-negative integer</a>, followed by a U+003B SEMICOLON character (;), followed
-        by one or more <a>space characters</a>, followed by a substring that is an
+        by one or more [=space characters=], followed by a substring that is an
         <a>ASCII case-insensitive</a> match for the string "<code>URL</code>", followed by a U+003D
         EQUALS SIGN character (=), followed by a <a>valid URL</a> that does not start with a literal
         U+0027 APOSTROPHE (') or U+0022 QUOTATION MARK (") character.
@@ -1394,7 +1394,7 @@
   A <dfn>character encoding declaration</dfn> is a mechanism by which the <a>character encoding</a>
   used to store or transmit a document is specified.
 
-  The following restrictions apply to <a>character encoding declarations</a>:
+  The following restrictions apply to [=character encoding declarations=]:
 
   * The character encoding name given must be an <a>ASCII case-insensitive</a> match for one of the
       <a lt="character encoding">labels</a> of the <a>character encoding</a> used to serialize the file. [[!ENCODING]]

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -100,7 +100,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>In a <{head}> element containing no other <{title}> elements.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Text</a> that is not <a>inter-element whitespace</a>.</dd>
+    <dd><a>Text</a> that is not <a>inter-element white space</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -227,7 +227,7 @@
   contain a <a>valid URL potentially surrounded by spaces</a>.
 
   A <{base}> element, if it has an <{base/href}> attribute, must come before any other elements in
-  the tree that have attributes defined as taking <a for="url">URLs</a>, except the <{html}> element 
+  the tree that have attributes defined as taking <a for="url">URLs</a>, except the <{html}> element
   (its <{html/manifest}> attribute isn't affected by <{base}> elements).
 
   <div class="impl">
@@ -465,7 +465,7 @@
   which indicates that the current document is the table of contents document for every chapter.
 
   </div>
-  
+
   <p>The <dfn element-attr for="link"><code>nonce</code></dfn> attribute represents a
   cryptographic nonce ("number used once") which can be used by <cite>Content Security Policy</cite>
   to determine whether or not an external resource specified by the link will be loaded and applied
@@ -822,28 +822,28 @@
   The <dfn element-attr for="meta"><code>content</code></dfn> attribute gives the value of the
   document metadata or pragma directive when the element is used for those purposes. The allowed
   values depend on the exact context, as described in subsequent sections of this specification.
-  
+
   <div class="warning">
-  
+
   <p><a href="https://www.w3.org/TR/css-device-adapt-1/#viewport-meta"><code>&lt;meta name="viewport" content="..."></code></a>
   allows authors to define specific viewport characteristics (such as the layout viewport's width and zoom factor)
   for their documents. Among these is the ability to prevent or restrict users from being able to zoom, using
   <code>content</code> values such as <code>user-scalable=no</code> or <code>maximum-scale=1.0</code>. Authors should not suppress
   or limit the ability of users to resize a document, as this causes accessibility and usability issues.</p>
-  
+
   <div class="example">
   The following examples illustrate code that should be avoided:
   <pre highlight="html">
-  
+
    &lt;!-- DO NOT DO THIS -->
-  
+
    &lt;meta name="viewport" content="<mark>user-scalable=no</mark>">
 
    &lt;meta name="viewport" content="width=device-width, initial-scale=1.0, <mark>maximum-scale=1.0</mark>">
   </pre>
   </div>
-  
-  <p>There may be specific use cases where preventing users from zooming may be appropriate, such as map applications – 
+
+  <p>There may be specific use cases where preventing users from zooming may be appropriate, such as map applications –
   where custom zoom functionality is handled via scripting.
   However, in general this practice should be avoided, and HTML conformance checking tools should display a warning if
   they encounter these values.</p>
@@ -1135,7 +1135,7 @@
             then abort these steps.
         3. Let <var>input</var> be the value of the element's <code>content</code> attribute.
         4. Let <var>position</var> point at the first character of <var>input</var>.
-        5. <a>Skip whitespace</a>.
+        5. <a>Skip white space</a>.
         6. <a>Collect a sequence of characters</a> that are not [=space characters=].
         7. Let <var>candidate</var> be the string that resulted from the previous step.
         8. If <var>candidate</var> is the empty string, abort these steps.
@@ -1198,7 +1198,7 @@
             attribute's value is the empty string, then abort these steps.
         3. Let <var>input</var> be the value of the element's <code>content</code> attribute.
         4. Let <var>position</var> point at the first character of <var>input</var>.
-        5. <a>Skip whitespace</a>.
+        5. <a>Skip white space</a>.
         6. <a>Collect a sequence of characters</a> that are <a>ASCII digits</a>, and parse the
             resulting string using the <a>rules for parsing non-negative integers</a>. If the
             sequence of characters collected is the empty string, then no number will have been
@@ -1212,11 +1212,11 @@
         10. If the character in <var>input</var> pointed to by <var>position</var> is not a U+003B
             SEMICOLON character (;), a U+002C COMMA character (,), or a <a>space character</a>, then
             abort these steps.
-        11. <a>Skip whitespace</a>.
+        11. <a>Skip white space</a>.
         12. If the character in <var>input</var> pointed to by <var>position</var> is a U+003B
             SEMICOLON character (;), a U+002C COMMA character (,), then advance <var>position</var>
             to the next character.
-        13. <a>Skip whitespace</a>.
+        13. <a>Skip white space</a>.
         14. If <var>position</var> is past the end of <var>input</var>, jump to the step labeled
             <i>end</i>.
         15. Let <var>url</var> be equal to the substring of <var>input</var> from the character at
@@ -1233,11 +1233,11 @@
             CAPITAL LETTER L character (L) or a U+006C LATIN SMALL LETTER L character (l), then
             advance <var>position</var> to the next character. Otherwise, jump to the step labeled
             <var>Parse</var>.
-        19. <a>Skip whitespace</a>.
+        19. <a>Skip white space</a>.
         20. If the character in <var>input</var> pointed to by <var>position</var> is a U+003D
             EQUALS SIGN (=), then advance <var>position</var> to the next character. Otherwise, jump
             to the step step labeled <var>Parse</var>.
-        21. <a>Skip whitespace</a>.
+        21. <a>Skip white space</a>.
         22. <i>Skip quotes</i>: If the character in <var>input</var> pointed to by
             <var>position</var> is either a U+0027 APOSTROPHE character (') or U+0022 QUOTATION MARK
             character ("), then let <var>quote</var> be that character, and advance

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -507,9 +507,9 @@
     <dd>The <dfn element-attr for="source"><code>srcset</code></dfn> content attribute must be 
     present, and must consist of one or more <a>image candidate strings</a>, each separated from the 
     next by a U+002C COMMA character (,). If an <a>image candidate string</a> contains no 
-    descriptors and no <a>space characters</a> after the URL, the following 
+    descriptors and no [=space characters=] after the URL, the following 
     <a>image candidate string</a>, if there is one, must begin with one or more 
-    <a>space characters</a>.
+    [=space characters=].
 
     If the <{source/srcset}> attribute has any <a>image candidate strings</a> using a 
     <a>width descriptor</a>, the 
@@ -758,22 +758,22 @@
   <a>image candidate strings</a>,
   each separated from the next by a U+002C COMMA character (,).
   If an <a>image candidate string</a> contains no descriptors
-  and no <a>space characters</a> after the URL,
+  and no [=space characters=] after the URL,
   the following <a>image candidate string</a>, if there is one,
-  must begin with one or more <a>space characters</a>.
+  must begin with one or more [=space characters=].
 
   An <dfn>image candidate string</dfn> consists of the following components, in order, with the
   further restrictions described below this list:
 
   <ol>
 
-    <li>Zero or more <a>space characters</a>.</li>
+    <li>Zero or more [=space characters=].</li>
 
     <li>A <a>valid non-empty URL</a> that does not start or end with a U+002C COMMA character (,),
     referencing a non-interactive, optionally animated, image resource
     that is neither paged nor scripted.</li>
 
-    <li>Zero or more <a>space characters</a>.</li>
+    <li>Zero or more [=space characters=].</li>
 
     <li>
 
@@ -797,7 +797,7 @@
 
     </li>
 
-    <li>Zero or more <a>space characters</a>.</li>
+    <li>Zero or more [=space characters=].</li>
 
   </ol>
 
@@ -1636,14 +1636,14 @@
     <li>Let <var>candidates</var> be an initially empty <a>source set</a>.</li>
 
     <li><i>Splitting loop</i>: <a>Collect a sequence of characters</a>
-    that are <a>space characters</a> or U+002C COMMA characters.
+    that are [=space characters=] or U+002C COMMA characters.
     If any U+002C COMMA characters were collected, that is a <a for="parser">parse error</a>.</li>
 
     <li>If <var>position</var> is past the end of <var>input</var>,
     return <var>candidates</var> and abort these steps.</li>
 
     <li><a>Collect a sequence of characters</a> that are not
-    <a>space characters</a>, and let that be <var>url</var>.</li>
+    [=space characters=], and let that be <var>url</var>.</li>
 
     <li>Let <var>descriptors</var> be a new empty list.</li>
 
@@ -3631,15 +3631,15 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
 
   <ol>
 
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
+    <li>Any number of [=comments=] and [=space characters=].</li>
 
-    <li>Optionally, a <a>DOCTYPE</a>.</li>
+    <li>Optionally, a [=DOCTYPE=].</li>
 
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
+    <li>Any number of [=comments=] and [=space characters=].</li>
 
     <li>The <a>document element</a>, in the form of an <{html}> element.</li>
 
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
+    <li>Any number of [=comments=] and [=space characters=].</li>
 
   </ol>
 
@@ -3683,7 +3683,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     the <code>srcdoc</code> attribute, and once more to prevent the
     ampersand from being misinterpreted when parsing the sandboxed content.
 
-    Furthermore, notice that since the <a>DOCTYPE</a> is optional in
+    Furthermore, notice that since the [=DOCTYPE=] is optional in
     <a lt="iframe srcdoc document"><code>iframe</code> <code>srcdoc</code> documents</a>, and the <{html}>,
     <{head}>, and <{body}> elements have <a>optional
     start and end tags</a>, and the <{title}> element is also optional in <a lt="iframe srcdoc document"><code>iframe</code> <code>srcdoc</code>
@@ -11598,7 +11598,7 @@ red:89
   <a>represents</a> its children.
 
   The <dfn element-attr for="map"><code>name</code></dfn> attribute gives the map a name so that
-  it can be referenced. The attribute must be present and must have a non-empty value with no <a>space characters</a>. The value of the <code>name</code> attribute must not be a <a>compatibility caseless</a> match for the value of the <code>name</code> attribute of another <{map}> element in the same
+  it can be referenced. The attribute must be present and must have a non-empty value with no [=space characters=]. The value of the <code>name</code> attribute must not be a <a>compatibility caseless</a> match for the value of the <code>name</code> attribute of another <{map}> element in the same
   document. If the <{global/id}> attribute is also specified, both attributes must
   have the same value.
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -532,7 +532,7 @@
     <code>srcset</code> attribute specified, it must have at least one of the following:
 
     * A <{source/media}> attribute specified with a value that, after 
-        <a>stripping leading and trailing whitespace</a>, is not the empty string and is not an 
+        <a>stripping leading and trailing white space</a>, is not the empty string and is not an 
         <a>ASCII case-insensitive</a> match for the string "<code>all</code>".
     * A <{source/type}> attribute specified.
 
@@ -1664,7 +1664,7 @@
 
     <ol>
 
-      <li><i>Descriptor tokenizer</i>: <a>Skip whitespace</a></li>
+      <li><i>Descriptor tokenizer</i>: <a>Skip white space</a></li>
 
       <li>Let <var>current descriptor</var> be the empty string.</li>
 
@@ -1916,7 +1916,7 @@
 
   <ol>
 
-    <li>Remove all consecutive <a>&lt;whitespace-token&gt;</a>s
+    <li>Remove all consecutive <<whitespace-token>>s
     from the end of <var>unparsed size</var>.
     If <var>unparsed size</var> is now empty,
     that is a <a for="parser">parse error</a>;
@@ -1930,7 +1930,7 @@
     Otherwise, there is a <a for="parser">parse error</a>;
     continue to the next iteration of this algorithm.</li>
 
-    <li>Remove all consecutive <a>&lt;whitespace-token&gt;</a>s
+    <li>Remove all consecutive <<whitespace-token>>s
     from the end of <var>unparsed size</var>.
     If <var>unparsed size</var> is now empty,
     return <var>size</var> and exit this algorithm.
@@ -2203,7 +2203,7 @@
       <li>If the image is a descendant of a <{figure}> element that has a child
       <{figcaption}> element, and, ignoring the <{figcaption}> element and its
     descendants, the <{figure}> element has no {{Text}} node descendants other
-    than <a>inter-element whitespace</a>, and no <a>embedded content</a> descendant
+    than <a>inter-element white space</a>, and no <a>embedded content</a> descendant
     other than the <{img}> element, then the contents of the first such
       <{figcaption}> element are the caption information; abort these steps.</li>
 
@@ -3156,9 +3156,9 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   <ul>
   <li><dfn lt="the conditions described above|described above"></dfn>The <{img}> element is in a <{figure}> element
   </li><li>The <{figure}> element contains a <{figcaption}> element
-  </li><li>The <{figcaption}> element contains content other than inter-element whitespace
+  </li><li>The <{figcaption}> element contains content other than inter-element white space
   </li><li>Ignoring the <{figcaption}> element and its descendants, the <code>figure</code>
-  element has no {{Text}} node descendants other than inter-element whitespace, and no
+  element has no {{Text}} node descendants other than inter-element white space, and no
   embedded content descendant other than the <{img}> element.
   </li></ul>
 
@@ -3703,7 +3703,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   <p class="note">
     Due to restrictions of <a href="#xhtml">the XHTML syntax</a>, in XML the U+003C LESS-THAN
   SIGN character (&lt;) needs to be escaped as well. In order to prevent <a>attribute-value normalization</a>, some of XML's
-  whitespace characters — specifically U+0009 CHARACTER TABULATION (tab), U+000A LINE FEED
+  white space characters — specifically U+0009 CHARACTER TABULATION (tab), U+000A LINE FEED
   (LF), and U+000D CARRIAGE RETURN (CR) — also need to be escaped. [[!XML]]
   </p>
 
@@ -12154,7 +12154,7 @@ red:89
   and <a>MathML <code>mtext</code></a>) are descendants of HTML elements, they may contain
   <a>phrasing content</a> elements from the <a>HTML namespace</a>. [[!MATHML]]
 
-  User agents must handle text other than <a>inter-element whitespace</a> found in MathML
+  User agents must handle text other than <a>inter-element white space</a> found in MathML
   elements whose content models do not allow straight text by pretending for the purposes of MathML
   content models, layout, and rendering that the text is actually wrapped in an <a>MathML <code>mtext</code></a> element in
   the <a>MathML namespace</a>. (Such text is not, however, conforming.)

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3123,7 +3123,7 @@ part of the form.</p>
 
   <strong>The <a>value sanitization algorithm</a> is as follows</strong>: <a>Strip line
   breaks</a> from the <a for="forms">value</a>, then <a>strip leading and
-  trailing whitespace</a> from the <a for="forms">value</a>.
+  trailing white space</a> from the <a for="forms">value</a>.
 
   <strong>Constraint validation</strong>: While the <a for="forms">value</a>
   of the element is neither the empty string nor a <a lt="valid url">valid</a>
@@ -3281,7 +3281,7 @@ part of the form.</p>
 
     <strong>The <a>value sanitization algorithm</a> is as follows</strong>: <a>Strip
     line breaks</a> from the <a for="forms">value</a>, then <a>strip
-    leading and trailing whitespace</a> from the <a for="forms">value</a>.
+    leading and trailing white space</a> from the <a for="forms">value</a>.
 
     <strong>Constraint validation</strong>: While the <a for="forms">value</a>
     of the element is neither the empty string nor a single <a>valid e-mail address</a>, the
@@ -3322,7 +3322,7 @@ part of the form.</p>
 
       <li>Let <var>latest values</var> be a copy of the element's <a for="forms">value<em>s</em></a>.</li>
 
-      <li><a>Strip leading and trailing whitespace</a> from each value in <var>latest values</var>.</li>
+      <li><a>Strip leading and trailing white space</a> from each value in <var>latest values</var>.</li>
 
       <li>Let the element's <a for="forms">value</a> be the result of
       concatenating all the values in <var>latest values</var>, separating each value from
@@ -3341,7 +3341,7 @@ part of the form.</p>
 
     <ol>
 
-      <li><a lt="split a string on commas">Split on commas</a> the element's <a for="forms">value</a>, <a>strip leading and trailing whitespace</a> from
+      <li><a lt="split a string on commas">Split on commas</a> the element's <a for="forms">value</a>, <a>strip leading and trailing white space</a> from
       each resulting token, if any, and let the element's <a for="forms">values</a> be the (possibly empty) resulting list of
       (possibly empty) tokens, maintaining the original order.</li>
 
@@ -3380,7 +3380,7 @@ ldh-str       = &lt; as defined in <a>RFC 1034 section 3.5</a> &gt;
   <p class="note">
     This requirement is a <a>willful violation</a> of RFC 5322, which defines a
   syntax for e-mail addresses that is simultaneously too strict (before the "@" character), too
-  vague (after the "@" character), and too lax (allowing comments, whitespace characters, and quoted
+  vague (after the "@" character), and too lax (allowing comments, white space characters, and quoted
   strings in manners unfamiliar to most users) to be of practical use here.
   </p>
 
@@ -8250,7 +8250,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt><a>Content model</a>:</dt>
     <dd>If the element has a <{option/label}> attribute and a <{option/value}> attribute: <a>Nothing</a>.</dd>
     <dd>If the element has a <{option/label}> attribute but no <{option/value}> attribute: <a>Text</a>.</dd>
-    <dd>If the element has no <{option/label}> attribute: and is not a child of a <{datalist}> element: <a>Text</a> that is not <a>inter-element whitespace</a>.</dd>
+    <dd>If the element has no <{option/label}> attribute: and is not a child of a <{datalist}> element: <a>Text</a> that is not <a>inter-element white space</a>.</dd>
     <dd>If the element has no <{option/label}> attribute and is a child of a <{datalist}> element: <a>Text</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>An <{option}> element's <a>end tag</a> may be omitted if
@@ -8407,7 +8407,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   element's <a>index</a>.
 
   The <dfn attribute for="HTMLOptionElement"><code>text</code></dfn> IDL attribute, on getting, must
-  return the result of <a>stripping and collapsing whitespace</a> from the <a>child text content</a>
+  return the result of <a>stripping and collapsing white space</a> from the <a>child text content</a>
   of the <{option}> element, in <a>tree order</a>,
   excluding any that are descendants of descendants of the <{option}> element that are themselves
   <{script}> elements in the <a>HTML namespace</a> or <{script}> elements in the
@@ -9870,9 +9870,9 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   <p class="example">For instance, if a user enters the word "<kbd>three</kbd>" into a numeric field that expects digits, the user's input would
   be the string "three" but the control's <a for="forms">value</a> would remain
   unchanged. Or, if a user enters the email address "<kbd>&nbsp;&nbsp;awesome@example.com</kbd>"
-  (with leading whitespace) into <{input/E-mail|an email field}>, the
+  (with leading white space) into <{input/E-mail|an email field}>, the
   user's input would be the string "&nbsp;&nbsp;awesome@example.com" but the browser's UI for
-  email fields might translate that into a <a for="forms">value</a> of "<code>awesome@example.com</code>" (without the leading whitespace).</p>
+  email fields might translate that into a <a for="forms">value</a> of "<code>awesome@example.com</code>" (without the leading white space).</p>
 
   To define the behavior of constraint validation in the face of the <{input}>
   element's <{input/multiple}> attribute, <{input}> elements

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1259,7 +1259,7 @@
 
   If a <{dl}> element contains no <{dt}> or <{dd}> child elements, it contains no term-description groups.
 
-  If a <{dl}> element has one or more non-<a>whitespace</a> text node children, or has children that are neither <{dt}> or <{dd}> elements, then all such text nodes and elements as well as their descendants (including any <{dt}> and <{dd}> elements) do not form part of any term-description group within the <{dl}>.
+  If a <{dl}> element has one or more non-<a>white space</a> text node children, or has children that are neither <{dt}> or <{dd}> elements, then all such text nodes and elements as well as their descendants (including any <{dt}> and <{dd}> elements) do not form part of any term-description group within the <{dl}>.
 
   If a <{dl}> element has one or more <{dt}> element children, but no <{dd}> element children, then it consists of one group with terms but no descriptions.
 

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -904,7 +904,7 @@
   The <a facet for="menuitem">Label</a> of the command is the value of the
   <{option}> element's <code>label</code> attribute, if there is
   one, or else the value of <{option}> element's {{Node/textContent}} IDL attribute,
-  with <a>leading and trailing whitespace
+  with <a>leading and trailing white space
   stripped</a>, and with any sequences of two or more <a>space
   characters</a> replaced by a single U+0020 SPACE character.
 

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -1354,7 +1354,7 @@
   keyword "<code>shortcut</code>". If the "<code>shortcut</code>" keyword is
   present, the <{link/rel}> attribute's entire value must be an
   <a>ASCII case-insensitive</a> match for the string "<code>shortcut&nbsp;icon</code>" (with a single U+0020 SPACE character between the tokens and
-  no other <a>space characters</a>).
+  no other [=space characters=]).
 
 <h5 id="link-type-license">Link type "<dfn attr-value for="link/type"><code>license</code></dfn>"</h5>
 

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -801,7 +801,7 @@
     Adjust <var>filename</var> to be suitable for the local file system.
 
     <p class="example">For example, this could involve removing characters that are not legal in
-    file names, or trimming leading and trailing whitespace.</p>
+    file names, or trimming leading and trailing white space.</p>
 
     </li>
 

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -475,7 +475,7 @@ o............A....e
 
        1. Let <var>for</var> be the value of the <{script/for}> attribute.
        2. Let <var>event</var> be the value of the <{script/event}> attribute.
-       3. <a>Strip leading and trailing whitespace</a> from <var>event</var> and <var>for</var>.
+       3. <a>Strip leading and trailing white space</a> from <var>event</var> and <var>for</var>.
        4. If <var>for</var> is not an <a>ASCII case-insensitive</a> match for the string "<code>window</code>",
            then the user agent must abort these steps at this point. The script is not executed.
        5. If <var>event</var> is not an <a>ASCII case-insensitive</a> match for either the string

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -433,7 +433,7 @@ o............A....e
 
       Otherwise, if the <{script}> element has a <{script/type}> attribute, let
       <var>the script block's type string</var> for this <{script}> element be the value of that
-      attribute with any leading or trailing sequences of <a>space characters</a> removed.
+      attribute with any leading or trailing sequences of [=space characters=] removed.
 
       Otherwise, the element has a non-empty <{script/language}> attribute; let
       <var>the script block's type string</var> for this <{script}> element be the

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -74,7 +74,7 @@
   The <code>onblur</code>, <code>onerror</code>, <code>onfocus</code>, <a attribute for="GlobalEventHandlers"><code>onload</code></a>,
   <code>onresize</code>, and <code>onscroll</code> <a>event handlers</a> of the <code>Window</code>
   object, exposed on the <{body}> element, replace the generic <a>event handlers</a> with
-  the same names normally supported by <a>html elements</a>.
+  the same names normally supported by <a>HTML elements</a>.
 
   <p class="example">
     Thus, for example, a bubbling <code>error</code> event dispatched on a child of
@@ -341,7 +341,7 @@
   <div class="example">
     Here is a graduation program with two sections, one for the list of people graduating, and
     one for the description of the ceremony. (The markup in this example features an uncommon style
-    sometimes used to minimize the amount of <a>inter-element whitespace</a>.)
+    sometimes used to minimize the amount of <a>inter-element white space</a>.)
 
     <pre highlight="html">
       &lt;!DOCTYPE Html&gt;

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -1223,7 +1223,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
     context) as a <dfn>ruby annotation container</dfn>.
 
     Furthermore, a ruby element contains <dfn>ignored ruby content</dfn>. Ignored ruby content does
-    not form part of the document's semantics. It consists of some <a>inter-element whitespace</a>
+    not form part of the document's semantics. It consists of some <a>inter-element white space</a>
     and <{rp}> elements, the latter of which are used for legacy user agents that do not
     support ruby at all.
 
@@ -1338,7 +1338,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
       </li>
       <li>
         If <var>current child</var> is a {{Text}} node and is <a>inter-element
-        whitespace</a>, then run these substeps:
+        white space</a>, then run these substeps:
         <ol>
           <li>
             If <var>current annotations</var> is not empty, increment <var>index</var> by one and
@@ -1359,7 +1359,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
               </li>
               <li>
                 If <var>peek child</var> is a {{Text}} node and is <a>inter-element
-                whitespace</a>, then jump to the step labelled <i>peek ahead</i>.
+                white space</a>, then jump to the step labelled <i>peek ahead</i>.
               </li>
               <li>
                 If <var>peek child</var> is an <{rt}> element, an
@@ -1476,7 +1476,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
       </li>
       <li>
         If <var>current automatic base nodes</var> contains nodes that are not {{Text}}
-        nodes, or {{Text}} nodes that are not <a>inter-element whitespace</a>, then
+        nodes, or {{Text}} nodes that are not <a>inter-element white space</a>, then
         run these substeps:
         <ol>
           <li>
@@ -1668,7 +1668,7 @@ affected by the heat source (upper left) and the food source (lower right).&lt;/
       <li>
         If <var>current automatic annotation nodes</var> contains nodes that are not
         {{Text}} nodes, or {{Text}} nodes that are not <a>inter-element
-        whitespace</a>, then create a new DOM range whose <a lt="range start">start</a> is the <a lt="range bp">boundary
+        white space</a>, then create a new DOM range whose <a lt="range start">start</a> is the <a lt="range bp">boundary
         point</a> (<var>root</var>, <var>current automatic annotation range start</var>) and
         whose <a lt="range end">end</a> is the <a lt="range bp">boundary point</a> (<var>root</var>, <var>index</var>), and
         append it at the end of <var>annotations</var>.

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -110,13 +110,13 @@ path: sections/semantics-common-idioms.include
   elements in documents that are in <a>quirks mode</a>, will be matched in an
   <a>ASCII case-insensitive</a> manner.</p>
 
-  When comparing a CSS element <a>type selector</a> to the names of <a>html elements</a> in
+  When comparing a CSS element <a>type selector</a> to the names of <a>HTML elements</a> in
   <a>HTML documents</a>, the CSS element <a>type selector</a> must first be
   converted to <a>ASCII lowercase</a>. The same selector when compared to other elements must be
   compared according to its original case. In both cases, the comparison is <a>case-sensitive</a>.
 
   When comparing the name part of a CSS <a>attribute selector</a> to the names of namespace-less
-  attributes on <a>html elements</a> in <a>HTML documents</a>, the name part of the CSS
+  attributes on <a>HTML elements</a> in <a>HTML documents</a>, the name part of the CSS
   <a>attribute selector</a> must first be converted to <a>ASCII lowercase</a>. The same selector
   when compared to other attributes must be compared according to its original case. In both cases,
   the comparison is <a>case-sensitive</a>.
@@ -180,9 +180,9 @@ path: sections/semantics-common-idioms.include
   <ul class="brief">
     <li> IDs and classes in <a>no-quirks mode</a> and <a>limited-quirks mode</a>
     </li><li> the names of elements not in the <a>HTML namespace</a>
-    </li><li> the names of <a>html elements</a> in <a>XML documents</a>
+    </li><li> the names of <a>HTML elements</a> in <a>XML documents</a>
     </li><li> the names of attributes of elements not in the <a>HTML namespace</a>
-    </li><li> the names of attributes of <a>html elements</a> in <a>XML documents</a>
+    </li><li> the names of attributes of <a>HTML elements</a> in <a>XML documents</a>
     </li><li> the names of attributes that themselves have namespaces
   </li></ul>
 
@@ -408,7 +408,7 @@ path: sections/semantics-common-idioms.include
       * elements that are <a>editing hosts</a> or <a>editable</a> and are neither <{input}> elements
          nor <{textarea}> elements
 
-      The '':read-only'' <a>pseudo-class</a> must match all other <a>html elements</a>.
+      The '':read-only'' <a>pseudo-class</a> must match all other <a>HTML elements</a>.
 
   : '':dir(ltr)''
   :: The '':dir(ltr)'' <a>pseudo-class</a> must match all elements whose <a>directionality</a> is

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -8,13 +8,13 @@
 ██     ██    ██    ██     ██ ██             ██    ██    ██    ██   ███    ██    ██     ██  ██   ██
 ██     ██    ██    ██     ██ ████████        ██████     ██    ██    ██    ██    ██     ██ ██     ██
 -->
+<!-- This section ostensibly kept up to date by travil@microsoft.com -->
 
 <h2 id="syntax"><dfn>The HTML syntax</dfn></h2>
 
-  <p class="note">
-  This section only describes the rules for resources labeled with an <a>HTML
-  MIME type</a>. Rules for XML resources are discussed in the section below entitled "<a>the XHTML syntax</a>".
-  </p>
+  <p class="note">This section only describes the rules for resources labeled with an 
+  [=HTML MIME type=]. Rules for XML resources are discussed in the section below entitled 
+  "[=The XML syntax=]".</p>
 
 <h3 id="writing-html-documents">Writing HTML documents</h3>
 

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -1063,9 +1063,6 @@
   Where possible, references to such elements are hyperlinked to their definition.
   </p>
 
-  </div>
-
-  <div class="impl">
 
 <h4 id="overview-of-the-parsing-model">Overview of the parsing model</h4>
 
@@ -1106,9 +1103,7 @@
   To handle these cases, parsers have a <dfn>script nesting level</dfn>, which must be initially
   set to zero, and a <dfn>parser pause flag</dfn>, which must be initially set to false.
 
-  </div>
 
-  <div class="impl">
 
 <h4 id="the-input-byte-stream">The <dfn>input byte stream</dfn></h4>
 
@@ -1926,9 +1921,6 @@
   construction stage.
   </p>
 
-  </div>
-
-  <div class="impl">
 
 <h4 id="parse-state">Parse state</h4>
 
@@ -2335,9 +2327,6 @@
   The <dfn>frameset-ok flag</dfn> is set to "ok" when the parser is created. It is set to "not
   ok" after certain tokens are seen.
 
-  </div>
-
-  <div class="impl">
 
 <h4 id="sec-tokenization"><dfn lt="tokenizer|tokenization">Tokenization</dfn></h4>
 
@@ -8485,9 +8474,8 @@
 
   </dl>
 
-  </div>
 
-  <div class="impl">
+
 
 <h4 id="the-end">The end</h4>
 
@@ -8527,7 +8515,10 @@
 
     </li>
 
-    <li><a>Queue a task</a> to <a>fire a simple event</a> that bubbles named <code>DOMContentLoaded</code> at the {{Document}}.</li>
+    <li><a>Queue a task</a> to run the following substeps:
+
+        1. <a>fire an event</a> named <code>DOMContentLoaded</code> at the {{Document}} object, with its {{Event/bubbles}} attribute initialized to true.
+        2. Enable the [=client message queue=] of the {{ServiceWorkerContainer}} object whose associated [=service worker client=] is the {{Document}} object's [=relevant settings object=].
 
     <li><a>Spin the event loop</a> until the <a>set of scripts that will execute as soon
     as possible</a> and the <a>list of scripts that will execute in order as soon as
@@ -8543,10 +8534,9 @@
 
       <li>Set the <a>current document readiness</a> to "<code>complete</code>".</li>
 
-      <li><i>Load event</i>: If the <code>Document</code> is in a <a>browsing context</a>,
-      <a>fire a simple event</a> named <code>load</code> at the
-      <code>Document</code>'s <code>Window</code> object, with <i>target override</i> set to the <code>Document</code>
-      object.</li>
+      <li><i>Load event</i>: If the {{Document}} has a <a>browsing context</a>, then
+      <a>fire an event</a> named <code>load</code> at the
+      {{Document}} object's {{Window}} object, with <i>legacy target override flag</i> set.</li>
 
     </ol>
 
@@ -8554,7 +8544,7 @@
 
     <li>
 
-    If the <code>Document</code> is in a <a>browsing context</a>, then <a>queue a
+    If the <code>Document</code> has a <a>browsing context</a>, then <a>queue a
     task</a> to run the following substeps:
 
     <ol>
@@ -8564,16 +8554,20 @@
 
       <li>Set the <code>Document</code>'s <a>page showing</a> flag to true.</li>
 
-      <li><a>Fire</a> a <a>trusted</a> event with the name <code>pageshow</code> at the <code>Window</code> object of the
-      {{Document}}, with <i>target override</i> set to the <code>Document</code>
-      object,
-      using the <code>PageTransitionEvent</code> interface, with the <code>persisted</code> attribute initialized to false. This
-      event must not bubble, must not be cancelable, and has no default action.</li>
+      <li><a>Fire an event</a> named <code>pageshow</code> at the {{Document}} object's {{Window}} object using
+      {{PageTransitionEvent}}, with the <code>persisted</code> attribute initialized to false, and
+      <i>legacy target override flag</i> set.</li>.
 
     </ol>
 
     </li>
-
+    <!-- App cache -->
+    <!--
+    <li>If the {{Document}} has any [=pending application cache download process tasks=], then
+    [=queue=] each such [=task=] in the order they were added to the list of
+    [=pending application cache download process tasks=], and then empty the list of
+    [=pending application cache download process tasks=]. The [=task source=] for these [=tasks=] is the [=networking task source=].</li>
+    -->
     <li>If the <code>Document</code>'s <a>print when loaded</a> flag is set, then run the
     <a>printing steps</a>.</li>
 
@@ -8602,7 +8596,7 @@
   Except where otherwise specified, the <a>task source</a> for the <a>tasks</a> mentioned in this section is the <a>DOM manipulation task
   source</a>.
 
-  </div>
+
 
   <div class="impl">
 
@@ -8684,9 +8678,6 @@
   that start tag.
   </p>
 
-  </div>
-
-  <div class="impl">
 
 <h4 id="an-introduction-to-error-handling-and-strange-cases-in-the-parser">An introduction to error handling and strange cases in the parser</h4>
 
@@ -8975,7 +8966,7 @@
 
   The following steps form the <dfn>HTML fragment serialization algorithm</dfn>. The algorithm
   takes as input a DOM {{Element}}, {{Document}}, or {{DocumentFragment}}
-  referred to as <var>the node</var>, and either returns a string.
+  referred to as <var>the node</var>, and returns a string.
 
   <p class="note">
   This algorithm serializes the <em>children</em> of the node being serialized, not
@@ -9015,7 +9006,7 @@
 
         <p class="note">
   For <a>HTML elements</a> created by the <a>HTML parser</a> or
-        <code>Document.createElement()</code>, <var>tagname</var> will be
+        {{Document/createElement()}}, <var>tagname</var> will be
         lowercase.
   </p>
 
@@ -9070,7 +9061,7 @@
 
         </dl>
 
-        While the exact order of attributes is user agent-defined, and may depend on factors such as the
+        While the exact order of attributes is UA-defined, and may depend on factors such as the
         order that the attributes were given in the original markup, the sort order must be stable,
         such that consecutive invocations of this algorithm serialize an element's attributes in the
         same order.
@@ -9080,14 +9071,8 @@
         If <var>current node</var> is an <{area}>, <{base}>,
         <{basefont}>, <{bgsound}>, <{br}>, <{col}>,
         <{embed}>, <{frame}>, <{hr}>, <{img}>,
-        <{input}>, <{link}>, <{menuitem}>,
-        <{meta}>, <{param}>, <{source}>, <{track}> or
+        <{input}>, <{link}>, <{meta}>, <{param}>, <{source}>, <{track}> or
         <{wbr}> element, then continue on to the next child node at this point.
-
-        If <var>current node</var> is a <{pre}>, <{textarea}>, or
-        <{listing}> element, and the first child node of the element, if any, is a
-        {{Text}} node whose character data has as its first character a U+000A LINE FEED
-        (LF) character, then append a U+000A LINE FEED (LF) character.
 
         Append the value of running the <a>HTML fragment serialization algorithm</a> on the
         <var>current node</var> element (thus recursing into this algorithm for that
@@ -9158,8 +9143,9 @@
 
   </ol>
 
-  <p class="warning">It is possible that the output of this algorithm, if parsed with an <a>HTML
-  parser</a>, will not return the original tree structure.</p>
+  <p class="warning">It is possible that the output of this algorithm, if parsed with an <a>HTML parser</a>,
+  will not return the original tree structure. Tree structures that do not roundtrip
+  a serialize and reparse step can also be produced by the <a>HTML parser</a> itself, although such cases are typically non-conforming.</p>
 
   <div class="example">
     For instance, if a <{textarea}> element to which a <code>Comment</code> node
@@ -9181,6 +9167,251 @@
     would contain a <code>script</code> node, even though no <code>script</code> node existed in the
     original DOM.
   </div>
+
+
+  <div class="example">
+
+    <p>For example, consider the following markup:</p>
+
+    <pre highlight="html">&lt;form id="outer"&gt;&lt;div&gt;&lt;/form&gt;&lt;form id="inner"&gt;&lt;input&gt;</pre>
+
+    <p>This will be parsed into:</p>
+
+    <ul class="domTree"><li class="t1">html<ul><li class="t1">head</li><li class="t1">body<ul><li class="t1">form <span class="t2">id="outer"</span>
+
+       <ul>
+
+        <li class="t1">
+
+        div
+
+         <ul>
+
+          <li class="t1">
+
+          form <span class="t2">id="inner"</span>
+
+           <ul>
+
+            <li class="t1">
+
+            input
+
+            </li>
+
+           </ul>
+
+          </li>
+
+         </ul>
+
+        </li>
+
+       </ul>
+
+      </li>
+
+     </ul>
+
+    </li>
+
+   </ul>
+
+  </li>
+
+ </ul>
+
+ <p>The input element will be associated with the inner form element. Now, if this tree structure is serialized and reparsed, the &lt;form id="inner"&gt; start tag will be ignored, and so the input element will be associated with the outer form element instead.</p>
+
+ <pre highlight="html">&lt;html&gt;&lt;head&gt;&lt;/head&gt;&lt;body&gt;&lt;form id="outer"&gt;&lt;div&gt;<mark>&lt;form id="inner"&gt;</mark>&lt;input&gt;&lt;/form&gt;&lt;/div&gt;&lt;/form&gt;&lt;/body&gt;&lt;/html&gt;</pre>
+
+ <ul class="domTree">
+
+  <li class="t1">
+
+  html
+
+   <ul>
+
+    <li class="t1">
+
+    head
+
+    </li>
+
+    <li class="t1">
+
+    body
+
+     <ul>
+
+      <li class="t1">
+
+      form <span class="t2">id="outer"</span>
+
+       <ul>
+
+        <li class="t1">
+
+        div
+
+         <ul>
+
+          <li class="t1">
+
+          input
+
+          </li>
+
+         </ul>
+
+        </li>
+
+       </ul>
+
+      </li>
+
+     </ul>
+
+    </li>
+
+   </ul>
+
+  </li>
+
+ </ul>
+
+</div>
+
+<div class="example">
+
+ <p>As another example, consider the following markup:</p>
+
+ <pre highlight="html">&lt;a&gt;&lt;table&gt;&lt;a&gt;</pre>
+
+ <p>This will be parsed into:</p>
+
+ <ul class="domTree">
+
+  <li class="t1">
+
+  html
+
+   <ul>
+
+    <li class="t1">
+
+    head
+
+    </li>
+
+    <li class="t1">
+
+    body
+
+     <ul>
+
+      <li class="t1">
+
+      a
+
+       <ul>
+
+        <li class="t1">
+
+        a
+
+        </li>
+
+        <li class="t1">
+
+        table
+
+        </li>
+
+       </ul>
+
+      </li>
+
+     </ul>
+
+    </li>
+
+   </ul>
+
+  </li>
+
+ </ul>
+
+ <p>That is, the a elements are nested, because the second a element is foster parented. After a serialize-reparse roundtrip, the a elements and the table element would all be siblings, because the second &lt;a&gt; start tag implicitly closes the first a element.</p>
+
+ <pre highlight="html">&lt;html&gt;&lt;head&gt;&lt;/head&gt;&lt;body&gt;&lt;a&gt;<mark>&lt;a&gt;</mark>&lt;/a&gt;&lt;table&gt;&lt;/table&gt;&lt;/a&gt;&lt;/body&gt;&lt;/html&gt;</pre>
+
+ <ul class="domTree">
+
+  <li class="t1">
+
+  html
+
+   <ul>
+
+    <li class="t1">
+
+    head
+
+    </li>
+
+    <li class="t1">
+
+    body
+
+     <ul>
+
+      <li class="t1">
+
+      a
+
+      </li>
+
+      <li class="t1">
+
+      a
+
+      </li>
+
+      <li class="t1">
+
+      table
+
+      </li>
+
+     </ul>
+
+    </li>
+
+   </ul>
+
+  </li>
+
+ </ul>
+
+</div>
+
+<p>For historical reasons, this algorithm does not round-trip an initial U+000A LINE FEED (LF) character in pre, textarea, or listing elements, even though (in the first two cases) the markup being round-tripped can be conforming. The HTML parser will drop such a character during parsing, but this algorithm does not serialize an extra U+000A LINE FEED (LF) character.</p>
+
+<div class="example">
+
+ <p>For example, consider the following markup:</p>
+
+ <pre highlight="html">&lt;pre&gt;
+
+
+
+Hello.&lt;/pre&gt;</pre>
+
+ <p>When this document is first parsed, the pre element's child text content starts with a single newline character. After a serialize-reparse roundtrip, the pre element's child text content is simply "Hello.".</p>
+
+</div>
 
   <dfn>Escaping a string</dfn> (for the purposes of the algorithm above)
   consists of running the following steps:
@@ -9247,32 +9478,36 @@
     <li>
 
     Set the state of the <a>HTML parser</a>'s <a>tokenization</a> stage as
-    follows:
+    follows, switching on the [=context=] element:
 
     <dl class="switch">
 
-      <dt>If it is a <{title}> or <{textarea}> element</dt>
+      <dt><{title}></dt>
+      <dt><{textarea}></dt>
 
       <dd>Switch the tokenizer to the [[#RCDATA-state]].</dd>
 
-      <dt>If it is a <{style}>, <{xmp}>, <{iframe}>,
-      <{noembed}>, or <{noframes}> element</dt>
+      <dt><{style}></dt>
+      <dt><{xmp}></dt>
+      <dt><{iframe}></dt>
+      <dt><{noembed}></dt>
+      <dt><{noframes}></dt>
 
       <dd>Switch the tokenizer to the [[#rawtext-state]].</dd>
 
-      <dt>If it is a <{script}> element</dt>
+      <dt><{script}></dt>
 
       <dd>Switch the tokenizer to the [[#script-data-state]].</dd>
 
-      <dt>If it is a <{noscript}> element</dt>
+      <dt><{noscript}></dt>
 
       <dd>If the <a>scripting flag</a> is enabled, switch the tokenizer to the [[#rawtext-state]]. Otherwise, leave the tokenizer in the [[#data-state]].</dd>
 
-      <dt>If it is a <{plaintext}> element</dt>
+      <dt><{plaintext}></dt>
 
       <dd>Switch the tokenizer to the [[#plaintext-state]].</dd>
 
-      <dt>Otherwise</dt>
+      <dt>Any other element</dt>
 
       <dd>Leave the tokenizer in the [[#data-state]].</dd>
 
@@ -9371,7 +9606,6 @@
 
   </ol>
 
-  </div>
 
 <h3 id="named-character-references">Named character references</h3>
 
@@ -9379,9 +9613,7 @@
   to which they refer. It is referenced by the previous sections.
 
   <div id="named-character-references-table">
-<pre class="include">
-path: includes/entities.include
-</pre>
+<pre class="include">path: includes/entities.include</pre>
   </div>
 
   This data is also available <a href='entities.json'>as a JSON file</a>.

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -2215,7 +2215,7 @@
     <li><{template}> in the [=HTML namespace=]</li>
   </ul>
 
-  The <a>stack of open elements</a> is said to <dfn lt="have a particular element in select scope|have a select element in select scope">have a particular element in select scope</dfn> when it <a>has that element in the specific scope</a> consisting of all element types
+  The <a>stack of open elements</a> is said to <dfn lt="have a particular element in select scope|have a `select` element in select scope|have a select element in select scope">have a particular element in select scope</dfn> when it <a>has that element in the specific scope</a> consisting of all element types
   <em>except</em> the following:
 
   <ul class="brief">

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -4389,7 +4389,7 @@
     <dt>If the <a>adjusted current node</a> is an element in the <a>HTML namespace</a></dt>
     <dt>If the <a>adjusted current node</a> is a <a>MathML text integration point</a> and the token is a start tag whose tag name is neither "mglyph" nor "malignmark"</dt>
     <dt>If the <a>adjusted current node</a> is a <a>MathML text integration point</a> and the token is a character token</dt>
-    <dt>If the <a>adjusted current node</a> is an <a>MathML <code>annotation-xml</code></a> element and the token is a start tag whose tag name is "svg"</dt>
+    <dt>If the <a>adjusted current node</a> is a <a>MathML <code>annotation-xml</code></a> element and the token is a start tag whose tag name is "svg"</dt>
     <dt>If the <a>adjusted current node</a> is an <a>HTML integration point</a> and the token is a start tag</dt>
     <dt>If the <a>adjusted current node</a> is an <a>HTML integration point</a> and the token is a character token</dt>
     <dt>If the token is an end-of-file token</dt>
@@ -4410,25 +4410,25 @@
   elements:
 
   <ul class="brief">
-    <li>An <a>MathML <code>mi</code></a> element</li>
-    <li>An <a>MathML <code>mo</code></a> element</li>
-    <li>An <a>MathML <code>mn</code></a> element</li>
-    <li>An <a>MathML <code>ms</code></a> element</li>
-    <li>An <a>MathML <code>mtext</code></a> element</li>
+    <li>A <a>MathML <code>mi</code></a> element</li>
+    <li>A <a>MathML <code>mo</code></a> element</li>
+    <li>A <a>MathML <code>mn</code></a> element</li>
+    <li>A <a>MathML <code>ms</code></a> element</li>
+    <li>A <a>MathML <code>mtext</code></a> element</li>
   </ul>
 
   A node is an <dfn>HTML integration point</dfn> if it is one of the following elements:
 
   <ul class="brief">
-    <li>An <a>MathML <code>annotation-xml</code></a> element in the <a>MathML namespace</a> whose
+    <li>A <a>MathML <code>annotation-xml</code></a> element whose
     start tag token had an attribute with the name "encoding" whose value was
     an <a>ASCII case-insensitive</a> match for the string "<code>[[#text-html|text/html]]</code>"</li>
-    <li>An <a>MathML <code>annotation-xml</code></a> element in the <a>MathML namespace</a> whose
+    <li>A <a>MathML <code>annotation-xml</code></a> element whose
     start tag token had an attribute with the name "encoding" whose value was
     an <a>ASCII case-insensitive</a> match for the string "<code>application/xhtml+xml</code>"</li>
-    <li>A SVG <{foreignObject}> element</li>
-    <li>A SVG <{desc}> element</li>
-    <li>A SVG <a element for="svg"><code>title</code></a> element</li>
+    <li>An SVG <{foreignObject}> element</li>
+    <li>An SVG <{desc}> element</li>
+    <li>An SVG <a element for="svg"><code>title</code></a> element</li>
   </ul>
 
   <p class="note">
@@ -4557,50 +4557,42 @@
 
   <hr />
 
-  When the steps below require the user agent to <dfn lt="create an element for the token|create an element for a token">create an element for a token</dfn> in a particular <var>given namespace</var> and with a
-  particular <var>intended parent</var>, the user agent must run the following steps:
+  When the steps below require the UA to <dfn lt="create an element for the token|create an element for a token">create an element for a token</dfn> in a particular <var>given namespace</var> and with a
+  particular <var>intended parent</var>, the UA must run the following steps:
 
-  <ol>
-
-    <li>
-
-    Create a node implementing the interface appropriate for the element type corresponding to
-    the tag name of the token in <var>given namespace</var> (as given in the specification
-    that defines that element, e.g., for an <{a}> element in the <a>HTML
-    namespace</a>, this specification defines it to be the <code>HTMLAnchorElement</code>
-    interface), with the tag name being the name of that element, with the node being in the given
-    namespace, and with the attributes on the node being those given in the given token.
-
-    The interface appropriate for an element in the <a>HTML namespace</a> that is not
-    defined in this specification (or [=other applicable specifications=]) is
-    {{HTMLUnknownElement}}. Elements in other namespaces whose interface is not defined by
-    that namespace's specification must use the interface {{Element}}.
-
-    The <a>node document</a> of the newly created element
-    must be the <a>node document</a> of the <var>intended parent</var>.
-
-    </li>
-
-    <li>If the newly created element has an <{xmlns/xmlns}> attribute <em>in the
+  1. Let |document| be |intended parent|'s [=node document=].
+  2. Let |local name| be the tag name of the token.
+  3. Let |is| be the value of the "<code>is</code>" attribute in the given token, if such an attribute exists, or null otherwise.
+  4. Let definition be the result of looking up a custom element definition given document, given namespace, local name, and is.
+  5. If definition is non-null and the parser was not originally created for the HTML fragment parsing algorithm, then let will execute script be true. Otherwise, let it be false.
+  6. If will execute script is true, then:
+    1. Increment document's throw-on-dynamic-markup-insertion counter.
+    2. If the JavaScript execution context stack is empty, then perform a microtask checkpoint.
+    3. Push a new element queue onto the custom element reactions stack.
+  7. Let element be the result of creating an element given document, localName, given namespace, null, and is. If will execute script is true, set the synchronous custom elements flag; otherwise, leave it unset.
+    <p class="note">This will cause custom element constructors to run, if will execute script is true. However, since we incremented the throw-on-dynamic-markup-insertion counter, this cannot cause new characters to be inserted into the tokenizer, or the document to be blown away.</p>
+  8. Append each attribute in the given token to element.
+    <p class="note">This can enqueue a custom element callback reaction for the attributeChangedCallback, which might run immediately (in the next step).</p>
+    <p class="note">Even though the is attribute governs the creation of a customized built-in element, it is not present during the execution of the relevant custom element constructor; it is appended in this step, along with all other attributes.</p>
+  9. If will execute script is true, then:
+    1. Let queue be the result of popping the current element queue from the custom element reactions stack. (This will be the same element queue as was pushed above.)
+    2. Invoke custom element reactions in queue.
+    3. Decrement document's throw-on-dynamic-markup-insertion counter.
+  10. If the newly created element has an <{xmlns/xmlns}> attribute <em>in the
     <a>XMLNS namespace</a></em> whose value is not exactly the same as the element's namespace,
     that is a <a for="parser">parse error</a>. Similarly, if the newly created element has an <code>xmlns:xlink</code> attribute in the <a>XMLNS namespace</a> whose value is not the
-    <a>XLink namespace</a>, that is a <a for="parser">parse error</a>.</li>
-
-    <li>If the newly created element is a <a>resettable element</a>,
+    <a>XLink namespace</a>, that is a <a for="parser">parse error</a>.
+  11. If the newly created element is a <a>resettable element</a>,
     invoke its <a>reset algorithm</a>. (This initializes the
-    element's <a for="forms">value</a> and <a for="forms">checkedness</a> based on the element's attributes.)</li>
-
-    <li>If the element is a <a>form-associated element</a>, and the <a><code>form</code> element pointer</a> is not null, and there is no <code>template</code>
+    element's <a for="forms">value</a> and <a for="forms">checkedness</a> based on the element's attributes.)
+  12. If the element is a <a>form-associated element</a>, and the <a><code>form</code> element pointer</a> is not null, and there is no <code>template</code>
     element on the <a>stack of open elements</a>, and the newly created element is either not
     <a>reassociateable</a> or doesn't have a <code>form</code> attribute, and the <var>intended parent</var> is in
     the same <a>tree</a> as the element pointed to by the <a><code>form</code> element pointer</a>, associate the newly created element with the
     <{form}> element pointed to by the <a><code>form</code> element
     pointer</a>, and suppress the running of the <a>reset the form owner</a> algorithm when
-    the parser subsequently attempts to insert the element.</li>
-
-    <li>Return the newly created element.</li>
-
-  </ol>
+    the parser subsequently attempts to insert the element.
+  13. Return element.
 
   <hr />
 

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -2355,7 +2355,7 @@
 
   The exact behavior of certain states depends on the <a>insertion mode</a> and the
   <a>stack of open elements</a>. Certain states also use a <dfn>|temporary buffer|</dfn> to track
-  progress, and the [=character reference state=] uses a <dfn>|return state|</dfn> to return to the
+  progress, and the [[#character-reference-state]] uses a <dfn>return state</dfn> to return to the
   state it was invoked from.
 
   The output of the tokenization step is a series of zero or more of the following tokens:
@@ -2404,7 +2404,7 @@
   <dl class="switch">
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Set the [=return state=] to the [=data state=]. Switch to the [=character reference state=].</dd>
+    <dd>Set the |[=return state=]| to the [[#data-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
     <dd>Switch to the [[#tag-open-state]].</dd>
@@ -2421,17 +2421,17 @@
 
   </dl>
 
-<h5 id="rcdata-state">RCDATA state</h5>
+<h5 id="RCDATA-state">RCDATA state</h5>
 
   Consume the <a>next input character</a>:
 
   <dl class="switch">
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Set the [=return state=] to the [=RCDATA state=]. Switch to the [[#character-reference-state]].</dd>
+    <dd>Set the |[=return state=]| to the [[#RCDATA-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
-    <dd>Switch to the [[#rcdata-less-than-sign-state]].</dd>
+    <dd>Switch to the [[#RCDATA-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
     <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
@@ -2583,7 +2583,7 @@
 
   </dl>
 
-<h5 id="rcdata-less-than-sign-state">RCDATA less-than sign state</h5>
+<h5 id="RCDATA-less-than-sign-state">RCDATA less-than sign state</h5>
 
   Consume the <a>next input character</a>:
 
@@ -2591,7 +2591,7 @@
 
     <dt>U+002F SOLIDUS (/)</dt>
     <dd>Set the <var>temporary buffer</var> to the empty string. Switch to
-    the [[#rcdata-end-tag-open-state]].</dd>
+    the [[#RCDATA-end-tag-open-state]].</dd>
 
     <dt>Anything else</dt>
     <dd>Emit a U+003C LESS-THAN SIGN character token.
@@ -2599,22 +2599,22 @@
 
   </dl>
 
-<h5 id="rcdata-end-tag-open-state">RCDATA end tag open state</h5>
+<h5 id="RCDATA-end-tag-open-state">RCDATA end tag open state</h5>
 
   Consume the <a>next input character</a>:
 
   <dl class="switch">
 
     <dt><a>ASCII letter</a></dt>
-    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in [[#rcdata-end-tag-name-state]].</dd>
+    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in [[#RCDATA-end-tag-name-state]].</dd>
 
     <dt>Anything else</dt>
     <dd>Emit a U+003C LESS-THAN SIGN character token and a
-    U+002F SOLIDUS character token. [=Reconsume=] in the [[#rcdata-state]].</dd>
+    U+002F SOLIDUS character token. [=Reconsume=] in the [[#RCDATA-state]].</dd>
 
   </dl>
 
-<h5 id="rcdata-end-tag-name-state">RCDATA end tag name state</h5>
+<h5 id="RCDATA-end-tag-name-state">RCDATA end tag name state</h5>
 
   Consume the <a>next input character</a>:
 
@@ -2652,7 +2652,7 @@
     <dt>Anything else</dt>
     <dd>Emit a U+003C LESS-THAN SIGN character token, a
     U+002F SOLIDUS character token, and a character token for each of the characters in the <var>temporary buffer</var> (in the order they were added to the buffer).
-    [=Reconsume=] in the [[#rcdata-state]].</dd>
+    [=Reconsume=] in the [[#RCDATA-state]].</dd>
 
   </dl>
 
@@ -3298,7 +3298,7 @@
     <dd>Switch to the [[#after-attribute-value-quoted-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Set the [=return state=] to the [[#attribute-value-double-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
+    <dd>Set the |[=return state=]| to the [[#attribute-value-double-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+0000 NULL</dt>
     <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
@@ -3322,7 +3322,7 @@
     <dd>Switch to the [[#after-attribute-value-quoted-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Set the [=return state=] to the [[#attribute-value-single-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
+    <dd>Set the |[=return state=]| to the [[#attribute-value-single-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+0000 NULL</dt>
     <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
@@ -3350,7 +3350,7 @@
     <dd>Switch to the [[#before-attribute-name-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Set the [=return state=] to the [[#attribute-value-unquoted-state]]. Switch to the [[#character-reference-state]].</dd>
+    <dd>Set the |[=return state=]| to the [[#attribute-value-unquoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
@@ -3448,7 +3448,7 @@
   Otherwise, if there is an <a>adjusted current node</a> and it is not an element in the
   <a>HTML namespace</a> and the next seven characters are a <a>case-sensitive</a> match
   for the string "[CDATA[" (the five uppercase letters "CDATA" with a U+005B LEFT SQUARE BRACKET
-  character before and after), then consume those characters and switch to the [[#cdata-section-state]].
+  character before and after), then consume those characters and switch to the [[#CDATA-section-state]].
 
   Otherwise, this is a <a for="parser">parse error</a>. Create a comment token whose data is the
   empty string. Switch to the [[#bogus-comment-state]] (don't consume anything in the current state).
@@ -3604,24 +3604,19 @@
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd>Switch to the [[#data-state]]. Emit the comment token.</dd>
 
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and a U+FFFD
-    REPLACEMENT CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
-
     <dt>U+0021 EXCLAMATION MARK (!)</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#comment-end-bang-state]].</dd>
+    <dd>Switch to the [[#comment-end-bang-state]].</dd>
 
     <dt>U+002D HYPHEN-MINUS (-)</dt>
-    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) to the comment token's
+    <dd>Append a U+002D HYPHEN-MINUS character (-) to the comment token's
     data.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit the comment token.
+    Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and the <a>current
-    input character</a> to the comment token's data. Switch to the [[#comment-state]].</dd>
+    <dd>Append two U+002D HYPHEN-MINUS characters (-) to the comment token's data. [=Reconsume=] in the [[#comment-state]].</dd>
 
   </dl>
 
@@ -3636,20 +3631,14 @@
     the comment token's data. Switch to the [[#comment-end-dash-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd>Switch to the [[#data-state]]. Emit the comment token.</dd>
-
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-), a U+0021 EXCLAMATION
-    MARK character (!), and a U+FFFD REPLACEMENT CHARACTER character to the comment token's data.
-    Switch to the [[#comment-state]].</dd>
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit the comment token.
+    Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Append two U+002D HYPHEN-MINUS characters (-), a U+0021 EXCLAMATION MARK character (!), and
-    the <a>current input character</a> to the comment token's data. Switch to the [[#comment-state]].</dd>
+    <dd>Append two U+002D HYPHEN-MINUS characters (-) and a U+0021 EXCLAMATION MARK character (!) to the comment token's data. [=Reconsume=] in the [[#comment-state]].</dd>
 
   </dl>
 
@@ -3667,12 +3656,11 @@
     <dd>Switch to the [[#before-doctype-name-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
-    Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Create a new DOCTYPE token.
+    Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#before-doctype-name-state]]. Reconsume the
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#before-doctype-name-state]].</dd>
 
   </dl>
 
@@ -3703,8 +3691,8 @@
     <i>on</i>. Switch to the [[#data-state]]. Emit the token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
-    Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Create a new DOCTYPE token.
+    Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Create a new DOCTYPE token. Set the token's name to the <a>current input character</a>.
@@ -3737,8 +3725,8 @@
     DOCTYPE token's name.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current DOCTYPE token's name.</dd>
@@ -3762,8 +3750,8 @@
     <dd>Switch to the [[#data-state]]. Emit the current DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>
@@ -3808,8 +3796,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -3843,8 +3831,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -3870,8 +3858,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current DOCTYPE token's public
@@ -3897,8 +3885,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current DOCTYPE token's public
@@ -3931,8 +3919,8 @@
     missing), then switch to the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -3965,8 +3953,8 @@
     the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -4000,8 +3988,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -4035,8 +4023,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
@@ -4062,8 +4050,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current DOCTYPE token's system
@@ -4089,8 +4077,8 @@
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current DOCTYPE token's system
@@ -4115,8 +4103,8 @@
     <dd>Switch to the [[#data-state]]. Emit the current DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
-    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's
+    <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd><a for="parser">Parse error</a>. Switch to the [[#bogus-doctype-state]]. (This does
@@ -4134,103 +4122,182 @@
     <dd>Switch to the [[#data-state]]. Emit the DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd>Switch to the [[#data-state]]. Emit the DOCTYPE token. Reconsume the EOF
-    character.</dd>
+    <dd>Emit the DOCTYPE token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Ignore the character.</dd>
 
   </dl>
 
-<h5 id="cdata-section-state">CDATA section state</h5>
+<h5 id="CDATA-section-state">CDATA section state</h5>
 
-  Switch to the [[#data-state]].
-
-  Consume every character up to the next occurrence of the three character sequence U+005D RIGHT
-  SQUARE BRACKET U+005D RIGHT SQUARE BRACKET U+003E GREATER-THAN SIGN (<code>]]&gt;</code>),
-  or the end of the file (EOF), whichever comes first. Emit a series of character tokens consisting
-  of all the characters consumed except the matching three character sequence at the end (if one was
-  found before the end of the file).
-
-  If the end of the file was reached, reconsume the EOF character.
-
-<h5 id="tokenizing-character-references">Tokenizing character references</h5>
-
-  This section defines how to <dfn>consume a character reference</dfn>, optionally with an
-  <dfn>additional allowed character</dfn>, which, if specified where the algorithm is invoked, adds
-  a character to the list of characters that cause there to not be a character reference.
-
-  This definition is used when parsing character references in text and in attributes.
-
-  The behavior depends on the identity of the next character (the one immediately after the
-  U+0026 AMPERSAND character), as follows:
+  Consume the <a>next input character</a>:
 
   <dl class="switch">
 
+    <dt>U+005D RIGHT SQUARE BRACKET (])</dt>
+    <dd>Switch to the [[#CDATA-section-bracket-state]].</dd>
+
+    <dt>EOF</dt>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
+
+    <dt>Anything else</dt>
+    <dd>Emit the [=current input character=] as a character token.</dd>
+
+    <p class="note">U+0000 NULL characters are handled in the tree construction stage, as part of the [[#the-rules-for-parsing-tokens-in-foreign-content|in foreign content]] insertion mode, which is the only place where CDATA sections can appear.</p>
+
+<h5 id="CDATA-section-bracket-state">CDATA section bracket state</h5>
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
+
+    <dt>U+005D RIGHT SQUARE BRACKET (])</dt>
+    <dd>Switch to the [[#CDATA-section-end-state]].</dd>
+
+    <dt>Anything else</dt>
+    <dd>Emit a U+005D RIGHT SQUARE BRACKET character token. [=Reconsume=] in the [[#CDATA-section-state]]</dd>
+
+<h5 id="CDATA-section-end-state">CDATA section end state</h5>
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
+
+    <dt>U+005D RIGHT SQUARE BRACKET (])</dt>
+    <dd>Emit a U+005D RIGHT SQUARE BRACKET character token.</dd>
+
+    <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
+    <dd>Switch to the [[#data-state]].</dd>
+
+    <dt>Anything else</dt>
+    <dd>Emit two U+005D RIGHT SQUARE BRACKET character tokens. [=Reconsume=] in the [[#CDATA-section-state]]</dd>
+
+<h5 id="character-reference-state">Character reference state</h5>
+
+  Set the |[=temporary buffer=]| to the empty string. Append a U+0026 AMPERSAND (&amp;) character to the temporary buffer.
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
     <dt>U+0009 CHARACTER TABULATION (tab)</dt>
     <dt>U+000A LINE FEED (LF)</dt>
     <dt>U+000C FORM FEED (FF)</dt>
-
     <dt>U+0020 SPACE</dt>
     <dt>U+003C LESS-THAN SIGN</dt>
     <dt>U+0026 AMPERSAND</dt>
     <dt>EOF</dt>
-    <dt>The <a>additional allowed character</a>, if there is one</dt>
-
-    <dd>Not a character reference. No characters are consumed, and nothing is returned. (This is not
-    an error, either.)</dd>
+    <dd>[=Reconsume=] in the [[#character-reference-end-state]].</dd>
 
     <dt>U+0023 NUMBER SIGN (#)</dt>
+    <dd>Append the [=current input character=] to the |[=temporary buffer=]|. Switch to the [[#numeric-character-reference-state]].
 
-    <dd>
+    <dt>Anything else</dt>
+    <dd>Consume the maximum number of characters possible, with the consumed characters matching one of the identifiers in the first column of the [[#named-character-references]] table (in a [=case-sensitive=] manner). Append each character to the |[=temporary buffer=]| when it's consumed.
 
-    Consume the U+0023 NUMBER SIGN.
+        If no match can be made and the |[=temporary buffer=]| consists of a U+0026 AMPERSAND character (&) followed by a sequence of one or more [=alphanumeric ASCII characters=] and a U+003B SEMICOLON character (;), then this is a <a for="parser">parse error</a>.
 
-    The behavior further depends on the character after the U+0023 NUMBER SIGN:
+        If no match can be made, switch to the [[#character-reference-end-state]].
 
-    <dl class="switch">
+        If the character reference was consumed as part of an attribute (|[=return state=]| is either [[#attribute-value-double-quoted-state]], [[#attribute-value-single-quoted-state]] or [[#attribute-value-unquoted-state]]), and the last character matched is not a U+003B SEMICOLON character (;), and the [=next input character=] is either a U+003D EQUALS SIGN character (=) or an [=alphanumeric ASCII character=], then, for historical reasons, switch to the [[#character-reference-end-state]].
 
+        If the last character matched is not a U+003B SEMICOLON character (;), this is a <a for="parser">parse error</a>.
+
+        Set the |[=temporary buffer=]| to the empty string. Append one or two characters corresponding to the character reference name (as given by the second column of the [[#named-character-references]] table) to the |[=temporary buffer=]|.
+
+        Switch to the [[#character-reference-end-state]].
+
+        <div class="example">
+
+          If the markup contains (not in an attribute) the string <code>I'm &amp;notit; I tell you</code>, the character reference is parsed as "not", as in, <code>I'm ¬it; I tell you</code> (and this is a parse error). But if the markup was <code>I'm &amp;notin; I tell you</code>, the character reference would be parsed as "notin;", resulting in <code>I'm ∉ I tell you</code> (and no parse error).
+
+          However, if the markup contains the string <code>I'm &amp;notit; I tell you</code> in an attribute, no character reference is parsed and string remains intact (and there is no parse error).
+        </div>
+    </dd>
+  </dl>
+
+<h5 id="numeric-character-reference-state">Numeric character reference state</h5>
+
+  Set the <dfn>character reference code</dfn> to zero (0).
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
       <dt>U+0078 LATIN SMALL LETTER X</dt>
       <dt>U+0058 LATIN CAPITAL LETTER X</dt>
-
-      <dd>
-
-      Consume the X.
-
-      Follow the steps below, but using <a>ASCII hex digits</a>.
-
-      When it comes to interpreting the number, interpret it as a hexadecimal number.
-
-      </dd>
+      <dd>Append the [=current input character=] to the |[=temporary buffer=]|. Switch to the [[#hexadecimal-character-reference-start-state]].</dd>
 
       <dt>Anything else</dt>
+      <dd>[=Reconsume=] in the [[#decimal-character-reference-start-state]].</dd>
+  </dl>
 
-      <dd>
+<h5 id="hexadecimal-character-reference-start-state">Hexadecimal character reference start state</h5>
 
-      Follow the steps below, but using <a>ASCII digits</a>.
+  Consume the <a>next input character</a>:
 
-      When it comes to interpreting the number, interpret it as a decimal number.
+  <dl class="switch">
+      <dt>[=ASCII hex digit=]</dt>
+      <dd>[=Reconsume=] in the [[#hexadecimal-character-reference-state]].</dd>
 
-      </dd>
+      <dt>Anything else</dt>
+      <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#character-reference-end-state]].</dd>
+  </dl>
 
-    </dl>
+<h5 id="decimal-character-reference-start-state">Decimal character reference start state</h5>
 
-    Consume as many characters as match the range of characters given above (<a>ASCII hex digits</a>
-    or <a>ASCII digits</a>).
+  Consume the <a>next input character</a>:
 
-    If no characters match the range, then don't consume any characters (and unconsume the U+0023
-    NUMBER SIGN character and, if appropriate, the X character). This is a <a for="parser">parse error</a>;
-    nothing is returned.
+  <dl class="switch">
+      <dt>[=ASCII digit=]</dt>
+      <dd>[=Reconsume=] in the [[#decimal-character-reference-state]].</dd>
 
-    Otherwise, if the next character is a U+003B SEMICOLON, consume that too. If it isn't, there
-    is a <a for="parser">parse error</a>.
+      <dt>Anything else</dt>
+      <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#character-reference-end-state]].</dd>
+  </dl>
 
-    If one or more characters match the range, then take them all and interpret the string of
-    characters as a number (either hexadecimal or decimal as appropriate).
+<h5 id="hexadecimal-character-reference-state">Hexadecimal character reference state</h5>
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
+      <dt>[=Uppercase ASCII hex digit=]</dt>
+      <dd>Multiply the |[=character reference code=]| by 16. Add a numeric version of the [=current input character=] as a hexademical digit (subtract 0x0037 from the character's code point) to the |[=character reference code=]|.</dd>
+
+      <dt>[=Lowercase ASCII hex digit=]</dt>
+      <dd>Multiply the |[=character reference code=]| by 16. Add a numeric version of the [=current input character=] as a hexademical digit (subtract 0x0057 from the character's code point) to the |[=character reference code=]|.</dd>
+
+      <dt>[=ASCII digit=]</dt>
+      <dd>Multiply the |[=character reference code=]| by 16. Add a numeric version of the [=current input character=] (subtract 0x0030 from the character's code point) to the |[=character reference code=]|.</dd>
+
+      <dt>U+003B SEMICOLON character (;)</dt>
+      <dd>Switch to the [[#numeric-character-reference-end-state]].</dd>
+
+      <dt>Anything else</dt>
+      <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#numeric-character-reference-end-state]].</dd>
+  </dl>
+
+<h5 id="decimal-character-reference-state">Decimal character reference state</h5>
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
+      <dt>[=ASCII digit=]</dt>
+      <dd>Multiply the |[=character reference code=]| by 16. Add a numeric version of the [=current input character=] (subtract 0x0030 from the character's code point) to the |[=character reference code=]|.</dd>
+
+      <dt>U+003B SEMICOLON character (;)</dt>
+      <dd>Switch to the [[#numeric-character-reference-end-state]].</dd>
+
+      <dt>Anything else</dt>
+      <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#numeric-character-reference-end-state]].</dd>
+  </dl>
+
+<h5 id="numeric-character-reference-end-state">Numeric character reference end state</h5>
+
+    Check the |[=character reference code=]|.
 
     If that number is one of the numbers in the first column of the following table, then this is
-    a <a for="parser">parse error</a>. Find the row with that number in the first column, and return a
-    character token for the Unicode character given in the second column of that row.
+    a <a for="parser">parse error</a>. Find the row with that number in the first column, and set the
+    |[=character reference code=]| to the number in the second column of that row.
 
     <table>
       <thead>
@@ -4271,66 +4338,34 @@
       <tr><td>0x9F <td>U+0178 <td>LATIN CAPITAL LETTER Y WITH DIAERESIS (&#x0178;)
     </table>
 
-    Otherwise, if the number is in the range 0xD800 to 0xDFFF or is greater
-    than 0x10FFFF, then this is a <a for="parser">parse error</a>. Return a U+FFFD REPLACEMENT CHARACTER
-    character token.
+    If the number is in the range 0xD800 to 0xDFFF or is greater
+    than 0x10FFFF, then this is a <a for="parser">parse error</a>. Set the |[=character reference code=]| to 0xFFFD.
 
-    Otherwise, return a character token for the Unicode character whose code point is that
-    number.
-
-      Additionally, if the number is in the range 0x0001 to 0x0008,    0x000D to 0x001F,  0x007F  to 0x009F, 0xFDD0 to 0xFDEF, or is
+    If the number is in the range 0x0001 to 0x0008,    0x000D to 0x001F,  0x007F  to 0x009F, 0xFDD0 to 0xFDEF, or is
     one of 0x000B, 0xFFFE, 0xFFFF, 0x1FFFE, 0x1FFFF, 0x2FFFE, 0x2FFFF, 0x3FFFE, 0x3FFFF, 0x4FFFE,
     0x4FFFF, 0x5FFFE, 0x5FFFF, 0x6FFFE, 0x6FFFF, 0x7FFFE, 0x7FFFF, 0x8FFFE, 0x8FFFF, 0x9FFFE,
     0x9FFFF, 0xAFFFE, 0xAFFFF, 0xBFFFE, 0xBFFFF, 0xCFFFE, 0xCFFFF, 0xDFFFE, 0xDFFFF, 0xEFFFE,
     0xEFFFF, 0xFFFFE, 0xFFFFF, 0x10FFFE, or 0x10FFFF, then this is a <a for="parser">parse error</a>.
 
-    </dd>
+    Set the |[=temporary buffer=]| to the empty string. Append the Unicode character with code point equal to the |[=character reference code=]| to the |[=temporary buffer=]|. Switch to the [[#character-reference-end-state]].
+
+<h5 id="character-reference-end-state">Character reference end state</h5>
+
+  Consume the [=next input character=].
+
+  Check the |[=return state=]|:
+
+  <dl class="switch">
+    <dt>[[#attribute-value-double-quoted-state]]</dt>
+    <dt>[[#attribute-value-single-quoted-state]]</dt>
+    <dt>[[#attribute-value-unquoted-state]]</dt>
+    <dd>Append each character in the |[=temporary buffer=]| (in the order they were added to the buffer) to the current attribute's value.</dd>
 
     <dt>Anything else</dt>
-
-    <dd>
-
-    Consume the maximum number of characters possible, with the consumed characters matching one
-    of the identifiers in the first column of the [[#named-character-references]] table (in
-    a <a>case-sensitive</a> manner).
-
-    If no match can be made, then no characters are consumed, and nothing is returned. In this
-    case, if the characters after the U+0026 AMPERSAND character (&amp;) consist of a sequence of
-    one or more <a>alphanumeric ASCII characters</a> followed by a U+003B SEMICOLON character
-    (;), then this is a <a for="parser">parse error</a>.
-
-    If the character reference is being consumed <a>as part of an attribute</a>, and the last character matched is not a U+003B
-    SEMICOLON character (;), and the next character is either a U+003D EQUALS SIGN character (=) or
-    an <a>alphanumeric ASCII character</a>, then, for
-    historical reasons, all the characters that were matched after the U+0026 AMPERSAND character
-    (&amp;) must be unconsumed, and nothing is returned.
-
-    However, if this next character is in fact a U+003D EQUALS SIGN character (=), then this is a
-    <a for="parser">parse error</a>, because some legacy user agents  will
-    misinterpret the markup in those cases.
-
-    Otherwise, a character reference is parsed. If the last character matched is not a U+003B
-    SEMICOLON character (;), there is a <a for="parser">parse error</a>.
-
-    Return one or two character tokens for the character(s) corresponding to the character
-    reference name (as given by the second column of the [[#named-character-references]]
-    table).
-
-    <div class="example">
-      If the markup contains (not in an attribute) the string <code>I'm &amp;notit; I
-      tell you</code>, the character reference is parsed as "not", as in, <code>I'm &not;it;
-      I tell you</code> (and this is a parse error). But if the markup was <code>I'm
-      &amp;notin; I tell you</code>, the character reference would be parsed as "notin;", resulting
-      in <code>I'm &notin; I tell you</code> (and no parse error).
-    </div>
-
-    </dd>
-
+    <dd>For each of the characters in the |[=temporary buffer=]| (in the order they were added to the buffer), emit the character as a character token.</dd>
   </dl>
 
-  </div>
-
-  <div class="impl">
+  [=Reconsume=] in the |[=return state=]|.
 
 <h4 id="tree-construction">Tree construction</h4>
 
@@ -4842,7 +4877,7 @@
     <li>If the algorithm that was invoked is the <a>generic raw text element parsing
     algorithm</a>, switch the tokenizer to the [[#rawtext-state]]; otherwise the algorithm
     invoked was the <a>generic RCDATA element parsing algorithm</a>, switch the tokenizer to
-    the [[#rcdata-state]].</li>
+    the [[#RCDATA-state]].</li>
 
     <li>Let the <a>original insertion mode</a> be the current <a>insertion
     mode</a>.
@@ -6341,7 +6376,7 @@
       that token and move on to the next one. (Newlines at the start of <code>textarea</code>
       elements are ignored as an authoring convenience.)</li>
 
-      <li>Switch the tokenizer to the [[#rcdata-state]].</li>
+      <li>Switch the tokenizer to the [[#RCDATA-state]].</li>
 
       <li>Let the <a>original insertion mode</a> be the current <a>insertion
       mode</a>.
@@ -9142,7 +9177,7 @@
 
       <dt>If it is a <{title}> or <{textarea}> element</dt>
 
-      <dd>Switch the tokenizer to the [[#rcdata-state]].</dd>
+      <dd>Switch the tokenizer to the [[#RCDATA-state]].</dd>
 
       <dt>If it is a <{style}>, <{xmp}>, <{iframe}>,
       <{noembed}>, or <{noframes}> element</dt>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -18,33 +18,23 @@
 
 <h3 id="writing-html-documents">Writing HTML documents</h3>
 
-  <i>This section only applies to documents, authoring tools, and markup generators. In
-  particular, it does not apply to conformance checkers; conformance checkers must use the
-  requirements given in the next section ("parsing HTML documents").</i>
+  <i>This section only applies to documents, authoring tools, and markup generators. In particular, 
+  it does not apply to conformance checkers; conformance checkers must use the requirements given in 
+  the next section ("parsing HTML documents").</i>
 
-  Documents must consist of the following parts, in the given
-  order:
+  Documents must consist of the following parts, in the given order:
 
-  <ol>
-
-    <li>Optionally, a single U+FEFF BYTE ORDER MARK (BOM) character.</li>
-
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
-
-    <li>A <a>DOCTYPE</a>.</li>
-
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
-
-    <li>The <a>document element</a>, in the form of an <{html}> element.</li>
-
-    <li>Any number of <a>comments</a> and <a>space characters</a>.</li>
-
-  </ol>
+  1. Optionally, a single U+FEFF BYTE ORDER MARK (BOM) character.
+  2. Any number of [=comments=] and [=space characters=].
+  3. A [=DOCTYPE=].
+  4. Any number of [=comments=] and [=space characters=].
+  5. The <a>document element</a>, in the form of an <{html}> element.
+  6. Any number of [=comments=] and [=space characters=].
 
   The various types of content mentioned above are described in the next few sections.
 
-  In addition, there are some restrictions on how <a>character encoding declarations</a> are to be serialized, as discussed in the
-  section on that topic.
+  In addition, there are some restrictions on how [=character encoding declarations=] are to be 
+  serialized, as discussed in the section on that topic.
 
   <div class="note">
 
@@ -79,10 +69,10 @@
   A DOCTYPE must consist of the following components, in this order:
 
   1. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>&lt;!DOCTYPE</code>".
-  2. One or more <a>space characters</a>.
+  2. One or more [=space characters=].
   3. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>html</code>".
   4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> (defined below).
-  5. Zero or more <a>space characters</a>.
+  5. Zero or more [=space characters=].
   6. A U+003E GREATER-THAN SIGN character (&gt;).
 
   <p class="note">
@@ -95,9 +85,9 @@
   "<code>&lt;!DOCTYPE html></code>", a <dfn>DOCTYPE legacy string</dfn> may be inserted
   into the DOCTYPE (in the position defined above). This string must consist of:
 
-  1. One or more <a>space characters</a>.
+  1. One or more [=space characters=].
   2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>SYSTEM</code>".
-  3. One or more <a>space characters</a>.
+  3. One or more [=space characters=].
   4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>quote mark</i>).
   5. The literal string "<code>about:legacy-compat</code>".
   6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>quote mark</i>).
@@ -117,14 +107,14 @@
   string</dfn> can be inserted into the DOCTYPE (in the position defined above). This string must
   consist of:
 
-  1. One or more <a>space characters</a>.
+  1. One or more [=space characters=].
   2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>PUBLIC</code>".
-  3. One or more <a>space characters</a>.
+  3. One or more [=space characters=].
   4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>first quote mark</i>).
   5. The string from one of the cells in the first column of the table below. The row to which this cell belongs is the <i>selected row</i>.
   6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>first quote mark</i>).
   7. If a system identifier is used,
-      1. One or more <a>space characters</a>.
+      1. One or more [=space characters=].
       2. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>third quote mark</i>).
       3. The string from the cell in the second column of the <i>selected row</i>.
       4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>third quote mark</i>).
@@ -157,7 +147,7 @@
       <td> No
   </table>
 
-  A <a>DOCTYPE</a> containing an <a>obsolete permitted DOCTYPE
+  A [=DOCTYPE=] containing an <a>obsolete permitted DOCTYPE
   string</a> is an <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use <a>obsolete permitted DOCTYPEs</a>, as they are unnecessarily
   long.
 
@@ -226,7 +216,7 @@
   tag). <a>Foreign elements</a> whose start tag is <em>not</em> marked as self-closing can
   have <a>text</a>, <a>character
   references</a>, <a>CDATA sections</a>, other <a lt="kind of element">elements</a>, and
-  <a>comments</a>, but the text must not contain the character U+003C LESS-THAN SIGN (&lt;) or an
+  [=comments=], but the text must not contain the character U+003C LESS-THAN SIGN (&lt;) or an
   <a>ambiguous ampersand</a>.
 
   <div class="note">
@@ -256,7 +246,7 @@
   </div>
 
   <a>Normal elements</a> can have <a>text</a>, <a>character references</a>, other
-  <a lt="kind of element">elements</a>, and <a>comments</a>, but
+  <a lt="kind of element">elements</a>, and [=comments=], but
   the text must not contain the character U+003C LESS-THAN SIGN (&lt;) or an
   <a>ambiguous ampersand</a>. Some <a>normal elements</a>
   also have <a>yet more restrictions</a> on what content they are
@@ -279,14 +269,14 @@
 
     <li>The next few characters of a start tag must be the element's <a>tag name</a>.</li>
 
-    <li>If there are to be any attributes in the next step, there must first be one or more <a>space characters</a>.</li>
+    <li>If there are to be any attributes in the next step, there must first be one or more [=space characters=].</li>
 
     <li>Then, the start tag may have a number of attributes, the <a>syntax for which</a> is described below. Attributes must be
     separated from each other by one or more <a>space
     characters</a>.</li>
 
     <li>After the attributes, or after the <a>tag name</a> if there are
-    no attributes, there may be one or more <a>space characters</a>.
+    no attributes, there may be one or more [=space characters=].
     (Some attributes are required to be followed by a space. See [[#elements-attributes]] below.)</li>
 
     <li>Then, if the element is one of the <a>void elements</a>, or if the element is a <a>foreign element</a>, then there may be a single U+002F SOLIDUS
@@ -363,10 +353,10 @@
 
     <dd>
 
-    The <a>attribute name</a>, followed by zero or more <a>space characters</a>, followed by a single U+003D EQUALS SIGN
-    character, followed by zero or more <a>space characters</a>,
+    The <a>attribute name</a>, followed by zero or more [=space characters=], followed by a single U+003D EQUALS SIGN
+    character, followed by zero or more [=space characters=],
     followed by the <a>attribute value</a>, which, in addition
-    to the requirements given above for attribute values, must not contain any literal <a>space characters</a>, any U+0022 QUOTATION MARK characters (&#x22;),
+    to the requirements given above for attribute values, must not contain any literal [=space characters=], any U+0022 QUOTATION MARK characters (&#x22;),
     U+0027 APOSTROPHE characters (&#x27;), U+003D EQUALS SIGN characters (=), U+003C LESS-THAN SIGN
     characters (&lt;), U+003E GREATER-THAN SIGN characters (&gt;), or U+0060 GRAVE ACCENT characters
     (`), and must not be the empty string.
@@ -390,8 +380,8 @@
 
     <dd>
 
-    The <a>attribute name</a>, followed by zero or more <a>space characters</a>, followed by a single U+003D EQUALS SIGN
-    character, followed by zero or more <a>space characters</a>,
+    The <a>attribute name</a>, followed by zero or more [=space characters=], followed by a single U+003D EQUALS SIGN
+    character, followed by zero or more [=space characters=],
     followed by a single U+0027 APOSTROPHE character ('), followed by the <a>attribute value</a>, which, in addition to the requirements
     given above for attribute values, must not contain any literal U+0027 APOSTROPHE characters ('),
     and finally followed by a second single U+0027 APOSTROPHE character (').
@@ -414,8 +404,8 @@
 
     <dd>
 
-    The <a>attribute name</a>, followed by zero or more <a>space characters</a>, followed by a single U+003D EQUALS SIGN
-    character, followed by zero or more <a>space characters</a>,
+    The <a>attribute name</a>, followed by zero or more [=space characters=], followed by a single U+003D EQUALS SIGN
+    character, followed by zero or more [=space characters=],
     followed by a single U+0022 QUOTATION MARK character ("), followed by the <a>attribute value</a>, which, in addition to the requirements
     given above for attribute values, must not contain any literal U+0022 QUOTATION MARK characters
     ("), and finally followed by a second single U+0022 QUOTATION MARK character (").
@@ -946,7 +936,7 @@
 
   The numeric character reference forms described above are allowed to reference any Unicode code
   point other than U+0000, U+000D, permanently undefined Unicode characters (noncharacters),
-  surrogates (U+D800&ndash;U+DFFF), and <a>control characters</a> other than <a>space characters</a>.
+  surrogates (U+D800&ndash;U+DFFF), and <a>control characters</a> other than [=space characters=].
 
   An <dfn>ambiguous ampersand</dfn> is a U+0026 AMPERSAND
   character (&amp;) that is followed by one or more <a>alphanumeric ASCII characters</a>,
@@ -7211,7 +7201,7 @@
     <dd>
 
     If any of the tokens in the <var>pending table
-    character tokens</var> list are character tokens that are not <a>space characters</a>, then this is a <a for="parser">parse error</a>: reprocess the
+    character tokens</var> list are character tokens that are not [=space characters=], then this is a <a for="parser">parse error</a>: reprocess the
     character tokens in the <var>pending table character
     tokens</var> list using the rules given in the "anything else" entry in the "<a>in table</a>" insertion mode.
 
@@ -8879,8 +8869,8 @@
   that this doesn't match the resulting tree!); the <a>list of active formatting elements</a>
   has the new <{b}> element in it; and the <a>insertion mode</a> is still "<a>in table body</a>".
 
-  Had the character tokens been only <a>space characters</a>
-  instead of "bbb", then those <a>space characters</a> would just be
+  Had the character tokens been only [=space characters=]
+  instead of "bbb", then those [=space characters=] would just be
   appended to the <{tbody}> element.
 
   Finally, the <code>table</code> is closed by a "table" end tag. This pops all the nodes from

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -456,7 +456,7 @@
     <tr> <td> <code>lang</code>    <td> [=XML namespace=]   <td> <{xml/lang|xml:lang}>
     <tr> <td> <code>space</code>   <td> [=XML namespace=]   <td> <{xml/space|xml:space}>
     <tr> <td> <code>xmlns</code>   <td> [=XMLNS namespace=] <td> <{xmlns/xmlns}>
-    <tr> <td> <code>xlink</code>   <td> [=XMLNS namespace=] <td> <code>xmlns:xlink</code>
+    <tr> <td> <code>xlink</code>   <td> [=XMLNS namespace=] <td> <{xlink/xlink|xmlns:xlink}>
   </table>
 
   No other namespaced attribute can be expressed in <a href="#syntax">the HTML syntax</a>.
@@ -2189,7 +2189,7 @@
     <li>SVG <a element for="svg"><code>title</code></a></li>
   </ul>
 
-  The <a>stack of open elements</a> is said to <dfn>have a particular element in list item scope</dfn> when it <a>has that element in the specific scope</a> consisting of the following
+  The <a>stack of open elements</a> is said to <dfn lt="have an li element in list item scope">have a particular element in list item scope</dfn> when it <a>has that element in the specific scope</a> consisting of the following
   element types:
 
   <ul class="brief">
@@ -2215,7 +2215,7 @@
     <li><{template}> in the [=HTML namespace=]</li>
   </ul>
 
-  The <a>stack of open elements</a> is said to <dfn lt="have an li element in list item scope|have a particular element in select scope">have a particular element in select scope</dfn> when it <a>has that element in the specific scope</a> consisting of all element types
+  The <a>stack of open elements</a> is said to <dfn lt="have a particular element in select scope|have a select element in select scope">have a particular element in select scope</dfn> when it <a>has that element in the specific scope</a> consisting of all element types
   <em>except</em> the following:
 
   <ul class="brief">
@@ -4557,42 +4557,41 @@
 
   <hr />
 
-  When the steps below require the UA to <dfn lt="create an element for the token|create an element for a token">create an element for a token</dfn> in a particular <var>given namespace</var> and with a
+  When the steps below require the UA to <dfn lt="create an element for the token|create an element for a token|creating an element for the token">create an element for a token</dfn> in a particular <var>given namespace</var> and with a
   particular <var>intended parent</var>, the UA must run the following steps:
 
   1. Let |document| be |intended parent|'s [=node document=].
   2. Let |local name| be the tag name of the token.
   3. Let |is| be the value of the "<code>is</code>" attribute in the given token, if such an attribute exists, or null otherwise.
-  4. Let definition be the result of looking up a custom element definition given document, given namespace, local name, and is.
-  5. If definition is non-null and the parser was not originally created for the HTML fragment parsing algorithm, then let will execute script be true. Otherwise, let it be false.
-  6. If will execute script is true, then:
-    1. Increment document's throw-on-dynamic-markup-insertion counter.
-    2. If the JavaScript execution context stack is empty, then perform a microtask checkpoint.
-    3. Push a new element queue onto the custom element reactions stack.
-  7. Let element be the result of creating an element given document, localName, given namespace, null, and is. If will execute script is true, set the synchronous custom elements flag; otherwise, leave it unset.
-    <p class="note">This will cause custom element constructors to run, if will execute script is true. However, since we incremented the throw-on-dynamic-markup-insertion counter, this cannot cause new characters to be inserted into the tokenizer, or the document to be blown away.</p>
-  8. Append each attribute in the given token to element.
-    <p class="note">This can enqueue a custom element callback reaction for the attributeChangedCallback, which might run immediately (in the next step).</p>
-    <p class="note">Even though the is attribute governs the creation of a customized built-in element, it is not present during the execution of the relevant custom element constructor; it is appended in this step, along with all other attributes.</p>
-  9. If will execute script is true, then:
-    1. Let queue be the result of popping the current element queue from the custom element reactions stack. (This will be the same element queue as was pushed above.)
-    2. Invoke custom element reactions in queue.
-    3. Decrement document's throw-on-dynamic-markup-insertion counter.
-  10. If the newly created element has an <{xmlns/xmlns}> attribute <em>in the
+  4. Let |definition| be the result of [=looking up a custom element definition=] given |document|, |given namespace|, |local name|, and |is|.
+  5. If |definition| is non-null and the parser was not originally created for the [=HTML fragment parsing algorithm=], then let |will execute script| be true. Otherwise, let it be false.
+  6. If |will execute script| is true, then:
+    1. Increment |document|'s [=throw-on-dynamic-markup-insertion counter=].
+    2. If the [=JavaScript execution context stack=] is empty, then [=perform a microtask checkpoint=].
+    3. Push a new [=element queue=] onto the [=custom element reactions stack=].
+  7. Let |element| be the result of [=creating an element=] given |document|, |local name|, |given namespace|, null, and |is|. If |will execute script| is true, set the synchronous custom elements flag; otherwise, leave it unset.
+    <p class="note">This will cause [=custom element constructors=] to run, if will execute script is true. However, since we incremented the [=throw-on-dynamic-markup-insertion counter=], this cannot cause {{Document/write()|new characters to be inserted into the tokenizer}}, or {{Document/open()|the document to be blown away}}.</p>
+  8. [=Append=] each attribute in the given token to |element|.
+    <p class="note">This can [=enqueue a custom element callback reaction=] for the <code>attributeChangedCallback</code>, which might run immediately (in the next step).</p>
+    <p class="note">Even though the <code>is</code> attribute governs the [=create an element|creation=] of a [=customized built-in element=], it is not present during the execution of the relevant [=custom element constructor=]; it is appended in this step, along with all other attributes.</p>
+  9. If |will execute script| is true, then:
+    1. Let |queue| be the result of popping the [=current element queue=] from the [=custom element reactions stack=]. (This will be the same [=element queue=] as was pushed above.)
+    2. [=Invoke custom element reactions=] in |queue|.
+    3. Decrement |document|'s [=throw-on-dynamic-markup-insertion counter=].
+  10. If |element| has an <{xmlns/xmlns}> attribute <em>in the
     <a>XMLNS namespace</a></em> whose value is not exactly the same as the element's namespace,
-    that is a <a for="parser">parse error</a>. Similarly, if the newly created element has an <code>xmlns:xlink</code> attribute in the <a>XMLNS namespace</a> whose value is not the
+    that is a <a for="parser">parse error</a>. Similarly, if |element| has an <{xlink/xlink|xmlns:xlink}> attribute in the [=XMLNS namespace=] whose value is not the
     <a>XLink namespace</a>, that is a <a for="parser">parse error</a>.
-  11. If the newly created element is a <a>resettable element</a>,
+  11. If |element| is a <a>resettable element</a>,
     invoke its <a>reset algorithm</a>. (This initializes the
     element's <a for="forms">value</a> and <a for="forms">checkedness</a> based on the element's attributes.)
-  12. If the element is a <a>form-associated element</a>, and the <a><code>form</code> element pointer</a> is not null, and there is no <code>template</code>
-    element on the <a>stack of open elements</a>, and the newly created element is either not
-    <a>reassociateable</a> or doesn't have a <code>form</code> attribute, and the <var>intended parent</var> is in
-    the same <a>tree</a> as the element pointed to by the <a><code>form</code> element pointer</a>, associate the newly created element with the
+  12. If |element| is a <a>form-associated element</a>, and the <a><code>form</code> element pointer</a> is not null, and there is no <code>template</code>
+    element on the <a>stack of open elements</a>, and |element| is either not [=listed elements|listed=] or doesn't have a <{formelements/form}> attribute, and the <var>intended parent</var> is in
+    the same <a>tree</a> as the element pointed to by the <a><code>form</code> element pointer</a>, [=associate=] |element| with the
     <{form}> element pointed to by the <a><code>form</code> element
     pointer</a>, and suppress the running of the <a>reset the form owner</a> algorithm when
     the parser subsequently attempts to insert the element.
-  13. Return element.
+  13. Return |element|.
 
   <hr />
 
@@ -4604,28 +4603,48 @@
     <li>Let the <var>adjusted insertion location</var> be the <a>appropriate place for
     inserting a node</a>.</li>
 
-    <li><a>Create an element for the token</a> in the given namespace, with the intended
+    <li>Let |element| be the result of <a>creating an element for the token</a> in the given namespace, with the intended
     parent being the element in which the <var>adjusted insertion location</var> finds
     itself.</li>
 
     <li>
 
-    If it is possible to insert an element at the <var>adjusted insertion
-    location</var>, then insert the newly created element at the <var>adjusted insertion
-    location</var>.
+    If it is possible to insert |element| at the <var>adjusted insertion location</var>, then:
+
+    <ol>
+       <li>
+
+          <p>Push a new [=element queue=] onto the [=custom element reactions stack=].</p>
+
+   </li>
+
+   <li>
+
+    Insert |element| at the <var>adjusted insertion location</var>.
+
+   </li>
+
+   <li>
+
+    <p>Pop the [=element queue=] from the [=custom element reactions stack=], and [=invoke custom element reactions=] in that queue.</p>
+
+   </li>
+
+  </ol>
+
+
 
     <p class="note">
   If the <var>adjusted insertion location</var> cannot accept more
-    elements, e.g., because it's a <code>Document</code> that already has an element child, then the
-    newly created element is dropped on the floor.
+    elements, e.g., because it's a <code>Document</code> that already has an element child, then |element| is dropped on the floor.
   </p>
 
     </li>
 
-    <li>Push the element onto the <a>stack of open elements</a> so that it is the new
+    <li>Push |element| onto the <a>stack of open elements</a> so that it is the new
     <a>current node</a>.</li>
 
-    <li>Return the newly created element.</li>
+    <li>Return |element|.</li>
 
   </ol>
 
@@ -4786,16 +4805,14 @@
   A&lt;script>
   var&nbsp;script&nbsp;=&nbsp;document.getElementsByTagName('script')[0];
   document.body.removeChild(script);
-  &lt;/script>B
-  </pre>
+  &lt;/script>B</pre>
       <td>One {{Text}} node in the document, containing "AB".
       <tr>
       <td><pre highlight="html">
   A&lt;script>
   var&nbsp;text&nbsp;=&nbsp;document.createTextNode('B');
   document.body.appendChild(text);
-  &lt;/script>C
-  </pre>
+  &lt;/script>C</pre>
       <td>Three {{Text}} nodes; "A" before the script, the script's contents, and "BC" after the script (the parser appends to the {{Text}} node created by the script).
       <tr>
       <td><pre highlight="html">
@@ -4803,23 +4820,19 @@
   var&nbsp;text&nbsp;=&nbsp;document.getElementsByTagName('script')[0].firstChild;
   text.data&nbsp;=&nbsp;'B';
   document.body.appendChild(text);
-  &lt;/script>C
-  </pre>
+  &lt;/script>C</pre>
       <td>Two adjacent {{Text}} nodes in the document, containing "A" and "BC".
       <tr>
       <td><pre highlight="html">
-  A&lt;table>B&lt;tr>C&lt;/tr>D&lt;/table>
-  </pre>
+  A&lt;table>B&lt;tr>C&lt;/tr>D&lt;/table></pre>
       <td>One {{Text}} node before the table, containing "ABCD". (This is caused by <a>foster parenting</a>.)
       <tr>
       <td><pre highlight="html">
-  A&lt;table>&lt;tr>&nbsp;B&lt;/tr>&nbsp;C&lt;/table>
-  </pre>
+  A&lt;table>&lt;tr>&nbsp;B&lt;/tr>&nbsp;C&lt;/table></pre>
       <td>One {{Text}} node before the table, containing "A&nbsp;B&nbsp;C" (A-space-B-space-C). (This is caused by <a>foster parenting</a>.)
       <tr>
       <td><pre highlight="html">
-  A&lt;table>&lt;tr>&nbsp;B&lt;/tr>&nbsp;&lt;/em>C&lt;/table>
-  </pre>
+  A&lt;table>&lt;tr>&nbsp;B&lt;/tr>&nbsp;&lt;/em>C&lt;/table></pre>
       <td>One {{Text}} node before the table, containing "A&nbsp;BC" (A-space-B-C), and one {{Text}} node inside the table (as a child of a <code>tbody</code>) with a single space character. (Space characters separated from non-space characters by non-character tokens are not affected by <a>foster parenting</a>, even if those other tokens then get ignored.)
     </table>
   </div>
@@ -4851,7 +4864,7 @@
 
   <hr />
 
-  DOM mutation events must not fire for changes caused by the user agent
+  DOM mutation events must not fire for changes caused by the UA
   parsing the document. This includes the parsing of any content inserted using {{Document/write()|document.write()}} and <code>document.writeln()</code> calls. [[!UIEVENTS]]
 
   However, <a>mutation observers</a> <em>do</em> fire, as required by the DOM specification.
@@ -4880,28 +4893,28 @@
 
 <h5 id="closing-elements-that-have-implied-end-tags">Closing elements that have implied end tags</h5>
 
-  When the steps below require the user agent to <dfn>generate implied end
+  When the steps below require the UA to <dfn>generate implied end
   tags</dfn>, then, while the <a>current node</a> is a
   <{dd}> element, a <{dt}> element, an
-  <{li}> element, an <{option}> element, an
-  <{optgroup}> element, a <{p}> element, an
+  <{li}> element, a <{menuitem}> element, an
+  <{optgroup}> element, an <{option}> element, a <{p}> element, an
   <{rb}> element, an <{rp}> element, an <code>rt</code>
-  element, or an <{rtc}> element, the user agent must
+  element, or an <{rtc}> element, the UA must
   pop the <a>current node</a> off the <a>stack of open
   elements</a>.
 
-  If a step requires the user agent to generate implied end tags but lists
-  an element to exclude from the process, then the user agent must perform the
+  If a step requires the UA to generate implied end tags but lists
+  an element to exclude from the process, then the UA must perform the
   above steps as if that element was not in the above list.
 
-  When the steps below require the user agent to <dfn>generate all implied end tags thoroughly</dfn>,
+  When the steps below require the UA to <dfn>generate all implied end tags thoroughly</dfn>,
   then, while the <a>current node</a> is a <{caption}> element, a
   <{colgroup}> element, a <{dd}> element, a <{dt}> element, an
   <{li}> element, an <{optgroup}> element, an <{option}> element, a
   <{p}> element, an <{rb}> element, an <{rp}> element, an <code>rt</code>
   element, an <{rtc}> element, a <{tbody}> element, a <{td}> element, a
   <{tfoot}> element, a <{th}> element, a <{thead}> element, or a
-  <{tr}> element, the user agent must pop the <a>current node</a> off the
+  <{tr}> element, the UA must pop the <a>current node</a> off the
   <a>stack of open elements</a>.
 
 <h5 id="the-rules-for-parsing-tokens-in-html-content">The rules for parsing tokens in HTML content</h5>
@@ -5100,6 +5113,43 @@
     {{Document}} as the intended parent. Append it to the {{Document}} object. Put
     this element in the <a>stack of open elements</a>.
 
+    <!-- App cache -->
+      <!--
+      <p>If the {{Document}} is being loaded as part of [=navigation=] of a [=browsing context=], run these steps:</p>
+
+
+  <ol>
+
+   <li>
+
+    <p>If the result of running [=match service worker registration=] for the document's [=URL=] is non-null, run the [=application cache selection algorithm=] passing the {{Document}} object with no manifest.</p>
+
+   </li>
+
+   <li>
+
+    <p>Otherwise, run these substeps:</p>
+
+    <ol>
+
+     <li>
+
+      <p>If the newly created element has a <{html/manifest}> attribute whose value is not the empty string, then [=parse=] the value of that attribute, relative to the newly created element's [=node document=], and if that is successful, run the [=application cache selection algorithm=] passing the {{Document}} object with the result of applying the [=URL serializer=] algorithm to the [=resulting URL record=] with the |exclude fragment flag| set.</p>
+
+     </li>
+
+     <li>
+
+      <p>Otherwise, run the [=application cache selection algorithm=] passing the {{Document}} object with no manifest.</p>
+
+     </li>
+
+    </ol>
+
+   </li>
+
+  </ol>
+-->
     Switch the <a>insertion mode</a> to "<a>before
     head</a>".
 
@@ -5122,6 +5172,10 @@
     it to the {{Document}} object. Put this element in the <a>stack of open
     elements</a>.
 
+    <!-- App Cache -->
+    <!--
+    <p>If the {{Document}} is being loaded as part of [=navigation=] of a [=browsing context=], then: run the [=application cache selection algorithm=] with no manifest, passing it the {{Document}} object.</p>
+    -->
     Switch the <a>insertion mode</a> to "<a>before head</a>", then reprocess the token.
 
     </dd>
@@ -5617,7 +5671,7 @@
     RETURN (CR), or U+0020 SPACE</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert the token's character</a>.
 
@@ -5626,7 +5680,7 @@
     <dt>Any other character token</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert the token's character</a>.
 
@@ -5701,7 +5755,7 @@
       node, if it has one.</li>
 
       <li>Pop all the nodes from the bottom of the <a>stack of open elements</a>, from the
-      <a>current node</a> up to, but not including, the <{html}> element.
+      <a>current node</a> up to, but not including, the root <{html}> element.
 
       <li><a>Insert an HTML element</a> for the token.</li>
 
@@ -5724,7 +5778,7 @@
     <ol>
 
       <li>If there is a node in the <a>stack of open elements</a> that is not either a
-      <{dd}> element, a <{dt}> element, an <{li}> element, an
+      <{dd}> element, a <{dt}> element, an <{li}> element, a <{menuitem}> element, an
       <{optgroup}> element, an <{option}> element, a <{p}> element, an
       <{rb}> element, an <{rp}> element, an <{rt}> element, an
       <{rtc}> element, a <{tbody}> element, a <{td}> element, a
@@ -5745,7 +5799,7 @@
     ignore the token.
 
     Otherwise, if there is a node in the <a>stack of open elements</a> that is not either a
-    <{dd}> element, a <{dt}> element, an <{li}> element, an
+    <{dd}> element, a <{dt}> element, an <{li}> element, a <{menuitem}> element, an
     <{optgroup}> element, an <{option}> element, a <{p}> element, an
     <{rb}> element, an <{rp}> element, an <{rt}> element, an
     <{rtc}> element, a <{tbody}> element, a <{td}> element, a
@@ -5765,7 +5819,7 @@
     ignore the token.
 
     Otherwise, if there is a node in the <a>stack of open elements</a> that is not either a
-    <{dd}> element, a <{dt}> element, an <{li}> element, an
+    <{dd}> element, a <{dt}> element, an <{li}> element, a <{menuitem}> element, an
     <{optgroup}> element, an <{option}> element, a <{p}> element, an
     <{rb}> element, an <{rp}> element, an <{rt}> element, an
     <{rtc}> element, a <{tbody}> element, a <{td}> element, a
@@ -5782,7 +5836,7 @@
 
     <dt>A start tag whose tag name is one of: "address", "article", "aside", "blockquote", "center",
     "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure", "footer", "header",
-    "main", "menu", "nav", "ol", "p", "section", "summary", "ul"</dt>
+    "main", "nav", "ol", "p", "section", "summary", "ul"</dt>
     <dd>
 
     If the <a>stack of open elements</a> <a>has a
@@ -5792,6 +5846,23 @@
     <a>Insert an HTML element</a> for the token.
 
     </dd>
+
+    <dt>
+ <dt>
+ A start tag whose tag name is "menu"
+
+ </dt>
+
+ <dd>
+
+  <p>If the <a>stack of open elements</a> <a>has a <code>p</code> element in button scope</a>, then <a>close a <code>p</code> element</a>.</p>
+
+  <p>If the <a>current node</a> is a <{menuitem}> element, pop that node from the <a>stack of open elements</a>.</p>
+
+  <p><a>Insert an HTML element</a> for the token.</p>
+
+ </dd>
+
 
     <dt>A start tag whose tag name is one of: "h1", "h2", "h3", "h4",
     "h5", "h6"</dt>
@@ -5883,8 +5954,7 @@
       <li>Otherwise, set <var>node</var> to the previous entry in the <a>stack of open
       elements</a> and return to the step labeled <i>loop</i>.</li>
 
-      <li><i>Done</i>: If the <a>stack of open elements</a> <span>has a <{p}> element in button scope</span>, then <span>close a
-      <{p}> element</span>.</li>
+      <li><i>Done</i>: If the <a>stack of open elements</a> <a>has a <code>p</code> element in button scope</a>, then <a>close a <code>p</code> element</a>.</li>
 
       <li>Finally, <a>insert an HTML element</a> for the token.</li>
 
@@ -6003,7 +6073,7 @@
 
       </li>
 
-      <li><a>reconstruct the active formatting elements</a>, if any.</li>
+      <li><a>Reconstruct the active formatting elements</a>, if any.</li>
 
       <li><a>Insert an HTML element</a> for the token.</li>
 
@@ -6167,7 +6237,7 @@
 
     If the <a>list of active formatting elements</a> contains an <{a}> element
     between the end of the list and the last <a>marker</a> on
-    the list (or the start of the list if there is no <a>marker</a> on the list), then this is a <a for="parser">parse error</a>; run the <a>adoption agency algorithm</a> for the tag name "a", then remove
+    the list (or the start of the list if there is no <a>marker</a> on the list), then this is a <a for="parser">parse error</a>; run the <a>adoption agency algorithm</a> for the token, then remove
     that element from the <a>list of active formatting elements</a> and the <a>stack of
     open elements</a> if the <a>adoption agency algorithm</a> didn't already remove it (it
     might not have if the element is not <a>in table
@@ -6184,7 +6254,7 @@
     will often result in non-conforming DOMs when parsed.
   </p>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token. <a>Push onto the list of active
     formatting elements</a> that element.
@@ -6195,7 +6265,7 @@
     "font", "i", "s", "small", "strike", "strong", "tt", "u"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token. <a>Push onto the list of active
     formatting elements</a> that element.
@@ -6205,12 +6275,12 @@
     <dt>A start tag whose tag name is "nobr"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     If the <a>stack of open elements</a> <a lt="in scope">has a
     <code>nobr</code> element in scope</a>, then this is a <a for="parser">parse error</a>; run the
-    <a>adoption agency algorithm</a> for the tag name "nobr", then once again
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>adoption agency algorithm</a> for the token, then once again
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token. <a>Push onto the list of active
     formatting elements</a> that element.
@@ -6222,14 +6292,14 @@
     "strike", "strong", "tt", "u"</dt>
     <dd>
 
-    Run the <a>adoption agency algorithm</a> for the token's tag name.
+    Run the <a>adoption agency algorithm</a> for the token.
 
     </dd>
 
     <dt>A start tag whose tag name is one of: "applet", "marquee", "object"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token.
 
@@ -6292,7 +6362,7 @@
     "img", "wbr"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token. Immediately pop the <a>current
     node</a> off the <a>stack of open elements</a>.
@@ -6307,7 +6377,7 @@
     <dt>A start tag whose tag name is "input"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token. Immediately pop the <a>current
     node</a> off the <a>stack of open elements</a>.
@@ -6320,7 +6390,7 @@
 
     </dd>
 
-    <dt>A start tag whose tag name is one of: "menuitem", "param", "source", "track"</dt>
+    <dt>A start tag whose tag name is one of: "param", "source", "track"</dt>
     <dd>
 
     <a>Insert an HTML element</a> for the token. Immediately pop the <a>current
@@ -6337,6 +6407,8 @@
     If the <a>stack of open elements</a> <a>has a
     <code>p</code> element in button scope</a>, then <a>close a <code>p</code>
     element</a>.
+
+      <p>If the <a>current node</a> is a <{menuitem}> element, pop that node from the <a>stack of open elements</a>.</p>
 
     <a>Insert an HTML element</a> for the token. Immediately pop the <a>current
     node</a> off the <a>stack of open elements</a>.
@@ -6388,7 +6460,7 @@
     <code>p</code> element in button scope</a>, then <a>close a <code>p</code>
     element</a>.
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     Set the <a>frameset-ok flag</a> to "not ok".
 
@@ -6416,7 +6488,7 @@
     <dt>A start tag whose tag name is "select"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token.
 
@@ -6435,11 +6507,24 @@
     If the <a>current node</a> is an <{option}> element, then pop the
     <a>current node</a> off the <a>stack of open elements</a>.
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token.
 
     </dd>
+
+    <dt>
+ <dt>A start tag whose tag name is "menuitem"</dt>
+
+ <dd>
+
+  <p>If the <a>current node</a> is a <{menuitem}> element, then pop the <a>current node</a> off the <a>stack of open elements</a>.</p>
+
+  <p><a>Reconstruct the active formatting elements</a>, if any.</p>
+
+  <p><a>Insert an HTML element</a> for the token.</p>
+
+ </dd>
 
     <dt>A start tag whose tag name is one of: "rb", "rtc"</dt>
     <dd>
@@ -6457,8 +6542,8 @@
 
     If the <a>stack of open elements</a> <a lt="in scope">has a
     <code>ruby</code> element in scope</a>, then <a>generate implied end tags</a>, except
-    for <{rtc}> elements. If the <a>current node</a> is not then a <code>ruby</code>
-    element or an <{rtc}> element, this is a <a for="parser">parse error</a>.
+    for <{rtc}> elements. If the <a>current node</a> is not now a <{rtc}> element or a <{ruby}>
+    element, this is a <a for="parser">parse error</a>.
 
     <a>Insert an HTML element</a> for the token.
     </dd>
@@ -6466,7 +6551,7 @@
     <dt>A start tag whose tag name is "math"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Adjust MathML attributes</a> for the token. (This fixes the case of MathML
     attributes that are not all lowercase.)
@@ -6485,7 +6570,7 @@
     <dt>A start tag whose tag name is "svg"</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Adjust SVG attributes</a> for the token. (This fixes the case of SVG attributes that
     are not all lowercase.)
@@ -6513,7 +6598,7 @@
     <dt>Any other start tag</dt>
     <dd>
 
-    <a>reconstruct the active formatting elements</a>, if any.
+    <a>Reconstruct the active formatting elements</a>, if any.
 
     <a>Insert an HTML element</a> for the token.
 
@@ -6565,8 +6650,8 @@
 
   </dl>
 
-  When the steps above say the user agent is to <dfn>close a <{p}> element</dfn>, it
-  means that the user agent must run the following steps:
+  When the steps above say the UA is to <dfn>close a <{p}> element</dfn>, it
+  means that the UA must run the following steps:
 
   <ol>
 
@@ -6581,10 +6666,11 @@
   </ol>
 
   The <dfn lt="closing misnested formatting elements|adoption agency algorithm|the handling for misnested tags">adoption agency algorithm</dfn>, which takes as its only argument
-  a tag name <var>subject</var> for which the algorithm is being run, consists of the
+  a token |token| for which the algorithm is being run, consists of the
   following steps:
 
   <ol>
+    <li><p>Let |subject| be |token|'s tag name.</p></li>
 
     <li>If the <a>current node</a> is an <a>HTML element</a>
     whose tag name is <var>subject</var>, and the <a>current node</a> is not in the
@@ -6632,7 +6718,7 @@
     elements</a> that is lower in the stack than <var>formatting element</var>, and is an
     element in the <a>special</a> category. There might not be one.</li>
 
-    <li>If there is no <var>furthest block</var>, then the user agent must first pop all the
+    <li>If there is no <var>furthest block</var>, then the UA must first pop all the
     nodes from the bottom of the <a>stack of open elements</a>, from the <a>current
     node</a> up to and including <var>formatting element</var>, then remove <var>formatting element</var> from the <a>list of active formatting elements</a>, and
     finally abort these steps.</li>
@@ -7069,8 +7155,8 @@
 
   </dl>
 
-  When the steps above require the user agent to <dfn>clear the stack back to a table context</dfn>, it
-  means that the user agent must, while the <a>current node</a> is not a <{table}>,
+  When the steps above require the UA to <dfn>clear the stack back to a table context</dfn>, it
+  means that the UA must, while the <a>current node</a> is not a <{table}>,
   <{template}>, or <{html}> element, pop elements from the <a>stack of open
   elements</a>.
 
@@ -7361,8 +7447,8 @@
 
   </dl>
 
-  When the steps above require the user agent to <dfn>clear the stack back to a table body context</dfn>,
-  it means that the user agent must, while the <a>current node</a> is not a <{tbody}>,
+  When the steps above require the UA to <dfn>clear the stack back to a table body context</dfn>,
+  it means that the UA must, while the <a>current node</a> is not a <{tbody}>,
   <{tfoot}>, <{thead}>, <{template}>, or <{html}> element, pop
   elements from the <a>stack of open elements</a>.
 
@@ -7459,8 +7545,8 @@
 
   </dl>
 
-  When the steps above require the user agent to <dfn>clear the stack back to a table row context</dfn>,
-  it means that the user agent must, while the <a>current node</a> is not a <{tr}>,
+  When the steps above require the UA to <dfn>clear the stack back to a table row context</dfn>,
+  it means that the UA must, while the <a>current node</a> is not a <{tr}>,
   <{template}>, or <{html}> element, pop elements from the <a>stack of open
   elements</a>.
 
@@ -7643,7 +7729,7 @@
     <dt>An end tag whose tag name is "select"</dt>
     <dd>
 
-    If the <a>stack of open elements</a> does not <span>have a <{select}> element in select scope</span>, this is a <a for="parser">parse error</a>; ignore the token. (<a>fragment case</a>)
+    If the <a>stack of open elements</a> does not <a>have a <code>select</code> element in select scope</a>, this is a <a for="parser">parse error</a>; ignore the token. (<a>fragment case</a>)
 
     Otherwise:
 
@@ -7659,7 +7745,7 @@
 
     <a for="parser">Parse error</a>.
 
-    If the <a>stack of open elements</a> does not <span>have a <{select}> element in select scope</span>, ignore the token.
+    If the <a>stack of open elements</a> does not <a>have a `select` element in select scope</a>, ignore the token.
     (<a>fragment case</a>)
 
     Otherwise:
@@ -7669,9 +7755,7 @@
 
     <a>Reset the insertion mode appropriately</a>.
 
-    <p class="note">
-  It just gets treated like an end tag.
-  </p>
+    Note: It just gets treated like an end tag.
 
     </dd>
 
@@ -7680,7 +7764,7 @@
 
     <a for="parser">Parse error</a>.
 
-    If the <a>stack of open elements</a> does not <span>have a <{select}> element in select scope</span>, ignore the token.
+    If the <a>stack of open elements</a> does not <a>have a `select` element in select scope</a>, ignore the token.
     (<a>fragment case</a>)
 
     Otherwise:
@@ -7989,7 +8073,7 @@
     <dt>An end tag whose tag name is "frameset"</dt>
     <dd>
 
-    If the <a>current node</a> is the <{html}> element, then this is a
+    If the <a>current node</a> is the root <{html}> element, then this is a
     <a for="parser">parse error</a>; ignore the token. (<a>fragment case</a>)
 
     Otherwise, pop the <a>current node</a> from the <a>stack of open
@@ -8022,11 +8106,11 @@
     <dt>An end-of-file token</dt>
     <dd>
 
-    If the <a>current node</a> is not the <{html}> element, then this is a
+    If the <a>current node</a> is not the root <{html}> element, then this is a
     <a for="parser">parse error</a>.
 
     <p class="note">
-  The <a>current node</a> can only be the <{html}> element in the <a>fragment case</a>.
+  The <a>current node</a> can only be the root <{html}> element in the <a>fragment case</a>.
   </p>
 
     <a lt="stops parsing">Stop parsing</a>.
@@ -8334,7 +8418,7 @@
 
     </dd>
 
-    <dt>An end tag whose tag name is "script", if the <a>current node</a> is a SVG <a element for="svg"><code>script</code></a> element</dt>
+    <dt>An end tag whose tag name is "script", if the <a>current node</a> is an SVG <a element for="svg"><code>script</code></a> element</dt>
     <dd>
 
     Pop the <a>current node</a> off the <a>stack of open elements</a>.
@@ -8346,7 +8430,7 @@
     Increment the parser's <a>script nesting level</a> by one. Set the <a>parser pause
     flag</a> to true.
 
-    <a>Process the <code>script</code> element</a> according to the SVG rules, if the user agent supports
+    <a>Process the SVG `script` element</a> according to the SVG rules, if the user agent supports
     SVG. [[!SVG]]
 
     <p class="note">
@@ -8375,13 +8459,13 @@
       <li>Initialize <var>node</var> to be the <a>current node</a> (the bottommost
       node of the stack).</li>
 
-      <li>If <var>node</var>'s tag name, in <a>ASCII lowercase</a>, is
+      <li>If <var>node</var>'s tag name, converted to <a>ASCII lowercase</a>, is
       not the same as the tag name of the token, then this is a <a for="parser">parse error</a>.</li>
 
       <li><i>Loop</i>: If <var>node</var> is the topmost element in the <a>stack of
       open elements</a>, abort these steps. (<a>fragment case</a>)</li>
 
-      <li>If <var>node</var>'s tag name, in <a>ASCII lowercase</a>, is
+      <li>If <var>node</var>'s tag name, converted to <a>ASCII lowercase</a>, is
       the same as the tag name of the token, pop elements from the <a>stack of open
       elements</a> until <var>node</var> has been popped from the stack, and then abort
       these steps.</li>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -56,30 +56,29 @@
 
 <h4 id="the-doctype">The DOCTYPE</h4>
 
-  A <dfn>DOCTYPE</dfn> is a
-  required preamble.
+  A <dfn>DOCTYPE</dfn> is a required preamble.
 
-  <p class="note">
-  DOCTYPEs are required for legacy reasons. When omitted, browsers tend to use a
+  <p class="note">DOCTYPEs are required for legacy reasons. When omitted, browsers tend to use a
   different rendering mode that is incompatible with some specifications. Including the DOCTYPE in a
   document ensures that the browser makes a best-effort attempt at following the relevant
-  specifications.
-  </p>
+  specifications.</p>
 
   A DOCTYPE must consist of the following components, in this order:
 
-  <ol class="breif">
-    1. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>&lt;!DOCTYPE</code>".
+  <!-- Editor's note: See Issue https://github.com/w3c/html/issues/729 around the obsolete permitted DOCTYPE string -->
+  
+  <ol class="brief">
+    1. A string that is an <a>ASCII case-insensitive</a> match for the string 
+        "<code>&lt;!DOCTYPE</code>".
     2. One or more [=space characters=].
     3. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>html</code>".
-    4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> (defined below).
+    4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> 
+        (defined below).
     5. Zero or more [=space characters=].
     6. A U+003E GREATER-THAN SIGN character (&gt;).
   </ol>
   
-  <p class="note">
-  In other words, <code>&lt;!DOCTYPE html></code>, case-insensitively.
-  </p>
+  <p class="note">In other words, <code>&lt;!DOCTYPE html></code>, case-insensitively.</p>
 
   <hr />
 
@@ -87,23 +86,22 @@
   "<code>&lt;!DOCTYPE html></code>", a <dfn>DOCTYPE legacy string</dfn> may be inserted
   into the DOCTYPE (in the position defined above). This string must consist of:
 
-  <ol class="breif">
+  <ol class="brief">
     1. One or more [=space characters=].
     2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>SYSTEM</code>".
     3. One or more [=space characters=].
     4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>quote mark</i>).
     5. The literal string "<code>about:legacy-compat</code>".
-    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>quote mark</i>).
+    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as 
+        in the earlier step labeled <i>quote mark</i>).
   </ol>
   
-  <p class="note">
-  In other words, <code>&lt;!DOCTYPE html SYSTEM "about:legacy-compat"></code> or
+  <p class="note">In other words, <code>&lt;!DOCTYPE html SYSTEM "about:legacy-compat"></code> or
   <code>&lt;!DOCTYPE html SYSTEM 'about:legacy-compat'></code>, case-insensitively except for the
-  part in single or double quotes.
-  </p>
+  part in single or double quotes.</p>
 
-  The <a>DOCTYPE legacy string</a> should not be used unless the document is generated from
-  a system that cannot output the shorter string.
+  The <a>DOCTYPE legacy string</a> should not be used unless the document is generated from a system 
+  that cannot output the shorter string.
 
   <hr />
 
@@ -111,18 +109,23 @@
   string</dfn> can be inserted into the DOCTYPE (in the position defined above). This string must
   consist of:
 
-  1. One or more [=space characters=].
-  2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>PUBLIC</code>".
-  3. One or more [=space characters=].
-  4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>first quote mark</i>).
-  5. The string from one of the cells in the first column of the table below. The row to which this cell belongs is the <i>selected row</i>.
-  6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>first quote mark</i>).
-  7. If a system identifier is used,
-      1. One or more [=space characters=].
-      2. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>third quote mark</i>).
-      3. The string from the cell in the second column of the <i>selected row</i>.
-      4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>third quote mark</i>).
-
+  <ol class="brief">
+    1. One or more [=space characters=].
+    2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>PUBLIC</code>".
+    3. One or more [=space characters=].
+    4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>first quote mark</i>).
+    5. The string from one of the cells in the first column of the table below. The row to which 
+        this cell belongs is the <i>selected row</i>.
+    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as 
+        in the earlier step labeled <i>first quote mark</i>).
+    7. If a system identifier is used,
+        1. One or more [=space characters=].
+        2. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>third quote mark</i>).
+        3. The string from the cell in the second column of the <i>selected row</i>.
+        4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character 
+            as in the earlier step labeled <i>third quote mark</i>).
+  </ol>
+  
   <table>
     <caption>
     Allowed values for public and system identifiers in an <a>obsolete permitted DOCTYPE string</a>.
@@ -151,9 +154,9 @@
       <td> No
   </table>
 
-  A [=DOCTYPE=] containing an <a>obsolete permitted DOCTYPE
-  string</a> is an <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use <a>obsolete permitted DOCTYPEs</a>, as they are unnecessarily
-  long.
+  A [=DOCTYPE=] containing an <a>obsolete permitted DOCTYPE string</a> is an 
+  <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use <a>obsolete permitted DOCTYPEs</a>, 
+  as they are unnecessarily long.
 
 <h4 id="writing-html-documents-elements">Elements</h4>
 
@@ -167,7 +170,7 @@
 
     <dd><{area}>, <{base}>, <{br}>, <{col}>, <{embed}>,
     <{hr}>, <{img}>, <{input}>, <{link}>,
-    <{menuitem}>, <{meta}>, <{param}>, <{source}>,
+    <{meta}>, <{param}>, <{source}>,
     <{track}>, <{wbr}></dd>
 
     <dt><dfn lt="raw text|raw text elements">Raw text elements</dfn></dt>
@@ -184,7 +187,7 @@
 
     <dt><dfn lt="normal elements">Normal elements</dfn></dt>
 
-    <dd>All other allowed <a>html elements</a> are normal elements.</dd>
+    <dd>All other allowed <a>HTML elements</a> are normal elements.</dd>
 
   </dl>
 
@@ -450,7 +453,6 @@
     <tr> <td> <code>show</code>    <td> [=XLink namespace=] <td> <{xlink/show|xlink:show}>
     <tr> <td> <code>title</code>   <td> [=XLink namespace=] <td> <{xlink/title|xlink:title}>
     <tr> <td> <code>type</code>    <td> [=XLink namespace=] <td> <{xlink/type|xlink:type}>
-    <tr> <td> <code>base</code>    <td> [=XML namespace=]   <td> <{xml/base|xml:base}>
     <tr> <td> <code>lang</code>    <td> [=XML namespace=]   <td> <{xml/lang|xml:lang}>
     <tr> <td> <code>space</code>   <td> [=XML namespace=]   <td> <{xml/space|xml:space}>
     <tr> <td> <code>xmlns</code>   <td> [=XMLNS namespace=] <td> <{xmlns/xmlns}>
@@ -472,7 +474,7 @@
   <p class="note">
   Omitting an element's <a>start tag</a> in the
   situations described below does not mean the element is not present; it is implied, but it is
-  still there. For example, an HTML document always has an <{html}> element, even if
+  still there. For example, an HTML document always has a root <{html}> element, even if
   the string <code>&lt;html></code> doesn't appear anywhere in the markup.
   </p>
 
@@ -6219,7 +6221,7 @@
 
     <ol>
 
-      <li><a>Generate implied end tags</a>, except for <a>html elements</a> with the
+      <li><a>Generate implied end tags</a>, except for <a>HTML elements</a> with the
       same tag name as the token.</li>
 
       <li>If the <a>current node</a> is not an <a>HTML element</a> with the same tag name as that of the token, then this is a <a for="parser">parse error</a>.</li>
@@ -6634,7 +6636,7 @@
 
       <ol>
 
-        <li><a>Generate implied end tags</a>, except for <a>html elements</a> with the
+        <li><a>Generate implied end tags</a>, except for <a>HTML elements</a> with the
         same tag name as the token.</li>
 
         <li>If <var>node</var> is not the <a>current node</a>, then this is a
@@ -9026,7 +9028,7 @@
         Append a U+003C LESS-THAN SIGN character (&lt;), followed by <var>tagname</var>.
 
         <p class="note">
-  For <a>html elements</a> created by the <a>HTML parser</a> or
+  For <a>HTML elements</a> created by the <a>HTML parser</a> or
         <code>Document.createElement()</code>, <var>tagname</var> will be
         lowercase.
   </p>
@@ -9048,7 +9050,7 @@
           The attribute's serialized name is the attribute's local name.
 
           <p class="note">
-  For attributes on <a>html elements</a> set by the <a>HTML
+  For attributes on <a>HTML elements</a> set by the <a>HTML
           parser</a> or by <code>Element.setAttribute()</code>, the local name will be
           lowercase.
   </p>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -1972,8 +1972,8 @@
 
   <hr />
 
-  When the steps below require the user agent to <dfn>reset the insertion mode appropriately</dfn>, it
-  means the user agent must follow these steps:
+  When the steps below require the UA to <dfn>reset the insertion mode appropriately</dfn>, it
+  means the UA must follow these steps:
 
   <ol>
 
@@ -2094,8 +2094,7 @@
   tags</a>).
 
   <p class="note">
-    The "<a>before html</a>" <a>insertion mode</a> creates the <{html}> <a>document element</a>
-    node, which is then added to the stack.
+    The "<a>before html</a>" <a>insertion mode</a> creates the <{html}> <a>document element</a>, which is then added to the stack.
   </p>
 
   <p class="note">
@@ -2124,16 +2123,18 @@
       <{colgroup}>, <{dd}>, <{details}>, <{dir}>, <{div}>, <{dl}>, <{dt}>, <{embed}>, <{fieldset}>,
       <{figcaption}>, <{figure}>, <{footer}>, <{form}>, <{frame}>, <{frameset}>, <{h1}>, <{h2}>,
       <{h3}>, <{h4}>, <{h5}>, <{h6}>, <{head}>, <{header}>, <{hr}>, <{html}>, <{iframe}>, <{img}>,
-      <{input}>, <{li}>, <{link}>, <{listing}>, <{main}>, <{marquee}>, <{menu}>, <{menuitem}>,
+      <{input}>, <{li}>, <{link}>, <{listing}>, <{main}>, <{marquee}>, <{menu}>,
       <{meta}>, <{nav}>, <{noembed}>, <{noframes}>, <{noscript}>, <{object}>, <{ol}>, <{p}>,
       <{param}>, <{plaintext}>, <{pre}>, <{script}>, <{section}>, <{select}>, <{source}>, <{style}>,
       <{summary}>, <{table}>, <{tbody}>, <{td}>, <{template}>, <{textarea}>, <{tfoot}>, <{th}>,
       <{thead}>, <{title}>, <{tr}>, <{track}>, <{ul}>, <{wbr}>,
-      and <{xmp}>; <a>MathML <code>mi</code></a>, <a>MathML <code>mo</code></a>,
+      <{xmp}>; <a>MathML <code>mi</code></a>, <a>MathML <code>mo</code></a>,
       <a>MathML <code>mn</code></a>, <a>MathML <code>ms</code></a>,
       <a>MathML <code>mtext</code></a>, and <a>MathML <code>annotation-xml</code></a>; and
       SVG <{foreignObject}>, SVG <{desc}>, and
       SVG <a element for="svg"><code>title</code></a>.
+
+      <p class="note">An <code>image</code> start tag token is handled by the tree builder, but it is not in this list because it is not an element; it gets turned into an <{img}> element.</p>
 
   : <dfn lt="formatting element tags|formatting">Formatting</dfn>
   :: The following HTML elements are those that end up in the
@@ -2144,7 +2145,7 @@
   :: All other elements found while parsing an HTML document.
 
   <p class="note">
-    Typically, the <a>special</a> elements have the start and and end tag tokens handled
+    Typically, the <a>special</a> elements have the start and end tag tokens handled
     specifically, while <a>ordinary</a> elements' tokens fall into "any other start tag" and "any
     other end tag" clauses, and some parts of the tree builder check if a particular element in the
     <a>stack of open elements</a> is in the <a>special</a> category. However, some elements (e.g.,
@@ -2193,8 +2194,8 @@
 
   <ul class="brief">
     <li>All the element types listed above for the <a lt="in scope">has an element in scope</a> algorithm.</li>
-    <li><{ol}></li>
-    <li><{ul}></li>
+    <li><{ol}> in the [=HTML namespace=]</li>
+    <li><{ul}> in the [=HTML namespace=]</li>
   </ul>
 
   The <a>stack of open elements</a> is said to <dfn lt="have a p element in button scope|has a p element in button scope|have a particular element in button scope">have a particular element in button scope</dfn> when it <a>has that element in the specific scope</a> consisting of the following element
@@ -2202,24 +2203,24 @@
 
   <ul class="brief">
     <li>All the element types listed above for the <a lt="in scope">has an element in scope</a> algorithm.</li>
-    <li><{button}></li>
+    <li><{button}> in the [=HTML namespace=]</li>
   </ul>
 
   The <a>stack of open elements</a> is said to <dfn lt="have a particular element in table scope|have an element in table scope|in table scope">have a particular element in table scope</dfn> when it <a>has that element in the specific scope</a> consisting of the following element
   types:
 
   <ul class="brief">
-    <li><{html}></li>
-    <li><{table}></li>
-    <li><{template}></li>
+    <li><{html}> in the [=HTML namespace=]</li>
+    <li><{table}> in the [=HTML namespace=]</li>
+    <li><{template}> in the [=HTML namespace=]</li>
   </ul>
 
   The <a>stack of open elements</a> is said to <dfn lt="have an li element in list item scope|have a particular element in select scope">have a particular element in select scope</dfn> when it <a>has that element in the specific scope</a> consisting of all element types
   <em>except</em> the following:
 
   <ul class="brief">
-    <li><{optgroup}></li>
-    <li><{option}> in the <a>HTML namespace</a></li>
+    <li><{optgroup}> in the [=HTML namespace=]</li>
+    <li><{option}> in the [=HTML namespace=]</li>
   </ul>
 
   Nothing happens if at any time any of the elements in the <a>stack of open elements</a>
@@ -2238,16 +2239,16 @@
   mis-nested <a>formatting element tags</a>.
 
   The list contains elements in the <a>formatting</a> category, and <a>markers</a>. The
-  <dfn>markers</dfn> are inserted when entering <{applet}> elements, buttons, <{object}> elements,
-  marquees, table cells, and table captions, and are used to prevent formatting from "leaking"
-  <em>into</em> <{applet}> elements, buttons, <{object}> elements, marquees, and tables.
+  <dfn>markers</dfn> are inserted when entering <{applet}>, <{object}>, <{marquee}>, <{template}>,
+  <{td}>, <{th}>, and <{caption}> elements, and are used to prevent formatting from "leaking"
+  into <{applet}>, <{object}>, <{marquee}>, <{template}>, <{td}>, <{th}>, and <{caption}> elements.
 
   In addition, each element in the <a>list of active formatting elements</a> is associated with the
   token for which it was created, so that further elements can be created for that token if
   necessary.
 
-  When the steps below require the user agent to <dfn>push onto the list of active formatting elements</dfn>
-  an element <var>element</var>,the user agent must perform the following steps:
+  When the steps below require the UA to <dfn>push onto the list of active formatting elements</dfn>
+  an element <var>element</var>, the UA must perform the following steps:
 
   1. If there are already three elements in the <a>list of active formatting elements</a> after the
       last <a>marker</a>, if any, or anywhere in the list if there are no <a>markers</a>, that have
@@ -2261,8 +2262,8 @@
       <p class="note">This is the Noah's Ark clause. But with three per family instead of two.</p>
   2. Add <var>element</var> to the <a>list of active formatting elements</a>.
 
-  When the steps below require the user agent to <dfn for="elements" lt="reconstruct the active formatting element|reconstruct the active formatting elements|reconstruction of the active formatting element|reconstruction of the active formatting elements">reconstruct the active formatting elements</dfn>,
-  the user agent must perform the following steps:
+  When the steps below require the UA to <dfn for="elements" lt="reconstruct the active formatting element|reconstruct the active formatting elements|reconstruction of the active formatting element|reconstruction of the active formatting elements">reconstruct the active formatting elements</dfn>,
+  the UA must perform the following steps:
 
   1. If there are no entries in the <a>list of active formatting elements</a>, then there is nothing
       to reconstruct; stop this algorithm.
@@ -2295,8 +2296,8 @@
     being executed, of course).
   </p>
 
-  When the steps below require the user agent to
-  <dfn>clear the list of active formatting elements up to the last marker</dfn>, the user agent must
+  When the steps below require the UA to
+  <dfn>clear the list of active formatting elements up to the last marker</dfn>, the UA must
   perform the following steps:
 
   1. Let <var>entry</var> be the last (most recently added) entry in the
@@ -2343,13 +2344,19 @@
   Implementations must act as if they used the following state machine to tokenize HTML. The
   state machine must start in the [[#data-state]]. Most states consume a single character,
   which may have various side-effects, and either switches the state machine to a new state to
-  <i>reconsume</i> the same character, or switches it to a new state to consume the next character,
+  [=reconsume=] the [=current input character=], or switches it to a new state to consume the next character,
   or stays in the same state to consume the next character. Some states have more complicated
   behavior and can consume several characters before switching to another state. In some cases, the
   tokenizer state is also changed by the tree construction stage.
 
+  When a state says to <dfn>reconsume</dfn> a matched character in a specified state, that means to
+  switch to that state, but when it attempts to consume the [=next input character=], provide it
+  with the [=current input character=] instead.
+
   The exact behavior of certain states depends on the <a>insertion mode</a> and the
-  <a>stack of open elements</a>. Certain states also use a <dfn><var>temporary buffer</var></dfn> to track progress.
+  <a>stack of open elements</a>. Certain states also use a <dfn>|temporary buffer|</dfn> to track
+  progress, and the [=character reference state=] uses a <dfn>|return state|</dfn> to return to the
+  state it was invoked from.
 
   The output of the tokenization step is a series of zero or more of the following tokens:
   DOCTYPE, start tag, end tag, comment, character, end-of-file. DOCTYPE tokens have a name, a public
@@ -2397,13 +2404,13 @@
   <dl class="switch">
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#character-reference-in-data-state]].</dd>
+    <dd>Set the [=return state=] to the [=data state=]. Switch to the [=character reference state=].</dd>
 
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
     <dd>Switch to the [[#tag-open-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit the <a>current input character</a> as a character
+    <dd><a for="parser">Parse error</a>. Emit the <a>current input character</a> as a character
     token.</dd>
 
     <dt>EOF</dt>
@@ -2414,17 +2421,6 @@
 
   </dl>
 
-<h5 id="character-reference-in-data-state">Character reference in data state</h5>
-
-  Switch to the [[#data-state]].
-
-  Attempt to <a>consume a character reference</a>, with no <a>additional allowed
-  character</a>.
-
-  If nothing is returned, emit a U+0026 AMPERSAND character (&amp;) token.
-
-  Otherwise, emit the character tokens that were returned.
-
 <h5 id="rcdata-state">RCDATA state</h5>
 
   Consume the <a>next input character</a>:
@@ -2432,13 +2428,13 @@
   <dl class="switch">
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#character-reference-in-rcdata-state]].</dd>
+    <dd>Set the [=return state=] to the [=RCDATA state=]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
     <dd>Switch to the [[#rcdata-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
     <dd>Emit an end-of-file token.</dd>
@@ -2447,17 +2443,6 @@
     <dd>Emit the <a>current input character</a> as a character token.</dd>
 
   </dl>
-
-<h5 id="character-reference-in-rcdata-state">Character reference in RCDATA state</h5>
-
-  Switch to the [[#rcdata-state]].
-
-  Attempt to <a>consume a character reference</a>, with no <a>additional allowed
-  character</a>.
-
-  If nothing is returned, emit a U+0026 AMPERSAND character (&amp;) token.
-
-  Otherwise, emit the character tokens that were returned.
 
 <h5 id="rawtext-state">RAWTEXT state</h5>
 
@@ -2469,7 +2454,7 @@
     <dd>Switch to the [[#rawtext-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
     <dd>Emit an end-of-file token.</dd>
@@ -2489,7 +2474,7 @@
     <dd>Switch to the [[#script-data-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
     <dd>Emit an end-of-file token.</dd>
@@ -2506,7 +2491,7 @@
   <dl class="switch">
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
     <dd>Emit an end-of-file token.</dd>
@@ -2528,23 +2513,16 @@
     <dt>U+002F SOLIDUS (/)</dt>
     <dd>Switch to the [[#end-tag-open-state]].</dd>
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new start tag token, set its tag name to the lowercase version of the <a>current
-    input character</a> (add 0x0020 to the character's code point), then switch to the [[#tag-name-state]].
-    (Don't emit the token yet; further details will be filled in before it is
-    emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new start tag token, set its tag name to the <a>current input character</a>,
-    then switch to the [[#tag-name-state]]. (Don't emit the token yet; further details will
-    be filled in before it is emitted.)</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new start tag token, set its tag name to the empty string. [=Reconsume=] in the
+    [[#tag-name-state]].</dd>
 
     <dt>U+003F QUESTION MARK (?)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#bogus-comment-state]].</dd>
+    <dd><a for="parser">Parse error</a>. Create a comment token whose data is the empty string. [=Reconsume=] in the [[#bogus-comment-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit a U+003C LESS-THAN SIGN
-    character token. Reconsume the <a>current input character</a>.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+003C LESS-THAN SIGN
+    character token. [=Reconsume=] in the [[#data-state]].</dd>
 
   </dl>
 
@@ -2554,26 +2532,19 @@
 
   <dl class="switch">
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, set its tag name to the lowercase version of the <a>current
-    input character</a> (add 0x0020 to the character's code point), then switch to the [[#tag-name-state]].
-    (Don't emit the token yet; further details will be filled in before it is
-    emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, set its tag name to the <a>current input character</a>,
-    then switch to the [[#tag-name-state]]. (Don't emit the token yet; further details will
-    be filled in before it is emitted.)</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in the [[#tag-name-state]].
+    </dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]].</dd>
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit a U+003C LESS-THAN SIGN
-    character token and a U+002F SOLIDUS character token. Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+003C LESS-THAN SIGN
+    character token, a U+002F SOLIDUS character token and an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#bogus-comment-state]].</dd>
+    <dd><a for="parser">Parse error</a>. Create a comment token whose data is the empty string. [=Reconsume=] in the [[#bogus-comment-state]].</dd>
 
   </dl>
 
@@ -2601,12 +2572,11 @@
     character's code point) to the current tag token's tag name.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current tag
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current tag
     token's tag name.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current tag token's tag name.</dd>
@@ -2624,8 +2594,8 @@
     the [[#rcdata-end-tag-open-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rcdata-state]]. Emit a U+003C LESS-THAN SIGN character token.
-    Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token.
+    [=Reconsume=] in the [[#RCDATA-state]].</dd>
 
   </dl>
 
@@ -2635,22 +2605,12 @@
 
   <dl class="switch">
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the lowercase version of the
-    <a>current input character</a> (add 0x0020 to the character's code point). Append the
-    <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#rcdata-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the <a>current input character</a>.
-    Append the <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#rcdata-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in [[#rcdata-end-tag-name-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rcdata-state]]. Emit a U+003C LESS-THAN SIGN character token and a
-    U+002F SOLIDUS character token. Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token and a
+    U+002F SOLIDUS character token. [=Reconsume=] in the [[#rcdata-state]].</dd>
 
   </dl>
 
@@ -2690,9 +2650,9 @@
     buffer</var>.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rcdata-state]]. Emit a U+003C LESS-THAN SIGN character token, a
+    <dd>Emit a U+003C LESS-THAN SIGN character token, a
     U+002F SOLIDUS character token, and a character token for each of the characters in the <var>temporary buffer</var> (in the order they were added to the buffer).
-    Reconsume the <a>current input character</a>.</dd>
+    [=Reconsume=] in the [[#rcdata-state]].</dd>
 
   </dl>
 
@@ -2707,8 +2667,8 @@
     the [[#rawtext-end-tag-open-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rawtext-state]]. Emit a U+003C LESS-THAN SIGN character token.
-    Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token.
+    [=Reconsume=] in the [[#rawtext-state]].</dd>
 
   </dl>
 
@@ -2718,22 +2678,12 @@
 
   <dl class="switch">
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the lowercase version of the
-    <a>current input character</a> (add 0x0020 to the character's code point). Append the
-    <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#rawtext-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the <a>current input character</a>.
-    Append the <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#rawtext-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in the [[#rawtext-end-tag-name-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rawtext-state]]. Emit a U+003C LESS-THAN SIGN character token and a
-    U+002F SOLIDUS character token. Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token and a
+    U+002F SOLIDUS character token. [=Reconsume=] in the [[#rawtext-state]].</dd>
 
   </dl>
 
@@ -2773,9 +2723,9 @@
     buffer</var>.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#rawtext-state]]. Emit a U+003C LESS-THAN SIGN character token, a
+    <dd>Emit a U+003C LESS-THAN SIGN character token, a
     U+002F SOLIDUS character token, and a character token for each of the characters in the <var>temporary buffer</var> (in the order they were added to the buffer).
-    Reconsume the <a>current input character</a>.</dd>
+    [=Reconsume=] in the [[#rawtext-state]].</dd>
 
   </dl>
 
@@ -2794,8 +2744,8 @@
     character token and a U+0021 EXCLAMATION MARK character token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-state]]. Emit a U+003C LESS-THAN SIGN character token.
-    Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token.
+    [=Reconsume=] in the [[#script-data-state]].</dd>
 
   </dl>
 
@@ -2805,22 +2755,12 @@
 
   <dl class="switch">
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the lowercase version of the
-    <a>current input character</a> (add 0x0020 to the character's code point). Append the
-    <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#script-data-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the <a>current input character</a>.
-    Append the <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#script-data-end-tag-name-state]]. (Don't emit the
-    token yet; further details will be filled in before it is emitted.)</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new end tag token, set its tag name to the empty string. [=Reconsume=] in the [[#script-data-end-tag-name-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-state]]. Emit a U+003C LESS-THAN SIGN character token
-    and a U+002F SOLIDUS character token. Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character token
+    and a U+002F SOLIDUS character token. [=Reconsume=] in the [[#script-data-state]].</dd>
 
   </dl>
 
@@ -2860,9 +2800,9 @@
     buffer</var>.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-state]]. Emit a U+003C LESS-THAN SIGN character token, a
+    <dd>Emit a U+003C LESS-THAN SIGN character token, a
     U+002F SOLIDUS character token, and a character token for each of the characters in the <var>temporary buffer</var> (in the order they were added to the buffer).
-    Reconsume the <a>current input character</a>.</dd>
+    [=Reconsume=] in the [[#script-data-state]].</dd>
 
   </dl>
 
@@ -2877,8 +2817,7 @@
     character token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-state]]. Reconsume the <a>current input
-    character</a>.</dd>
+    <dd>[=Reconsume=] in the [[#script-data-state]].</dd>
 
   </dl>
 
@@ -2893,8 +2832,7 @@
     character token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-state]]. Reconsume the <a>current input
-    character</a>.</dd>
+    <dd>[=Reconsume=] in the [[#script-data-state]].</dd>
 
   </dl>
 
@@ -2912,11 +2850,10 @@
     <dd>Switch to the [[#script-data-escaped-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd>Switch to the [[#data-state]]. <a for="parser">parse error</a>. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Emit the <a>current input character</a> as a character token.</dd>
@@ -2937,12 +2874,11 @@
     <dd>Switch to the [[#script-data-escaped-less-than-sign-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#script-data-escaped-state]]. Emit a U+FFFD
+    <dd><a for="parser">Parse error</a>. Switch to the [[#script-data-escaped-state]]. Emit a U+FFFD
     REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Switch to the [[#script-data-escaped-state]]. Emit the <a>current input
@@ -2967,12 +2903,11 @@
     token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#script-data-escaped-state]]. Emit a U+FFFD
+    <dd><a for="parser">Parse error</a>. Switch to the [[#script-data-escaped-state]]. Emit a U+FFFD
     REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Switch to the [[#script-data-escaped-state]]. Emit the <a>current input
@@ -2990,22 +2925,12 @@
     <dd>Set the <var>temporary buffer</var> to the empty string. Switch to
     the [[#script-data-escaped-end-tag-open-state]].</dd>
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Set the <var>temporary buffer</var> to the empty string. Append the
-    lowercase version of the <a>current input character</a> (add 0x0020 to the character's code
-    point) to the <var>temporary buffer</var>. Switch to the [[#script-data-double-escape-start-state]]. Emit a U+003C LESS-THAN SIGN character token and the
-    <a>current input character</a> as a character token.</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Set the <var>temporary buffer</var> to the empty string. Append the
-    <a>current input character</a> to the <var>temporary
-    buffer</var>. Switch to the [[#script-data-double-escape-start-state]]. Emit a U+003C
-    LESS-THAN SIGN character token and the <a>current input character</a> as a character
-    token.</dd>
+    <dt><a>ASCII letter</a></dt>
+    <dd>Set the <var>temporary buffer</var> to the empty string. Emit a U+003C LESS-THAN SIGN character token. [=Reconsume=] in the [[#script-data-double-escape-start-state]].</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-escaped-state]]. Emit a U+003C LESS-THAN SIGN character
-    token. Reconsume the <a>current input character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character
+    token. [=Reconsume=] in the [[#script-data-escaped-state]].</dd>
 
   </dl>
 
@@ -3015,23 +2940,13 @@
 
   <dl class="switch">
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the lowercase version of the
-    <a>current input character</a> (add 0x0020 to the character's code point). Append the
-    <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#script-data-escaped-end-tag-name-state]]. (Don't
-    emit the token yet; further details will be filled in before it is emitted.)</dd>
-
-    <dt><a>Lowercase ASCII letter</a></dt>
-    <dd>Create a new end tag token, and set its tag name to the <a>current input character</a>.
-    Append the <a>current input character</a> to the <var>temporary
-    buffer</var>. Finally, switch to the [[#script-data-escaped-end-tag-name-state]]. (Don't
+    <dt><a>ASCII letter</a></dt>
+    <dd>Create a new end tag token. [=Reconsume=] in the [[#script-data-escaped-end-tag-name-state]]. (Don't
     emit the token yet; further details will be filled in before it is emitted.)</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-escaped-state]]. Emit a U+003C LESS-THAN SIGN character
-    token and a U+002F SOLIDUS character token. Reconsume the <a>current input
-    character</a>.</dd>
+    <dd>Emit a U+003C LESS-THAN SIGN character
+    token and a U+002F SOLIDUS character token. [=Reconsume=] in the [[#script-data-escaped-state]].</dd>
 
   </dl>
 
@@ -3071,10 +2986,10 @@
     buffer</var>.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-escaped-state]]. Emit a U+003C LESS-THAN SIGN character
+    <dd>Emit a U+003C LESS-THAN SIGN character
     token, a U+002F SOLIDUS character token, and a character token for each of the characters in the
     <var>temporary buffer</var> (in the order they were added to the
-    buffer). Reconsume the <a>current input character</a>.</dd>
+    buffer). [=Reconsume=] in the [[#script-data-escaped-state]].</dd>
 
   </dl>
 
@@ -3105,8 +3020,7 @@
     token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-escaped-state]]. Reconsume the <a>current input
-    character</a>.</dd>
+    <dd>[=Reconsume=] in the [[#script-data-escaped-state]].</dd>
 
   </dl>
 
@@ -3125,11 +3039,10 @@
     LESS-THAN SIGN character token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
+    <dd><a for="parser">Parse error</a>. Emit a U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Emit the <a>current input character</a> as a character token.</dd>
@@ -3151,12 +3064,11 @@
     LESS-THAN SIGN character token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#script-data-double-escaped-state]]. Emit a
+    <dd><a for="parser">Parse error</a>. Switch to the [[#script-data-double-escaped-state]]. Emit a
     U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Switch to the [[#script-data-double-escaped-state]]. Emit the <a>current input
@@ -3182,12 +3094,11 @@
     token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#script-data-double-escaped-state]]. Emit a
+    <dd><a for="parser">Parse error</a>. Switch to the [[#script-data-double-escaped-state]]. Emit a
     U+FFFD REPLACEMENT CHARACTER character token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Switch to the [[#script-data-double-escaped-state]]. Emit the <a>current input
@@ -3206,8 +3117,7 @@
     the [[#script-data-double-escape-end-state]]. Emit a U+002F SOLIDUS character token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-double-escaped-state]]. Reconsume the <a>current
-    input character</a>.</dd>
+    <dd>[=Reconsume=] in the [[#script-data-double-escaped-state]].</dd>
 
   </dl>
 
@@ -3238,8 +3148,7 @@
     token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Switch to the [[#script-data-double-escaped-state]]. Reconsume the <a>current
-    input character</a>.</dd>
+    <dd>[=Reconsume=] in the [[#script-data-double-escaped-state]].</dd>
 
   </dl>
 
@@ -3252,39 +3161,24 @@
     <dt>U+0009 CHARACTER TABULATION (tab)</dt>
     <dt>U+000A LINE FEED (LF)</dt>
     <dt>U+000C FORM FEED (FF)</dt>
-
     <dt>U+0020 SPACE</dt>
     <dd>Ignore the character.</dd>
 
     <dt>U+002F SOLIDUS (/)</dt>
-    <dd>Switch to the [[#self-closing-start-tag-state]].</dd>
-
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
-
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Start a new attribute in the current tag token. Set that attribute's name to the lowercase
-    version of the <a>current input character</a> (add 0x0020 to the character's code point),
-    and its value to the empty string. Switch to the [[#attribute-name-state]].</dd>
-
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Start a new attribute in the current tag token. Set that
-    attribute's name to a U+FFFD REPLACEMENT CHARACTER character, and its value to the empty string.
-    Switch to the [[#attribute-name-state]].</dd>
-
-    <dt>U+0022 QUOTATION MARK (&quot;)</dt>
-    <dt>U+0027 APOSTROPHE (')</dt>
-    <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
-    <dt>U+003D EQUALS SIGN (=)</dt>
-    <dd><a for="parser">parse error</a>. Treat it as per the "anything else" entry below.</dd>
-
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
+    <dd>[=Reconsume=] in the [[#after-attribute-name-state]].</dd>
+
+    <dt>U+003D EQUALS SIGN (=)</dt>
+    <dd><a for="parser">Parse error</a>. Start a new attribute in the current tag token. Set that
+    attribute's name to the [=current input character=], and its value to the empty string. Switch
+    to the [[#attribute-name-state]].</dd>
+
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
     character.</dd>
 
     <dt>Anything else</dt>
-    <dd>Start a new attribute in the current tag token. Set that attribute's name to the
-    <a>current input character</a>, and its value to the empty string. Switch to the
+    <dd>Start a new attribute in the current tag token. Set that attribute's name and value to the empty string. [=Reconsume=] in the
     [[#attribute-name-state]].</dd>
 
   </dl>
@@ -3298,35 +3192,27 @@
     <dt>U+0009 CHARACTER TABULATION (tab)</dt>
     <dt>U+000A LINE FEED (LF)</dt>
     <dt>U+000C FORM FEED (FF)</dt>
-
     <dt>U+0020 SPACE</dt>
-    <dd>Switch to the [[#after-attribute-name-state]].</dd>
-
     <dt>U+002F SOLIDUS (/)</dt>
-    <dd>Switch to the [[#self-closing-start-tag-state]].</dd>
+    <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
+    <dt>EOF</dt>
+    <dd>[=Reconsume=] in the [[#after-attribute-name-state]].</dd>
 
     <dt>U+003D EQUALS SIGN (=)</dt>
     <dd>Switch to the [[#before-attribute-value-state]].</dd>
-
-    <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
     <dt><a>Uppercase ASCII letter</a></dt>
     <dd>Append the lowercase version of the <a>current input character</a> (add 0x0020 to the
     character's code point) to the current attribute's name.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     attribute's name.</dd>
 
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
     <dt>U+0027 APOSTROPHE (')</dt>
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
-    <dd><a for="parser">parse error</a>. Treat it as per the "anything else" entry below.</dd>
-
-    <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Treat it as per the "anything else" entry below.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current attribute's name.</dd>
@@ -3354,7 +3240,6 @@
     <dt>U+0009 CHARACTER TABULATION (tab)</dt>
     <dt>U+000A LINE FEED (LF)</dt>
     <dt>U+000C FORM FEED (FF)</dt>
-
     <dt>U+0020 SPACE</dt>
     <dd>Ignore the character.</dd>
 
@@ -3367,28 +3252,11 @@
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
-    <dt><a>Uppercase ASCII letter</a></dt>
-    <dd>Start a new attribute in the current tag token. Set that attribute's name to the lowercase
-    version of the <a>current input character</a> (add 0x0020 to the character's code point),
-    and its value to the empty string. Switch to the [[#attribute-name-state]].</dd>
-
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Start a new attribute in the current tag token. Set that
-    attribute's name to a U+FFFD REPLACEMENT CHARACTER character, and its value to the empty string.
-    Switch to the [[#attribute-name-state]].</dd>
-
-    <dt>U+0022 QUOTATION MARK (&quot;)</dt>
-    <dt>U+0027 APOSTROPHE (')</dt>
-    <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
-    <dd><a for="parser">parse error</a>. Treat it as per the "anything else" entry below.</dd>
-
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Start a new attribute in the current tag token. Set that attribute's name to the
-    <a>current input character</a>, and its value to the empty string. Switch to the
+    <dd>Start a new attribute in the current tag token. Set that attribute's name and value to the empty string. [=Reconsume=] in the
     [[#attribute-name-state]].</dd>
 
   </dl>
@@ -3409,33 +3277,14 @@
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
     <dd>Switch to the [[#attribute-value-double-quoted-state]].</dd>
 
-    <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#attribute-value-unquoted-state]]. Reconsume the <a>current
-    input character</a>.</dd>
-
     <dt>U+0027 APOSTROPHE (')</dt>
     <dd>Switch to the [[#attribute-value-single-quoted-state]].</dd>
 
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
-    attribute's value. Switch to the [[#attribute-value-unquoted-state]].</dd>
-
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the current tag
-    token.</dd>
-
-    <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
-    <dt>U+003D EQUALS SIGN (=)</dt>
-    <dt>U+0060 GRAVE ACCENT (`)</dt>
-    <dd><a for="parser">parse error</a>. Treat it as per the "anything else" entry below.</dd>
-
-    <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Treat it as per the "anything else" entry below.</dd>
 
     <dt>Anything else</dt>
-    <dd>Append the <a>current input character</a> to the current attribute's value. Switch to
-    the [[#attribute-value-unquoted-state]].</dd>
+    <dd>[=Reconsume=] in the [[#attribute-value-unquoted-state]].</dd>
 
   </dl>
 
@@ -3449,16 +3298,14 @@
     <dd>Switch to the [[#after-attribute-value-quoted-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#character-reference-in-attribute-value-state]], with the
-    <a>additional allowed character</a> being U+0022 QUOTATION MARK (&quot;).</dd>
+    <dd>Set the [=return state=] to the [[#attribute-value-double-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     attribute's value.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current attribute's value.</dd>
@@ -3475,16 +3322,14 @@
     <dd>Switch to the [[#after-attribute-value-quoted-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#character-reference-in-attribute-value-state]], with the
-    <a>additional allowed character</a> being U+0027 APOSTROPHE (').</dd>
+    <dd>Set the [=return state=] to the [[#attribute-value-single-quoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     attribute's value.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current attribute's value.</dd>
@@ -3505,14 +3350,13 @@
     <dd>Switch to the [[#before-attribute-name-state]].</dd>
 
     <dt>U+0026 AMPERSAND (&amp;)</dt>
-    <dd>Switch to the [[#character-reference-in-attribute-value-state]], with the
-    <a>additional allowed character</a> being U+003E GREATER-THAN SIGN (&gt;).</dd>
+    <dd>Set the [=return state=] to the [[#attribute-value-unquoted-state]]. Switch to the [[#character-reference-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     attribute's value.</dd>
 
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
@@ -3520,27 +3364,15 @@
     <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
     <dt>U+003D EQUALS SIGN (=)</dt>
     <dt>U+0060 GRAVE ACCENT (`)</dt>
-    <dd><a for="parser">parse error</a>. Treat it as per the "anything else" entry below.</dd>
+    <dd><a for="parser">Parse error</a>. Treat it as per the "anything else" entry below.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the current attribute's value.</dd>
 
   </dl>
-
-<h5 id="character-reference-in-attribute-value-state"><dfn lt="as part of an attribute">Character reference in attribute value state</dfn></h5>
-
-  Attempt to <a>consume a character reference</a>.
-
-  If nothing is returned, append a U+0026 AMPERSAND character (&amp;) to the current attribute's
-  value.
-
-  Otherwise, append the returned character tokens to the current attribute's value.
-
-  Finally, switch back to the attribute value state that switched into this state.
 
 <h5 id="after-attribute-value-quoted-state">After attribute value (quoted) state</h5>
 
@@ -3562,12 +3394,10 @@
     <dd>Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#before-attribute-name-state]]. Reconsume
-    the character.</dd>
+    <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#before-attribute-name-state]].</dd>
 
   </dl>
 
@@ -3581,11 +3411,11 @@
     <dd>Set the <i>self-closing flag</i> of the current tag token. Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
     character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#before-attribute-name-state]]. Reconsume
+    <dd><a for="parser">Parse error</a>. Switch to the [[#before-attribute-name-state]]. Reconsume
     the character.</dd>
 
   </dl>
@@ -3639,14 +3469,14 @@
     <dd>Switch to the [[#comment-start-dash-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the comment
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the comment
     token's data. Switch to the [[#comment-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3665,14 +3495,14 @@
     <dd>Switch to the [[#comment-end-state]]</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
+    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
     CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3691,11 +3521,11 @@
     <dd>Switch to the [[#comment-end-dash-state]]</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the comment
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the comment
     token's data.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3713,11 +3543,11 @@
     <dd>Switch to the [[#comment-end-state]]</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
+    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
     CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3736,22 +3566,22 @@
     <dd>Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and a U+FFFD
+    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and a U+FFFD
     REPLACEMENT CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
 
     <dt>U+0021 EXCLAMATION MARK (!)</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#comment-end-bang-state]].</dd>
+    <dd><a for="parser">Parse error</a>. Switch to the [[#comment-end-bang-state]].</dd>
 
     <dt>U+002D HYPHEN-MINUS (-)</dt>
-    <dd><a for="parser">parse error</a>. Append a U+002D HYPHEN-MINUS character (-) to the comment token's
+    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) to the comment token's
     data.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and the <a>current
+    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-) and the <a>current
     input character</a> to the comment token's data. Switch to the [[#comment-state]].</dd>
 
   </dl>
@@ -3770,12 +3600,12 @@
     <dd>Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append two U+002D HYPHEN-MINUS characters (-), a U+0021 EXCLAMATION
+    <dd><a for="parser">Parse error</a>. Append two U+002D HYPHEN-MINUS characters (-), a U+0021 EXCLAMATION
     MARK character (!), and a U+FFFD REPLACEMENT CHARACTER character to the comment token's data.
     Switch to the [[#comment-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
     Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3798,11 +3628,11 @@
     <dd>Switch to the [[#before-doctype-name-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
     Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#before-doctype-name-state]]. Reconsume the
+    <dd><a for="parser">Parse error</a>. Switch to the [[#before-doctype-name-state]]. Reconsume the
     character.</dd>
 
   </dl>
@@ -3826,15 +3656,15 @@
     [[#doctype-name-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Create a new DOCTYPE token. Set the token's name to a U+FFFD
+    <dd><a for="parser">Parse error</a>. Create a new DOCTYPE token. Set the token's name to a U+FFFD
     REPLACEMENT CHARACTER character. Switch to the [[#doctype-name-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Create a new DOCTYPE token. Set its <i>force-quirks flag</i> to
+    <dd><a for="parser">Parse error</a>. Create a new DOCTYPE token. Set its <i>force-quirks flag</i> to
     <i>on</i>. Switch to the [[#data-state]]. Emit the token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Create a new DOCTYPE token.
     Set its <i>force-quirks flag</i> to <i>on</i>. Emit the token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3864,11 +3694,11 @@
     character's code point) to the current DOCTYPE token's name.</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     DOCTYPE token's name.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3893,7 +3723,7 @@
     <dd>Switch to the [[#data-state]]. Emit the current DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -3927,23 +3757,23 @@
     <dd>Switch to the [[#before-doctype-public-identifier-state]].</dd>
 
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's public identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's public identifier to the empty string (not
     missing), then switch to the [[#doctype-public-identifier-double-quoted-state]].</dd>
 
     <dt>U+0027 APOSTROPHE (')</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's public identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's public identifier to the empty string (not
     missing), then switch to the [[#doctype-public-identifier-single-quoted-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -3970,15 +3800,15 @@
     the [[#doctype-public-identifier-single-quoted-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -3993,15 +3823,15 @@
     <dd>Switch to the [[#after-doctype-public-identifier-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     DOCTYPE token's public identifier.</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -4020,15 +3850,15 @@
     <dd>Switch to the [[#after-doctype-public-identifier-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     DOCTYPE token's public identifier.</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -4054,19 +3884,19 @@
     <dd>Switch to the [[#data-state]]. Emit the current DOCTYPE token.</dd>
 
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
     missing), then switch to the [[#doctype-system-identifier-double-quoted-state]].</dd>
 
     <dt>U+0027 APOSTROPHE (')</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
     missing), then switch to the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -4096,11 +3926,11 @@
     the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -4119,23 +3949,23 @@
     <dd>Switch to the [[#before-doctype-system-identifier-state]].</dd>
 
     <dt>U+0022 QUOTATION MARK (&quot;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
     missing), then switch to the [[#doctype-system-identifier-double-quoted-state]].</dd>
 
     <dt>U+0027 APOSTROPHE (')</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's system identifier to the empty string (not
     missing), then switch to the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -4162,15 +3992,15 @@
     the [[#doctype-system-identifier-single-quoted-state]].</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#bogus-doctype-state]].</dd>
 
   </dl>
@@ -4185,15 +4015,15 @@
     <dd>Switch to the [[#after-doctype-system-identifier-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     DOCTYPE token's system identifier.</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -4212,15 +4042,15 @@
     <dd>Switch to the [[#after-doctype-system-identifier-state]].</dd>
 
     <dt>U+0000 NULL</dt>
-    <dd><a for="parser">parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
+    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the current
     DOCTYPE token's system identifier.</dd>
 
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd><a for="parser">parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
+    <dd><a for="parser">Parse error</a>. Set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.
     Switch to the [[#data-state]]. Emit that DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
@@ -4246,11 +4076,11 @@
     <dd>Switch to the [[#data-state]]. Emit the current DOCTYPE token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
+    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Set the DOCTYPE token's
     <i>force-quirks flag</i> to <i>on</i>. Emit that DOCTYPE token. Reconsume the EOF character.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">parse error</a>. Switch to the [[#bogus-doctype-state]]. (This does
+    <dd><a for="parser">Parse error</a>. Switch to the [[#bogus-doctype-state]]. (This does
     <em>not</em> set the DOCTYPE token's <i>force-quirks flag</i> to <i>on</i>.)</dd>
 
   </dl>
@@ -5183,7 +5013,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A comment token</dt>
@@ -5216,7 +5046,7 @@
 
     <dt>Any other end tag</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -5257,7 +5087,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -5288,7 +5118,7 @@
     <dt>Any other end tag</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
 
     </dd>
 
@@ -5330,7 +5160,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -5508,7 +5338,7 @@
     <dt>A start tag whose tag name is "head"</dt>
     <dt>Any other end tag</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -5535,7 +5365,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -5576,13 +5406,13 @@
     <dt>A start tag whose tag name is one of: "head", "noscript"</dt>
     <dt>Any other end tag</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     Pop the <a>current node</a> (which will be a <{noscript}> element) from the
     <a>stack of open elements</a>; the new <a>current node</a> will be a
@@ -5618,7 +5448,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -5654,7 +5484,7 @@
     "noframes", "script", "style", "template", "title"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     Push the node pointed to by the <a><code>head</code> element pointer</a> onto
     the <a>stack of open elements</a>.
@@ -5685,7 +5515,7 @@
     <dt>A start tag whose tag name is "head"</dt>
     <dt>Any other end tag</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -5712,7 +5542,7 @@
     <dt>A character token that is U+0000 NULL</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
 
     </dd>
 
@@ -5745,13 +5575,13 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If there is a <{template}> element on the <a>stack of open elements</a>, then
     ignore the token.
@@ -5772,7 +5602,7 @@
     <dt>A start tag whose tag name is "body"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the second element on the <a>stack of open elements</a> is not a <code>body</code>
     element, if the <a>stack of open elements</a> has only one node on it, or if there is a
@@ -5789,7 +5619,7 @@
     <dt>A start tag whose tag name is "frameset"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>stack of open elements</a> has only one node on it, or if the second element
     on the <a>stack of open elements</a> is not a <{body}> element, then ignore the
@@ -6096,7 +5926,7 @@
 
       <ol>
 
-        <li><a for="parser">parse error</a>.</li>
+        <li><a for="parser">Parse error</a>.</li>
 
         <li><a>Generate implied end tags</a>.</li>
 
@@ -6386,7 +6216,7 @@
     <dt>An end tag whose tag name is "br"</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Drop the attributes from the token, and act as described in the
+    <a for="parser">Parse error</a>. Drop the attributes from the token, and act as described in the
     next entry; i.e., act as if this was a "br" start tag token with no attributes, rather than the
     end tag token that it actually is.
 
@@ -6455,7 +6285,7 @@
     <dt>A start tag whose tag name is "image"</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Change the token's tag name to "img" and reprocess it. (Don't
+    <a for="parser">Parse error</a>. Change the token's tag name to "img" and reprocess it. (Don't
     ask.)
     </dd>
 
@@ -6610,7 +6440,7 @@
 
     <dd>
 
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
 
     </dd>
 
@@ -6847,7 +6677,7 @@
     <dt>An end-of-file token</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>current node</a> is a <{script}> element, mark the
     <{script}> element as <a>"already started"</a>.
@@ -7009,7 +6839,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "caption"</dt>
@@ -7074,7 +6904,7 @@
     <dt>A start tag whose tag name is "table"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>stack of open elements</a> does not <a lt="in table scope">have a <code>table</code> element in table scope</a>, ignore the token.
 
@@ -7106,7 +6936,7 @@
     <dt>An end tag whose tag name is one of: "body", "caption", "col", "colgroup", "html", "tbody",
     "td", "tfoot", "th", "thead", "tr"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is one of: "style", "script", "template"</dt>
@@ -7126,7 +6956,7 @@
 
     Otherwise:
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     <a>Insert an HTML element</a> for the token.
 
@@ -7140,7 +6970,7 @@
     <dt>A start tag whose tag name is "form"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If there is a <{template}> element on the <a>stack of open elements</a>, or if
     the <a><code>form</code> element pointer</a> is not null, ignore the
@@ -7164,7 +6994,7 @@
     <dt>Anything else</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Enable <a>foster parenting</a>, process
+    <a for="parser">Parse error</a>. Enable <a>foster parenting</a>, process
     the token <a>using the rules for</a> the "<a>in
     body</a>" <a>insertion mode</a>, and then disable <a>foster
     parenting</a>.
@@ -7197,7 +7027,7 @@
     <dt>A character token that is U+0000 NULL</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
 
     </dd>
 
@@ -7283,7 +7113,7 @@
     <dt>An end tag whose tag name is one of: "body", "col", "colgroup", "html", "tbody", "td",
     "tfoot", "th", "thead", "tr"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -7315,7 +7145,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -7349,7 +7179,7 @@
 
     <dt>An end tag whose tag name is "col"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "template"</dt>
@@ -7405,7 +7235,7 @@
     <dt>A start tag whose tag name is one of: "th", "td"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     <a>Clear the stack back to a table body context</a>. (See below.)
 
@@ -7455,7 +7285,7 @@
     <dt>An end tag whose tag name is one of: "body", "caption", "col", "colgroup", "html", "td",
     "th", "tr"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -7551,7 +7381,7 @@
     <dt>An end tag whose tag name is one of: "body", "caption", "col", "colgroup", "html", "td",
     "th"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Anything else</dt>
@@ -7614,7 +7444,7 @@
     <dt>An end tag whose tag name is one of: "body", "caption",
     "col", "colgroup", "html"</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>An end tag whose tag name is one of: "table", "tbody",
@@ -7671,7 +7501,7 @@
 
     <dt>A character token that is U+0000 NULL</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>Any other character token</dt>
@@ -7688,7 +7518,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -7761,7 +7591,7 @@
     <dt>A start tag whose tag name is "select"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>stack of open elements</a> does not <span>have a <{select}> element in select scope</span>, ignore the token.
     (<a>fragment case</a>)
@@ -7782,7 +7612,7 @@
     <dt>A start tag whose tag name is one of: "input", "textarea"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>stack of open elements</a> does not <span>have a <{select}> element in select scope</span>, ignore the token.
     (<a>fragment case</a>)
@@ -7815,7 +7645,7 @@
 
     <dt>Anything else</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
   </dl>
@@ -7831,7 +7661,7 @@
     "td", "th"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     Pop elements from the <a>stack of open elements</a> until a <{select}> element
     has been popped from the stack.
@@ -7846,7 +7676,7 @@
     "td", "th"</dt>
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the <a>stack of open elements</a> does not <a lt="in table scope">have an element in table scope</a> that is an <a>HTML element</a> with the same tag name as that of the token, then ignore the token.
 
@@ -7969,7 +7799,7 @@
 
     <dt>Any other end tag</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>An end-of-file token</dt>
@@ -8020,7 +7850,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -8049,7 +7879,7 @@
     <dt>Anything else</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Switch the <a>insertion mode</a> to "<a>in body</a>" and reprocess the token.
+    <a for="parser">Parse error</a>. Switch the <a>insertion mode</a> to "<a>in body</a>" and reprocess the token.
 
     </dd>
 
@@ -8075,7 +7905,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -8139,7 +7969,7 @@
 
     <dt>Anything else</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
   </dl>
@@ -8164,7 +7994,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is "html"</dt>
@@ -8195,7 +8025,7 @@
 
     <dt>Anything else</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
   </dl>
@@ -8230,7 +8060,7 @@
     <dt>Anything else</dt>
     <dd>
 
-    <a for="parser">parse error</a>. Switch the <a>insertion mode</a> to "<a>in body</a>" and reprocess the token.
+    <a for="parser">Parse error</a>. Switch the <a>insertion mode</a> to "<a>in body</a>" and reprocess the token.
 
     </dd>
 
@@ -8272,7 +8102,7 @@
 
     <dt>Anything else</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
   </dl>
@@ -8287,7 +8117,7 @@
     <dt>A character token that is U+0000 NULL</dt>
     <dd>
 
-    <a for="parser">parse error</a>. <a lt="insert a character">Insert a U+FFFD REPLACEMENT CHARACTER character</a>.
+    <a for="parser">Parse error</a>. <a lt="insert a character">Insert a U+FFFD REPLACEMENT CHARACTER character</a>.
 
     </dd>
 
@@ -8317,7 +8147,7 @@
 
     <dt>A DOCTYPE token</dt>
     <dd>
-    <a for="parser">parse error</a>. Ignore the token.
+    <a for="parser"><a for="parser">Parse error</a>.
     </dd>
 
     <dt>A start tag whose tag name is one of:  "b", "big", "blockquote", "body", "br", "center",
@@ -8329,7 +8159,7 @@
 
     <dd>
 
-    <a for="parser">parse error</a>.
+    <a for="parser">Parse error</a>.
 
     If the parser was originally created for the <a>HTML fragment parsing algorithm</a>,
     then act as described in the "any other start tag" entry below. (<a>fragment case</a>)

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -68,13 +68,15 @@
 
   A DOCTYPE must consist of the following components, in this order:
 
-  1. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>&lt;!DOCTYPE</code>".
-  2. One or more [=space characters=].
-  3. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>html</code>".
-  4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> (defined below).
-  5. Zero or more [=space characters=].
-  6. A U+003E GREATER-THAN SIGN character (&gt;).
-
+  <ol class="breif">
+    1. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>&lt;!DOCTYPE</code>".
+    2. One or more [=space characters=].
+    3. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>html</code>".
+    4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> (defined below).
+    5. Zero or more [=space characters=].
+    6. A U+003E GREATER-THAN SIGN character (&gt;).
+  </ol>
+  
   <p class="note">
   In other words, <code>&lt;!DOCTYPE html></code>, case-insensitively.
   </p>
@@ -85,13 +87,15 @@
   "<code>&lt;!DOCTYPE html></code>", a <dfn>DOCTYPE legacy string</dfn> may be inserted
   into the DOCTYPE (in the position defined above). This string must consist of:
 
-  1. One or more [=space characters=].
-  2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>SYSTEM</code>".
-  3. One or more [=space characters=].
-  4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>quote mark</i>).
-  5. The literal string "<code>about:legacy-compat</code>".
-  6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>quote mark</i>).
-
+  <ol class="breif">
+    1. One or more [=space characters=].
+    2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>SYSTEM</code>".
+    3. One or more [=space characters=].
+    4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>quote mark</i>).
+    5. The literal string "<code>about:legacy-compat</code>".
+    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as in the earlier step labeled <i>quote mark</i>).
+  </ol>
+  
   <p class="note">
   In other words, <code>&lt;!DOCTYPE html SYSTEM "about:legacy-compat"></code> or
   <code>&lt;!DOCTYPE html SYSTEM 'about:legacy-compat'></code>, case-insensitively except for the

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -12,14 +12,14 @@
 
 <h2 id="syntax"><dfn>The HTML syntax</dfn></h2>
 
-  <p class="note">This section only describes the rules for resources labeled with an 
-  [=HTML MIME type=]. Rules for XML resources are discussed in the section below entitled 
+  <p class="note">This section only describes the rules for resources labeled with an
+  [=HTML MIME type=]. Rules for XML resources are discussed in the section below entitled
   "[=The XML syntax=]".</p>
 
 <h3 id="writing-html-documents">Writing HTML documents</h3>
 
-  <i>This section only applies to documents, authoring tools, and markup generators. In particular, 
-  it does not apply to conformance checkers; conformance checkers must use the requirements given in 
+  <i>This section only applies to documents, authoring tools, and markup generators. In particular,
+  it does not apply to conformance checkers; conformance checkers must use the requirements given in
   the next section ("parsing HTML documents").</i>
 
   Documents must consist of the following parts, in the given order:
@@ -33,7 +33,7 @@
 
   The various types of content mentioned above are described in the next few sections.
 
-  In addition, there are some restrictions on how [=character encoding declarations=] are to be 
+  In addition, there are some restrictions on how [=character encoding declarations=] are to be
   serialized, as discussed in the section on that topic.
 
   <div class="note">
@@ -66,18 +66,18 @@
   A DOCTYPE must consist of the following components, in this order:
 
   <!-- Editor's note: See Issue https://github.com/w3c/html/issues/729 around the obsolete permitted DOCTYPE string -->
-  
+
   <ol class="brief">
-    1. A string that is an <a>ASCII case-insensitive</a> match for the string 
+    1. A string that is an <a>ASCII case-insensitive</a> match for the string
         "<code>&lt;!DOCTYPE</code>".
     2. One or more [=space characters=].
     3. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>html</code>".
-    4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a> 
+    4. Optionally, a <a>DOCTYPE legacy string</a> or an <a>obsolete permitted DOCTYPE string</a>
         (defined below).
     5. Zero or more [=space characters=].
     6. A U+003E GREATER-THAN SIGN character (&gt;).
   </ol>
-  
+
   <p class="note">In other words, <code>&lt;!DOCTYPE html></code>, case-insensitively.</p>
 
   <hr />
@@ -92,15 +92,15 @@
     3. One or more [=space characters=].
     4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>quote mark</i>).
     5. The literal string "<code>about:legacy-compat</code>".
-    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as 
+    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as
         in the earlier step labeled <i>quote mark</i>).
   </ol>
-  
+
   <p class="note">In other words, <code>&lt;!DOCTYPE html SYSTEM "about:legacy-compat"></code> or
   <code>&lt;!DOCTYPE html SYSTEM 'about:legacy-compat'></code>, case-insensitively except for the
   part in single or double quotes.</p>
 
-  The <a>DOCTYPE legacy string</a> should not be used unless the document is generated from a system 
+  The <a>DOCTYPE legacy string</a> should not be used unless the document is generated from a system
   that cannot output the shorter string.
 
   <hr />
@@ -114,18 +114,18 @@
     2. A string that is an <a>ASCII case-insensitive</a> match for the string "<code>PUBLIC</code>".
     3. One or more [=space characters=].
     4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>first quote mark</i>).
-    5. The string from one of the cells in the first column of the table below. The row to which 
+    5. The string from one of the cells in the first column of the table below. The row to which
         this cell belongs is the <i>selected row</i>.
-    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as 
+    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as
         in the earlier step labeled <i>first quote mark</i>).
     7. If a system identifier is used,
         1. One or more [=space characters=].
         2. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the <i>third quote mark</i>).
         3. The string from the cell in the second column of the <i>selected row</i>.
-        4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character 
+        4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character
             as in the earlier step labeled <i>third quote mark</i>).
   </ol>
-  
+
   <table>
     <caption>
     Allowed values for public and system identifiers in an <a>obsolete permitted DOCTYPE string</a>.
@@ -154,8 +154,8 @@
       <td> No
   </table>
 
-  A [=DOCTYPE=] containing an <a>obsolete permitted DOCTYPE string</a> is an 
-  <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use <a>obsolete permitted DOCTYPEs</a>, 
+  A [=DOCTYPE=] containing an <a>obsolete permitted DOCTYPE string</a> is an
+  <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use <a>obsolete permitted DOCTYPEs</a>,
   as they are unnecessarily long.
 
 <h4 id="writing-html-documents-elements">Elements</h4>
@@ -627,8 +627,8 @@
 
     <pre highlight="html">
       &lt;!DOCTYPE HTML>
-      &lt;html>&lt;head>&lt;title>Hello&lt;/title>
-      &lt;/head>&lt;body>&lt;p>Welcome to this example.&lt;/p>&lt;/body>&lt;/html>
+      <small>&lt;html>&lt;head></small>&lt;title>Hello&lt;/title>
+      <small>&lt;/head>&lt;body></small>&lt;p>Welcome to this example.&lt;/p><small>&lt;/body>&lt;/html></small>
     </pre>
   </div>
 
@@ -653,13 +653,13 @@
   <{ol}>, <{p}>, <{pre}>, <a element>section</a>, <{table}>, or
   <{ul}> element, or if there is no more content in the parent element and the parent
   element is an <a>HTML element</a> that is not an <{a}>, <{audio}>, <{del}>,
-  <{ins}>, <{map}>, <{noscript}>, or <{video}> element.
+  <{ins}>, <{map}>, <{noscript}>, or <{video}> element, or an <a>autonomous custom element</a>.
 
   <div class="example">
     We can thus simplify the earlier example further:
 
     <pre highlight="html">
-      &lt;!DOCTYPE HTML>&lt;title>Hello&lt;/title>&lt;p>Welcome to this example.&lt;/p>
+      &lt;!DOCTYPE HTML>&lt;title>Hello&lt;/title>&lt;p>Welcome to this example.<small>&lt;/p></small>
     </pre>
   </div>
 
@@ -680,6 +680,10 @@
   the <{option}> element is immediately followed by another <{option}> element, or
   if it is immediately followed by an <{optgroup}> element, or if there is no more content
   in the parent element.
+
+  A <{menuitem}> element's <a>end tag</a> may be omitted if the <{menuitem}> element is immediately
+  followed by a <{menuitem}>, <{hr}>, or <{menu}> element, or if there is no more content in the
+  parent element.
 
   A <{colgroup}> element's <a>start tag</a> may be
   omitted if the first thing inside the <{colgroup}> element is a <{col}> element,
@@ -710,7 +714,6 @@
   <{tfoot}> element, or if there is no more content in the parent element.
 
   A <{tfoot}> element's <a>end tag</a> may be omitted if
-  the <{tfoot}> element is immediately followed by a <{tbody}> element, or if
   there is no more content in the parent element.
 
   A <{tr}> element's <a>end tag</a> may be omitted if the
@@ -872,12 +875,12 @@
 
   <div class="example">
     The following two <code>pre</code> blocks are equivalent:
+
     <pre highlight="html">
       &lt;pre>Hello&lt;/pre>
     </pre>
     <pre highlight="html">
-      &lt;pre>
-      Hello&lt;/pre>
+      &lt;pre><br>Hello&lt;/pre>
     </pre>
   </div>
 
@@ -919,8 +922,8 @@
 
     <dt>Named character references</dt>
 
-    <dd>The ampersand must be followed by one of the names given in [[#named-character-references]] section, using the same case. <span class="impl">The name must be one that is
-    terminated by a U+003B SEMICOLON character (;).</span></dd>
+    <dd>The ampersand must be followed by one of the names given in [[#named-character-references]] section, using the same case. The name must be one that is
+    terminated by a U+003B SEMICOLON character (;).</dd>
 
     <dt>Decimal numeric character reference</dt>
 
@@ -967,7 +970,7 @@
 
   <div class="example">
     CDATA sections can only be used in foreign content (MathML or SVG). In this example, a CDATA
-    section is used to escape the contents of an <a>MathML <code>ms</code></a> element:
+    section is used to escape the contents of a <a>MathML <code>ms</code></a> element:
 
     <pre highlight="html">
   &lt;p>You can add a string to a number, but this stringifies the number:&lt;/p>
@@ -983,13 +986,17 @@
 
 <h4 id="sec-comments">Comments</h4>
 
-  <dfn lt="comment|comments">Comments</dfn> must start with the four character sequence U+003C
-  LESS-THAN SIGN, U+0021 EXCLAMATION MARK, U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS (<code>&lt;!--</code>). Following this sequence, the comment may have <a>text</a>, with the additional restriction that the text must not start with
-  a single U+003E GREATER-THAN SIGN character (&gt;), nor start with a U+002D HYPHEN-MINUS character
-  (-) followed by a U+003E GREATER-THAN SIGN (&gt;) character, nor contain two consecutive U+002D
-  HYPHEN-MINUS characters (<code>--</code>), nor end with a U+002D HYPHEN-MINUS character
-  (-). Finally, the comment must be ended by the three character sequence U+002D HYPHEN-MINUS,
-  U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN (<code>--&gt;</code>).
+  <dfn lt="comment|comments">Comments</dfn> must have the following format:
+
+  1. The string "<code>&lt;!--</code>"
+  2. Optionally, [=text=], with the additional restriction that the text must not start with the
+      string "<code>></code>", nor start with the string "<code>-></code>", nor contain the strings
+      "<code>&lt;!--</code>", "<code>--></code>", or "<code>--!></code>", nor end with the string
+      "<code>&lt;!-</code>".
+  3. The string "<code>--></code>"
+
+  <p class="note">The [=text=] is allowed to end with the string "<code>&lt;!</code>", as in
+  <code>&lt;!--My favorite operators are > and &lt;!--></code>.</p>
 
   <div class="impl">
 
@@ -1000,7 +1007,7 @@
 
   <p class="note">
   The rules for parsing XML documents into DOM trees are covered by the next
-  section, entitled "<a href="#xhtml">the XHTML syntax</a>".
+  section, entitled "[[#xhtml]]".
   </p>
 
   User agents must use the parsing rules described in this section to generate the DOM trees from
@@ -1062,7 +1069,7 @@
 
 <h4 id="overview-of-the-parsing-model">Overview of the parsing model</h4>
 
-  <object data="images/parsing-model-overview.svg" width="345" height="535"><img src="images/parsing-model-overview.png" width="345" height="450" alt="" /></object>
+  <img src="images/parsing-model-overview.png" width="345" height="450" alt="" />
 
   The input to the HTML parsing process consists of a stream of <a>Unicode code points</a>, which is passed through a <a>tokenization</a> stage
   followed by a tree construction stage. The output is a {{Document}}
@@ -1373,7 +1380,7 @@
       <tr>
         <td>ko
         <td>Korean
-        <td><a>euc-kr</a>
+        <td><a>EUC-KR</a>
 
       <tr>
         <td>ku
@@ -1463,7 +1470,7 @@
       <tr>
         <td>zh-CN
         <td>Chinese (People's Republic of China)
-        <td><a>GB18030</a>
+        <td><a>gb18030</a>
 
       <tr>
         <td>zh-TW
@@ -1541,7 +1548,7 @@
         algorithm, is distinct from an unrecognized encoding or the empty string).</li>
 
         <li><i>Attributes</i>: <a>Get an
-        attribute</a> and its value. If no attribute was computed, then jump to the
+        attribute</a> and its value. If no attribute was sniffed, then jump to the
         <i>processing</i> step below.</li>
 
         <li>If the attribute's name is already in <var>attribute list</var>, then return
@@ -1795,7 +1802,6 @@
 
   User agents must support the encodings defined in the WHATWG Encoding specification, including, but not
   limited to,
-
   <dfn>UTF-8</dfn>,
   <dfn>ISO-8859-2</dfn>,
   <dfn>ISO-8859-8</dfn>,
@@ -1838,7 +1844,7 @@
     <li>If the new encoding is a <a>UTF-16 encoding</a>, then change it to <a>UTF-8</a>.</li>
 
     <li>If the new encoding is the <a>x-user-defined</a> encoding, then change it to
-    <a>Windows-1252</a>. [[!ENCODING]]</li>
+    <a>windows-1252</a>. [[!ENCODING]]</li>
 
     <li>If the new encoding is identical or equivalent to the encoding that is already being used
     to interpret the input stream, then set the <a>confidence</a> to <i>certain</i> and abort these steps.
@@ -1861,7 +1867,7 @@
     <i>certain</i>. Whenever possible, this should be done without actually contacting the network
     layer (the bytes should be re-parsed from memory), even if, e.g., the document is marked as not
     being cacheable. If this is not possible and contacting the network layer would involve repeating
-    a request that uses a method other than <code>GET</code>), then instead set the <a>confidence</a> to <i>certain</i> and ignore the new
+    a request that uses a method other than `<code>GET</code>`), then instead set the <a>confidence</a> to <i>certain</i> and ignore the new
     encoding. The resource will be misinterpreted. User agents may notify the user of the situation,
     to aid in application development.</li>
 

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -3411,12 +3411,11 @@
     <dd>Set the <i>self-closing flag</i> of the current tag token. Switch to the [[#data-state]]. Emit the current tag token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Reconsume the EOF
-    character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#before-attribute-name-state]]. Reconsume
-    the character.</dd>
+    <dd><a for="parser">Parse error</a>. [=Reconsume=] in
+    the [[#before-attribute-name-state]].</dd>
 
   </dl>
 
@@ -3426,21 +3425,17 @@
 
   <dl class="switch">
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
-    <dd>Switch to the <span>data state</span>. Emit the comment token.</dd>
+    <dd>Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>EOF</dt>
-    <dd>Switch to the <span>data state</span>. Reconsume the EOF character. Emit the comment token.</dd>
+    <dd>Emit the comment. Emit an end-of-file token.</dd>
 
     <dt>U+0000 NULL</dt>
     <dd>Append a U+FFFD REPLACEMENT CHARACTER character to the comment token's data.</dd>
 
     <dt>Anything else</dt>
-    <dd>Append the <span>current input character</span> to the comment token's data.</dd>
+    <dd>Append the [=current input character=] to the comment token's data.</dd>
   </dl>
-
-  Switch to the [[#data-state]].
-
-  If the end of the file was reached, reconsume the EOF character.
 
 <h5 id="markup-declaration-open-state">Markup declaration open state</h5>
 
@@ -3456,8 +3451,7 @@
   character before and after), then consume those characters and switch to the [[#cdata-section-state]].
 
   Otherwise, this is a <a for="parser">parse error</a>. Create a comment token whose data is the
-  empty string. Switch to the [[#bogus-comment-state]]. The next character that is consumed, if any,
-  is the first character that will be in the comment.
+  empty string. Switch to the [[#bogus-comment-state]] (don't consume anything in the current state).
 
 <h5 id="comment-start-state">Comment start state</h5>
 
@@ -3468,20 +3462,11 @@
     <dt>U+002D HYPHEN-MINUS (-)</dt>
     <dd>Switch to the [[#comment-start-dash-state]].</dd>
 
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">Parse error</a>. Append a U+FFFD REPLACEMENT CHARACTER character to the comment
-    token's data. Switch to the [[#comment-state]].</dd>
-
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
 
-    <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
-
     <dt>Anything else</dt>
-    <dd>Append the <a>current input character</a> to the comment token's data. Switch to the
-    [[#comment-state]].</dd>
+    <dd>[=Reconsume=] in the [[#comment-state]].</dd>
 
   </dl>
 
@@ -3494,20 +3479,15 @@
     <dt>U+002D HYPHEN-MINUS (-)</dt>
     <dd>Switch to the [[#comment-end-state]]</dd>
 
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
-    CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
-
     <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
     <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit the comment token. Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Append a U+002D HYPHEN-MINUS character (-) and the <a>current input character</a> to
-    the comment token's data. Switch to the [[#comment-state]].</dd>
+    <dd>Append a U+002D HYPHEN-MINUS character (-) to
+    the comment token's data. [=Reconsume=] in the [[#comment-state]].</dd>
 
   </dl>
 
@@ -3517,6 +3497,9 @@
 
   <dl class="switch">
 
+    <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
+    <dd>Append the [=current input character=] to the comment token's data. Switch to the [[#comment-less-than-sign-state]].</dd>
+    
     <dt>U+002D HYPHEN-MINUS (-)</dt>
     <dd>Switch to the [[#comment-end-dash-state]]</dd>
 
@@ -3525,14 +3508,74 @@
     token's data.</dd>
 
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit the comment token.
+    Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
     <dd>Append the <a>current input character</a> to the comment token's data.</dd>
 
   </dl>
 
+<h5 id="comment-less-than-sign-state">Comment less-than sign state</h5>
+
+  Consume the <a>next input character</a>:
+
+  <dl class="switch">
+
+    <dt>U+0021 EXCLAMATION MARK (!)</dt>
+    <dd>Append the [=current input character=] to the comment token's data. Switch to the [[#comment-less-than-sign-bang-state]].</dd>
+    
+    <dt>U+003C LESS-THAN SIGN (&lt;)</dt>
+    <dd>Append the [=current input character=] to the comment token's data.</dd>
+    
+    <dt>Anything else</dt>
+    <dd>[=Reconsume=] in the [[#comment-state]].</dd>
+
+  </dl>
+
+<h5 id="comment-less-than-sign-bang-state">Comment less-than sign bang state</h5>
+  
+  Consume the next input character:
+
+  <dl class="switch">
+  
+    <dt>U+002D HYPHEN-MINUS (-)</dt>
+    <dd>Switch to the [[#comment-less-than-sign-bang-dash-state]].</dd>
+
+    <dt>Anything else</dt>
+    <dd>[=Reconsume=] in the [[#comment-state]].
+    
+  </dl>
+  
+<h5 id="comment-less-than-sign-bang-dash-state">Comment less-than sign bang dash state</h5>
+  
+  Consume the next input character:
+
+  <dl class="switch">
+  
+    <dt>U+002D HYPHEN-MINUS (-)</dt>
+    <dd>Switch to the [[#comment-less-than-sign-bang-dash-dash-state]].</dd>
+
+    <dt>Anything else</dt>
+    <dd>[=Reconsume=] in the [[#comment-end-dash-state]].
+    
+  </dl>
+  
+<h5 id="comment-less-than-sign-bang-dash-dash-state">Comment less-than sign bang dash dash state</h5>
+  
+  Consume the next input character:
+
+  <dl class="switch">
+  
+    <dt>U+003E GREATER-THAN SIGN (&gt;)</dt>
+    <dt>EOF</dt>
+    <dd>[=Reconsume=] in the [[#comment-end-state]].
+
+    <dt>Anything else</dt>
+    <dd><a for="parser">Parse error</a>. [=Reconsume=] in the [[#comment-end-state]].
+    
+  </dl>
+  
 <h5 id="comment-end-dash-state">Comment end dash state</h5>
 
   Consume the <a>next input character</a>:
@@ -3542,17 +3585,13 @@
     <dt>U+002D HYPHEN-MINUS (-)</dt>
     <dd>Switch to the [[#comment-end-state]]</dd>
 
-    <dt>U+0000 NULL</dt>
-    <dd><a for="parser">Parse error</a>. Append a U+002D HYPHEN-MINUS character (-) and a U+FFFD REPLACEMENT
-    CHARACTER character to the comment token's data. Switch to the [[#comment-state]].</dd>
-
     <dt>EOF</dt>
-    <dd><a for="parser">Parse error</a>. Switch to the [[#data-state]]. Emit the comment token.
-    Reconsume the EOF character.</dd>
+    <dd><a for="parser">Parse error</a>. Emit the comment token.
+    Emit an end-of-file token.</dd>
 
     <dt>Anything else</dt>
-    <dd>Append a U+002D HYPHEN-MINUS character (-) and the <a>current input character</a> to
-    the comment token's data. Switch to the [[#comment-state]].</dd>
+    <dd>Append a U+002D HYPHEN-MINUS character (-) to
+    the comment token's data. [=Reconsume=] in the [[#comment-state]].</dd>
 
   </dl>
 

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1421,7 +1421,7 @@
   The first way, common to all event handlers, is as an <a>event handler IDL attribute</a>.
 
   The second way is as an <a>event handler content attribute</a>. Event handlers on
-  <a>html elements</a> and some of the event handlers on {{Window}} objects are exposed in this way.
+  <a>HTML elements</a> and some of the event handlers on {{Window}} objects are exposed in this way.
 
   <hr />
 
@@ -1698,7 +1698,7 @@
 <h5 id="event-handlers-on-elements-document-objects-and-window-objects">Event handlers on elements, <code>Document</code> objects, and <code>Window</code> objects</h5>
 
   The following are the <a>event handlers</a> (and their corresponding <a>event handler event
-  types</a>) that must be supported by all <a>html elements</a>, as both <a>event handler content
+  types</a>) that must be supported by all <a>HTML elements</a>, as both <a>event handler content
   attributes</a> and <a>event handler IDL attributes</a>; and that must be supported by all
   {{Document}} and {{Window}} objects, as <a>event handler IDL attributes</a>:
 
@@ -1768,7 +1768,7 @@
   <hr />
 
   The following are the <a>event handlers</a> (and their corresponding <a>event handler event
-  types</a>) that must be supported by all <a>html elements</a> other than <{body}> and <{frameset}>
+  types</a>) that must be supported by all <a>HTML elements</a> other than <{body}> and <{frameset}>
   elements, as both <a>event handler content attributes</a> and <a>event handler IDL attributes</a>;
   that must be supported by all {{Document}} objects, as <a>event handler IDL attributes</a>; and
   that must be supported by all {{Window}} objects, as <a>event handler IDL attributes</a> on the
@@ -1820,7 +1820,7 @@
   <hr />
 
   The following are the <a>event handlers</a> (and their corresponding <a>event handler event
-  types</a>) that must be supported by all <a>html elements</a>, as both <a>event handler content
+  types</a>) that must be supported by all <a>HTML elements</a>, as both <a>event handler content
   attributes</a> and <a>event handler IDL attributes</a> and that must be supported by all
   {{Document}} objects, as <a>event handler IDL attributes</a>:
 
@@ -2385,7 +2385,7 @@
        If the <var>type</var> string contains a U+003B SEMICOLON character (;), remove the first
        such character and all characters from it up to the end of the string.
 
-       <a>Strip leading and trailing whitespace</a> from <var>type</var>.
+       <a>Strip leading and trailing white space</a> from <var>type</var>.
   27. If <var>type</var> is <em>not</em> now an <a>ASCII case-insensitive</a> match for the string
        "<code>[[#text-html|text/html]]</code>", then act as if the tokenizer had emitted a
        start tag token with the tag name "pre" followed by a single U+000A LINE FEED (LF) character,
@@ -3684,7 +3684,7 @@
 
     User agents must compare the given values only to the MIME type/subtype parts of content
     types, not to the complete type including parameters. Thus, if <var>mimeType</var>
-    values passed to this method include characters such as commas or whitespace, or include MIME
+    values passed to this method include characters such as commas or white space, or include MIME
     parameters, then the handler being registered will never be used.
 
     <p class="note">

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -2107,7 +2107,7 @@
     <li>Let <var>position</var> be a pointer into <var>input</var>, initially
     pointing at the start of the string.</li>
 
-    <li>Remove all <a>space characters</a> from <var>input</var>.</li>
+    <li>Remove all [=space characters=] from <var>input</var>.</li>
 
     <li>If the length of <var>input</var> divides by 4 leaving no remainder, then: if
     <var>input</var> ends with one or two U+003D EQUALS SIGN (=) characters, remove them

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -2262,6 +2262,12 @@
     <a>HTML parser</a>) or <a>XML documents</a> (and the <a>XML parser</a>).
   </p>
 
+  {{Document}} objects have a <dfn>throw-on-dynamic-markup-insertion counter</dfn>, which is used in
+  conjunction with the [=create an element for the token=] algorithm to prevent
+  [=custom element constructors=] from being able to use {{Document/open()|document.open()}},
+  {{Document/close()|document.close()}}, and {{Document/write()|document.write()}} when they are
+  invoked by the parser. Initially, the counter must be set to zero.
+
 <h4 id="opening-the-input-stream">Opening the input stream</h4>
 
   The

--- a/sections/xhtml.include
+++ b/sections/xhtml.include
@@ -1,15 +1,15 @@
 <section>
 <!--
-██     ██ ██     ██ ████████ ██     ██ ██              ██████  ██    ██ ██    ██ ████████    ███    ██     ██
- ██   ██  ██     ██    ██    ███   ███ ██             ██    ██  ██  ██  ███   ██    ██      ██ ██    ██   ██
-  ██ ██   ██     ██    ██    ████ ████ ██             ██         ████   ████  ██    ██     ██   ██    ██ ██
-   ███    █████████    ██    ██ ███ ██ ██              ██████     ██    ██ ██ ██    ██    ██     ██    ███
-  ██ ██   ██     ██    ██    ██     ██ ██                   ██    ██    ██  ████    ██    █████████   ██ ██
- ██   ██  ██     ██    ██    ██     ██ ██             ██    ██    ██    ██   ███    ██    ██     ██  ██   ██
-██     ██ ██     ██    ██    ██     ██ ████████        ██████     ██    ██    ██    ██    ██     ██ ██     ██
+██     ██  ██     ██ ██              ██████  ██    ██ ██    ██ ████████    ███    ██     ██
+ ██   ██   ███   ███ ██             ██    ██  ██  ██  ███   ██    ██      ██ ██    ██   ██
+  ██ ██    ████ ████ ██             ██         ████   ████  ██    ██     ██   ██    ██ ██
+   ███     ██ ███ ██ ██              ██████     ██    ██ ██ ██    ██    ██     ██    ███
+  ██ ██    ██     ██ ██                   ██    ██    ██  ████    ██    █████████   ██ ██
+ ██   ██   ██     ██ ██             ██    ██    ██    ██   ███    ██    ██     ██  ██   ██
+██     ██  ██     ██ ████████        ██████     ██    ██    ██    ██    ██     ██ ██     ██
 -->
 
-<h2 id="xhtml"><dfn>The XHTML syntax</dfn></h2>
+<h2 id="xhtml"><dfn>The XML syntax</dfn></h2>
 
   <p class="note">
   This section only describes the rules for XML resources. Rules for
@@ -18,7 +18,7 @@
 
   <div class="impl">
 
-<h3 id="writing-xhtml-documents">Writing XHTML documents</h3>
+<h3 id="writing-xhtml-documents">Writing documents in the XML syntax</h3>
 
   </div>
 
@@ -42,7 +42,7 @@
 
   <div class="impl">
 
-<h3 id="parsing-xhtml-documents">Parsing XHTML documents</h3>
+<h3 id="parsing-xhtml-documents">Parsing XML documents</h3>
 
   This section describes the relationship between XML and the DOM, with a particular emphasis on
   how this interacts with HTML.
@@ -172,7 +172,7 @@
 
   For the purposes of conformance checkers, if a resource is determined to be in <a href="#xhtml">the XHTML syntax</a>, then it is an <a>XML document</a>.
 
-<h3 id="serializing-xhtml-fragments">Serializing XHTML fragments</h3>
+<h3 id="serializing-xhtml-fragments">Serializing XML fragments</h3>
 
   The <dfn>XML fragment serialization algorithm</dfn> for a <code>Document</code> or
   {{Element}} node either returns a fragment of XML that represents that node or throws an
@@ -260,7 +260,7 @@
   will throw a <code>HierarchyRequestError</code> exception.
   </p>
 
-<h3 id="parsing-xhtml-fragments">Parsing XHTML fragments</h3>
+<h3 id="parsing-xhtml-fragments">Parsing XML fragments</h3>
 
   The <dfn>XML fragment parsing algorithm</dfn> either returns a <code>Document</code> or throws
   a "{{SyntaxError}}" {{DOMException}}. Given a string <var>input</var> and a

--- a/single-page.bs
+++ b/single-page.bs
@@ -400,6 +400,14 @@ urlPrefix: https://drafts.csswg.org/cssom/#; type: dfn; spec: CSSOM;
 
 urlPrefix: http://www.w3.org/TR/custom-elements/#; type: dfn; spec: CUSTOM-ELEMENTS;
     text: autonomous custom element
+    text: current element queue
+    text: custom element constructor
+    text: custom element reactions stack
+    text: customized built-in element
+    text: element queue
+    text: enqueue a custom element callback reaction
+    text: invoke custom element reactions
+    text: looking up a custom element definition; url: look-up-a-custom-element-definition
     text: valid custom element name
     text: upgrades
 
@@ -872,14 +880,15 @@ urlPrefix: https://www.w3.org/TR/xml/#; spec: XML; for: xml
         url: sec-white-space; text: space
 
 urlPrefix: https://www.w3.org/TR/xlink11/#; spec: XLINK; for: xlink; type: element-attr
-    url: actuate-att; text: actuate
-    url: link-locators; text: href
+    text: actuate; url: actuate-att
+    text: href; url: link-locators
     url: link-semantics
         text: arcrole
         text: role
         text: title
-    url: link-types; text: type
-    url: show-att; text: show
+    text: show; url: show-att
+    text: type; url: link-types
+    text: xlink; url: att-method
 
 urlPrefix: https://www.w3.org/TR/xml-names/#; spec: XML-NAMES; for: xmlns; type: element-attr
     text: xmlns; url: ns-decl

--- a/single-page.bs
+++ b/single-page.bs
@@ -695,7 +695,7 @@ urlPrefix: https://www.w3.org/TR/resource-hints/#;  type: dfn; spec: RESOURCE-HI
 <!-- ************************************* SVG ************************************************* -->
 
 url: https://www.w3.org/TR/SVGTiny12/script.html#ScriptContentProcessing; type: dfn; spec: svgtiny12;
-    text: Process the script element
+    text: Process the SVG `script` element
 urlPrefix: https://www.w3.org/TR/SVG2/single-page.html#; type: element; spec: svg2; for: svg;
     text: script; url: interact-ScriptElement
     text: title; url: struct-TitleElement

--- a/single-page.bs
+++ b/single-page.bs
@@ -121,8 +121,6 @@ urlPrefix: https://www.w3.org/TR/css3-syntax/; type: dfn; spec: css3-syntax;
     text: consume a component value
     text: component value
     text: environment encoding
-<!--url: https://www.w3.org/TR/css3-syntax/#typedef-whitespace-token; type: type; spec: css3-syntax;
-    text: whitespace -->
 url: https://www.w3.org/TR/css-style-attr/#syntax; type: dfn; spec: css-style-attr;
     text: style attribute
 url: https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLRENDERINGCONTEXT; type: interface; spec: webgl;
@@ -293,12 +291,12 @@ urlPrefix: https://www.w3.org/TR/wai-aria-1.1/#; spec: aria;
         text: aria-valuemin
         text: aria-valuenow
         text: aria-valuetext
-        
-urlPrefix: https://w3c.github.io/aria-in-html/; type:dfn; 
+
+urlPrefix: https://w3c.github.io/aria-in-html/; type:dfn;
     text: Notes on Using ARIA in HTML; url: #
-urlPrefix: https://w3c.github.io/aria/practices/aria-practices.html; type:dfn; 
+urlPrefix: https://w3c.github.io/aria/practices/aria-practices.html; type:dfn;
     text: WAI-ARIA 1.1 Authoring Practices; url: #
-    
+
 <!-- ************************ CONTENT SECURITY POLICY (CSP) ************************************ -->
 
 urlPrefix: https://w3c.github.io/webappsec-csp/#; type: dfn; spec: CSP
@@ -401,6 +399,7 @@ urlPrefix: https://drafts.csswg.org/cssom/#; type: dfn; spec: CSSOM;
 <!-- ******************************** CUSTOM ELEMENTS ****************************************** -->
 
 urlPrefix: http://www.w3.org/TR/custom-elements/#; type: dfn; spec: CUSTOM-ELEMENTS;
+    text: autonomous custom element
     text: valid custom element name
     text: upgrades
 
@@ -652,7 +651,7 @@ urlPrefix: https://tools.ietf.org/html/
     url: rfc1034#section-3.5;   type: dfn; spec: rfc1034; text: rfc 1034 section 3.5
     urlPrefix: rfc4287#
         type: element; text: content; url: section-4.1.3; for: atom
-        type: element-attr; text: type; url: section-3.1.1; for: atom 
+        type: element-attr; text: type; url: section-3.1.1; for: atom
     url: rfc5322#section-3.2.3; type: dfn; spec: rfc5322; text: rfc 5322 section 3.2.3
     url: rfc5988#section-5;     type: dfn; spec: rfc5988; text: link header
     urlPrefix: rfc6265#; type: dfn; spec: rfc6265
@@ -692,8 +691,8 @@ url: https://www.w3.org/TR/SVGTiny12/script.html#ScriptContentProcessing; type: 
 urlPrefix: https://www.w3.org/TR/SVG2/single-page.html#; type: element; spec: svg2; for: svg;
     text: script; url: interact-ScriptElement
     text: title; url: struct-TitleElement
-    
-    
+
+
 <!-- ********************************** UI EVENTS ********************************************** -->
 
 urlPrefix: https://www.w3.org/TR/uievents/#; spec: UIEVENTS
@@ -885,7 +884,7 @@ urlPrefix: https://www.w3.org/TR/xlink11/#; spec: XLINK; for: xlink; type: eleme
 
 urlPrefix: https://www.w3.org/TR/xml-names/#; spec: XML-NAMES; for: xmlns; type: element-attr
     text: xmlns; url: ns-decl
-    
+
 </pre>
 
 <pre class="link-defaults">

--- a/single-page.bs
+++ b/single-page.bs
@@ -121,8 +121,8 @@ urlPrefix: https://www.w3.org/TR/css3-syntax/; type: dfn; spec: css3-syntax;
     text: consume a component value
     text: component value
     text: environment encoding
-url: https://www.w3.org/TR/css3-syntax/#typedef-whitespace-token; type: type; spec: css3-syntax;
-    text: whitespace
+<!--url: https://www.w3.org/TR/css3-syntax/#typedef-whitespace-token; type: type; spec: css3-syntax;
+    text: whitespace -->
 url: https://www.w3.org/TR/css-style-attr/#syntax; type: dfn; spec: css-style-attr;
     text: style attribute
 url: https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLRENDERINGCONTEXT; type: interface; spec: webgl;


### PR DESCRIPTION
Changes from sync:
* `<menuitem>` no longer void
* special foreign element attribute processing for `<base>` removed (no longer creates in XML namespace)
* removed end-tag omission clause: `<tfoot>` element is immediately followed by a `<tbody>` element
* Adds various missing tokenization states for comment and doctype (factored from previous algorithm)
* Adds a few processing hooks for custom elements during tree construction
