### PR TITLE
Remove references to BECSS (notions of binding) in widgets section.

### DIFF
--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -1403,16 +1403,15 @@ path: includes/cldr.include
 
 ### Introduction ### {#widgets-introduction}
 
-  Exactly how the bindings are implemented is not specified by this specification. User agents
-  are encouraged to make their bindings set the 'appearance' CSS property appropriately to achieve
+  Exactly how user agents render the elements in this section is not specified by this specification.
+  User agents are encouraged to set the 'appearance' CSS property appropriately to achieve
   platform-native appearances for widgets, and are expected to implement any relevant animations,
   etc, that are appropriate for the platform. [[!CSSUI]]
 
 ### The <{button}> element ### {#the-button-element-rendering}
 
-  When the *button* binding applies to a <{button}> element, the element
-  is expected to render as an ''inline-block'' box rendered as a button whose contents are the
-  contents of the element.
+  The <{button}> element is expected to render as an ''inline-block'' box rendered as a button whose
+  contents are the contents of the element.
 
   When the <{button}> element's <{button/type}> attribute is in the <{button/Menu}> state, the user
   agent is expected to indicate that activating the element will display a menu, e.g., by displaying
@@ -1430,10 +1429,10 @@ path: includes/cldr.include
     }
   </pre>
 
-  When the *details* binding applies to a <{details}> element, the element is expected to render as
-  a [=block box=]. The element's shadow tree is expected to take the element's first child
-  <{summary}> element, if any, and place it in a first [=block box=] container, and then take the
-  element's remaining descendants, if any, and place them in a second [=block box=] container.
+  The <{details}> element is expected to render as a [=block box=]. The element's shadow tree is
+  expected to take the element's first child <{summary}> element, if any, and place it in a first
+  [=block box=] container, and then take the element's remaining descendants, if any, and place
+  them in a second [=block box=] container.
 
   The first container is expected to allow the user to request the details be shown or hidden.
 
@@ -1442,19 +1441,19 @@ path: includes/cldr.include
 
 ### The <{input}> element as a text entry widget ### {#the-input-element-as-a-text-entry-widget}
 
-  When the *input-textfield* binding applies to an <{input}> element whose <{input/type}> attribute
-  is in the <{input/Text}>, <{input/Search}>, <{input/Telephone}>, <{input/URL}>, or
-  <{input/E-mail}> state, the element is expected to render as an ''inline-block'' box rendered as a
-  text field.
+  The <{input}> element whose <{input/type}> attribute is in the <{input/Text}>, <{input/Search}>,
+  <{input/Telephone}>, <{input/URL}>, or <{input/E-mail}> state, the element is expected to render
+  as an ''inline-block'' box rendered as a text field. Additionally, the 'line-height' property,
+  if it has a [=computed value=] equivalent to a value that is less than 1.0, must have a used
+  value of 1.0.
 
-  When the *input-password* binding applies to an <{input}> element whose <{input/type}> attribute
-  is in the <{input/Password}> state, the element is expected to render as an ''inline-block'' box
-  rendered as a text field whose contents are obscured.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Password}> state, the
+  element is expected to render as an ''inline-block'' box rendered as a text field whose contents
+  are obscured.
 
-  If these text fields provide a text selection, then, when the user changes the current selection
-  in such a binding, the user agent is expected to [=queue a task=] to [=fire a simple event=]
-  that bubbles named `select` at the element, using the [=user interaction task source=] as the task
-  source.
+  If these text fields provide a text selection, then, when the user changes the current selection,
+  the user agent is expected to [=queue a task=] to [=fire a simple event=] that bubbles named
+  `select` at the element, using the [=user interaction task source=] as the task source.
 
   If an <{input}> element whose <{input/type}> attribute is in one of the above states has a
   <{input/size}> attribute, and parsing that attribute's value using the
@@ -1474,47 +1473,36 @@ path: includes/cldr.include
   run, in pixels, and |max| is the maximum character width of that same font, also in pixels. (The
     element's 'letter-spacing' property does not affect the result.)
 
-  When the *input-textfield* binding applies to an element, the 'line-height' property, if it has a
-  [=computed value=] equivalent to a value that is less than 1.0, must have a used value of 1.0.
-
 ### The <{input}> element as domain-specific widgets ### {#the-input-element-as-domain-specific-widgets}
 
-  When the *input-datetime* binding applies to an <{input}> element whose <{input/type}> attribute
-  is in the <{input/DateTime|Date and Time}> state, the element is expected to render as an
-  ''inline-block'' box depicting a Date and Time control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/DateTime|Date and Time}> state,
+  the element is expected to render as an ''inline-block'' box depicting a Date and Time control.
 
-  When the *input-date* binding applies to an <{input}> element whose <{input/type}> attribute is in
-  the <{input/Date}> state, the element is expected to render as an ''inline-block'' box depicting a
-  Date control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Date}> state, the element is
+  expected to render as an ''inline-block'' box depicting a Date control.
 
-  When the *input-month* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Month}> state, the element is expected to render as an ''inline-block'' box
-  depicting a Month control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Month}> state, the element is
+  expected to render as an ''inline-block'' box depicting a Month control.
 
-  When the *input-week* binding applies to an <{input}> element whose <{input/type}> attribute is in
-  the <{input/Week}> state, the element is expected to render as an ''inline-block'' box depicting a
-  Week control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Week}> state, the element is
+  expected to render as an ''inline-block'' box depicting a Week control.
 
-  When the *input-time* binding applies to an <{input}> element whose <{input/type}> attribute is in
-  the <{input/Time}> state, the element is expected to render as an ''inline-block'' box depicting a
-  Time control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Time}> state, the element is
+  expected to render as an ''inline-block'' box depicting a Time control.
 
-  When the *input-datetime-local* binding applies to an <{input}> element whose <{input/type}>
-  attribute is in the <{input/LocalDateTime|Local Date and Time}> state, the element is expected to
-  render as an ''inline-block'' box depicting a Local Date and Time control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/LocalDateTime|Local Date and Time}>
+  state, the element is expected to render as an ''inline-block'' box depicting a Local Date and Time control.
 
-  When the *input-number* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Number}> state, the element is expected to render as an ''inline-block'' box
-  depicting a Number control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Number}> state, the element is
+  expected to render as an ''inline-block'' box depicting a Number control.
 
   These controls are all expected to be about one line high, and about as wide as necessary to show
   the widest possible value.
 
 ### The <{input}> element as a range control ### {#the-input-element-as-a-range-control}
 
-  When the *input-range* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Range}> state, the element is expected to render as an ''inline-block'' box
-  depicting a slider control.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Range}> state, the element
+  is expected to render as an ''inline-block'' box depicting a slider control.
 
   When the control is wider than it is tall (or square), the control is expected to be a horizontal
   slider, with the lowest value on the right if the 'direction' property on this element has a
@@ -1531,45 +1519,41 @@ path: includes/cldr.include
 
 ### The <{input}> element as a color well ### {#the-input-element-as-a-color-well}
 
-  When the *input-color* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Color}> state, the element is expected to render as an ''inline-block'' box
-  depicting a color well, which, when activated, provides the user with a color picker (e.g., a
-    color wheel or color palette) from which the color can be changed.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Color}> state, the element is
+  expected to render as an ''inline-block'' box depicting a color well, which, when activated, provides
+  the user with a color picker (e.g., a color wheel or color palette) from which the color can be changed.
 
   Predefined suggested values (provided by the <{input/list}> attribute) are expected to be shown in
   the color picker interface, not on the color well itself.
 
 ### The <{input}> element as a checkbox and radio button widgets ### {#the-input-element-as-a-checkbox-and-radio-button-widgets}
 
-  When the *input-checkbox* binding applies to an <{input}> element whose <{input/type}> attribute
-  is in the <{input/Checkbox}> state, the element is expected to render as an ''inline-block'' box
-  containing a single checkbox control, with no label.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Checkbox}> state, the element
+  is expected to render as an ''inline-block'' box containing a single checkbox control, with no label.
 
-  When the *input-radio* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Radio|Radio Button}> state, the element is expected to render as an
-  ''inline-block'' box containing a single radio button control, with no label.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Radio|Radio Button}> state,
+  the element is expected to render as an ''inline-block'' box containing a single radio button control,
+  with no label.
 
 ### The <{input}> element as a file upload control ### {#the-input-element-as-a-file-upload-control}
 
-  When the *input-file* binding applies to an <{input}> element whose <{input/type}> attribute is in
-  the <{input/File|File Upload}> state, the element is expected to render as an ''inline-block'' box
-  containing a span of text giving the file name(s) of the [=selected files=], if any, followed by a
-  button that, when activated, provides the user with a file picker from which the selection can be
-  changed.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/File|File Upload}> state, the
+  element is expected to render as an ''inline-block'' box containing a span of text giving the file
+  name(s) of the [=selected files=], if any, followed by a button that, when activated, provides the
+  user with a file picker from which the selection can be changed.
 
 ### The <{input}> element as a button ### {#the-input-element-as-a-button}
 
-  When the *input-button* binding applies to an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Submit|Submit Button}>, <{input/Reset|Reset Button}>, or <{input/Button}> state,
-  the element is expected to render as an ''inline-block'' box rendered as a button, about one line
-  high, containing the contents of the element's <{input/value}> attribute, if any, or text derived
-  from the element's <{input/type}> attribute in a user-agent-defined (and probably locale-specific)
-  fashion, if not.
+  An <{input}> element whose <{input/type}> attribute is in the <{input/Submit|Submit Button}>,
+  <{input/Reset|Reset Button}>, or <{input/Button}> state, the element is expected to render as an
+  ''inline-block'' box rendered as a button, about one line high, containing the contents of the
+  element's <{input/value}> attribute, if any, or text derived from the element's <{input/type}>
+  attribute in a user-agent-defined (and probably locale-specific) fashion, if not.
 
 ### The <{marquee}> element ### {#the-marquee-element-rendering}
 
-  When the *marquee* binding applies to a <{marquee}> element, while the element is [=turned on=],
-  the element is expected to render in an animated fashion according to its attributes as follows:
+  The <{marquee}> element, while the element is [=turned on=], the element is expected to render
+  in an animated fashion according to its attributes as follows:
 
   : If the element's <{marquee/behavior}> attribute is in the <{marquee/behavior/scroll}> state
   :: Slide the contents of the element in the direction described by the <{marquee/direction}>
@@ -1690,9 +1674,9 @@ path: includes/cldr.include
 
 ### The <{meter}> element ### {#the-meter-element-rendering}
 
-  When the *meter* binding applies to a <{meter}> element, the element is expected to render as an
-  ''display/inline-block'' box with a 'height' of &quot;1em&quot; and a 'width' of &quot;5em&quot;,
-  a 'vertical-align' of &quot;-0.2em&quot;, and with its contents depicting a gauge.
+  The <{meter}> element is expected to render as an ''display/inline-block'' box with a 'height'
+  of &quot;1em&quot; and a 'width' of &quot;5em&quot;, a 'vertical-align' of &quot;-0.2em&quot;, and
+  with its contents depicting a gauge.
 
   When the element is wider than it is tall (or square), the depiction is expected to be of a
   horizontal gauge, with the minimum value on the right if the 'direction' property on this element
@@ -1707,9 +1691,8 @@ path: includes/cldr.include
 
 ### The <{progress}> element ### {#the-progress-element-rendering}
 
-  When the *progress* binding applies to a <{progress}> element, the element is expected to render
-  as an ''display/inline-block'' box with a 'height' of &quot;1em&quot; and a 'width' of
-  &quot;10em&quot;, and a 'vertical-align' of &quot;-0.2em&quot;.
+  The <{progress}> element is expected to render as an ''display/inline-block'' box with a 'height'
+  of &quot;1em&quot; and a 'width' of &quot;10em&quot;, and a 'vertical-align' of &quot;-0.2em&quot;.
 
   <img class="extra" src="images/sample-progress.png" alt="" width="157" height="103" />
 
@@ -1736,21 +1719,20 @@ path: includes/cldr.include
 
 ### The <{select}> element ### {#the-select-element-rendering}
 
-  When the *select* binding applies to a <{select}> element whose <{select/multiple}> attribute is
-  present, the element is expected to render as a multi-select list box.
+  A <{select}> element whose <{select/multiple}> attribute is present, the element is expected to
+  render as a multi-select list box.
 
-  When the *select* binding applies to a <{select}> element whose <{select/multiple}> attribute is
-  absent, and the element's [=display size=] is greater than 1, the element is expected to render as
-  a single-select list box.
+  A <{select}> element whose <{select/multiple}> attribute is absent, and the element's
+  [=display size=] is greater than 1, the element is expected to render as a single-select list box.
 
   When the element renders as a list box, it is expected to render as an ''inline-block'' box whose
   'height' is the height necessary to contain as many rows for items as given by the element's
   [=display size=], or four rows if the attribute is absent, and whose 'width' is the
   [=width of the `select`'s labels=] plus the width of a scrollbar.
 
-  When the *select* binding applies to a <{select}> element whose <{select/multiple}> attribute is
-  absent, and the element's [=display size=] is 1, the element is expected to render as a one-line
-  drop down box whose width is the [=width of the `select`'s labels=].
+  A <{select}> element whose <{select/multiple}> attribute is absent, and the element's
+  [=display size=] is 1, the element is expected to render as a one-line drop down box whose width
+  is the [=width of the `select`'s labels=].
 
   In either case (list box or drop-down box), the element's items are expected to be the element's
   [=list of options=], with the element's <{optgroup}> element children providing headers for groups
@@ -1784,12 +1766,10 @@ path: includes/cldr.include
     textarea { white-space: pre-wrap; }
   </pre>
 
-  When the *textarea* binding applies to a <{textarea}> element, the element is expected to render
-  as an ''inline-block'' box rendered as a multiline text field. If this text field provides a
-  selection, then, when the user changes the current selection in such a binding, the user agent is
-  expected to [=queue a task=] to [=fire a simple event=] that bubbles named
-  <a event><code>select</code></a> at the element, using the [=user interaction task source=] as the
-  task source.
+  The <{textarea}> element is expected to render as an ''inline-block'' box rendered as a multiline
+  text field. If this text field provides a selection, the user agent is expected to [=queue a task=]
+  to [=fire a simple event=] that bubbles named <a event><code>select</code></a> at the element,
+  using the [=user interaction task source=] as the task source.
 
   If the element has a {{HTMLTextAreaElement/cols}} attribute, and parsing that attribute's value
   using the [=rules for parsing non-negative integers=] doesn't generate an error, then the user


### PR DESCRIPTION
Resolves #445.

Big-ish change, so requesting review.