### PR TITLE
Make HTML4/XHTML1 stict DOCTYPES non-conforming.

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -70,15 +70,12 @@
     1. A string that is an [=ASCII case-insensitive=] match for the string "`&lt;!DOCTYPE`".
     2. One or more [=space characters=].
     3. A string that is an [=ASCII case-insensitive=] match for the string "`html`".
-    4. Optionally, a [=DOCTYPE legacy string=] or an [=obsolete permitted DOCTYPE string=]
-        (defined below).
+    4. Optionally, a [=DOCTYPE legacy string=].
     5. Zero or more [=space characters=].
     6. A U+003E GREATER-THAN SIGN character (&gt;).
   </ol>
 
   <p class="note">In other words, <code>&lt;!DOCTYPE html></code>, case-insensitively.</p>
-
-  ---
 
   For the purposes of HTML generators that cannot output HTML markup with the short DOCTYPE
   "<code>&lt;!DOCTYPE html></code>", a <dfn>DOCTYPE legacy string</dfn> may be inserted
@@ -100,60 +97,6 @@
 
   The [=DOCTYPE legacy string=] should not be used unless the document is generated from a system
   that cannot output the shorter string.
-
-  ---
-
-  To help authors transition from HTML 4.01 and XHTML 1.1, an
-  <dfn>obsolete permitted DOCTYPE string</dfn> can be inserted into the DOCTYPE (in the position
-  defined above). This string must consist of:
-
-  <ol class="brief">
-    1. One or more [=space characters=].
-    2. A string that is an [=ASCII case-insensitive=] match for the string "<code>PUBLIC</code>".
-    3. One or more [=space characters=].
-    4. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the |first quote mark|).
-    5. The string from one of the cells in the first column of the table below. The row to which
-        this cell belongs is the |selected row|.
-    6. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character as
-        in the earlier step labeled |first quote mark|).
-    7. If a system identifier is used,
-        1. One or more [=space characters=].
-        2. A U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (the |third quote mark|).
-        3. The string from the cell in the second column of the |selected row|.
-        4. A matching U+0022 QUOTATION MARK or U+0027 APOSTROPHE character (i.e., the same character
-            as in the earlier step labeled |third quote mark|).
-  </ol>
-
-  <table>
-    <caption>Allowed values for public and system identifiers in an
-    [=obsolete permitted DOCTYPE string=].</caption>
-    <thead>
-    <tr>
-      <th> Public identifier
-      <th> System identifier
-      <th> System identifier optional?
-    <tbody>
-    <tr>
-      <td> <code>-//W3C//DTD&nbsp;HTML&nbsp;4.0//EN</code>
-      <td> <code>http://www.w3.org/TR/REC-html40/strict.dtd</code>
-      <td> Yes
-    <tr>
-      <td> <code>-//W3C//DTD&nbsp;HTML&nbsp;4.01//EN</code>
-      <td> <code>http://www.w3.org/TR/html4/strict.dtd</code>
-      <td> Yes
-    <tr>
-      <td> <code>-//W3C//DTD&nbsp;XHTML&nbsp;1.0&nbsp;Strict//EN</code>
-      <td> <code>http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd</code>
-      <td> No
-    <tr>
-      <td> <code>-//W3C//DTD&nbsp;XHTML&nbsp;1.1//EN</code>
-      <td> <code>http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd</code>
-      <td> No
-  </table>
-
-  A [=DOCTYPE=] containing an [=obsolete permitted DOCTYPE string=] is an
-  <dfn>obsolete permitted DOCTYPE</dfn>. Authors should not use [=obsolete permitted DOCTYPEs=],
-  as they are unnecessarily long.
 
 ### Elements ### {#writing-html-documents-elements}
 
@@ -4134,31 +4077,7 @@
     :: If the DOCTYPE token's name is not a [=case-sensitive=] match for the string "`html`", or the
         token's public identifier is not missing, or the token's system identifier is neither
         missing nor a [=case-sensitive=] match for the string
-        "<a scheme><code>about:legacy-compat</code></a>", and none of the sets of conditions in the
-        following list are matched, then there is a [=parse error=].
-
-        * The DOCTYPE token's name is a [=case-sensitive=] match for the string "`html`", the
-            token's public identifier is the [=case-sensitive=] string
-            "`-//W3C//DTD&nbsp;HTML&nbsp;4.0//EN`", and the token's system identifier is either
-            missing or the [=case-sensitive=] string "`http://www.w3.org/TR/REC-html40/strict.dtd`".
-        * The DOCTYPE token's name is a [=case-sensitive=] match for the string "`html`", the
-            token's public identifier is the [=case-sensitive=] string
-            "`-//W3C//DTD&nbsp;HTML&nbsp;4.01//EN`", and the token's system identifier is either
-            missing or the [=case-sensitive=] string "`http://www.w3.org/TR/html4/strict.dtd`".
-        * The DOCTYPE token's name is a [=case-sensitive=] match for the string "`html`", the
-            token's public identifier is the [=case-sensitive=] string
-            "`-//W3C//DTD&nbsp;XHTML&nbsp;1.0&nbsp;Strict//EN`", and the token's system identifier
-            is the [=case-sensitive=] string "`http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd`".
-        * The DOCTYPE token's name is a [=case-sensitive=] match for the string "`html`", the
-            token's public identifier is the [=case-sensitive=] string
-            "`-//W3C//DTD&nbsp;XHTML&nbsp;1.1//EN`", and the token's system identifier is the
-            [=case-sensitive=] string "`http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd`".
-
-        Conformance checkers may, based on the values (including presence or lack thereof) of the
-        DOCTYPE token's name, public identifier, or system identifier, switch to a conformance
-        checking mode for another language (e.g., based on the DOCTYPE token a conformance checker
-        could recognize that the document is an HTML 4.01-era document, and defer to an HTML 4.01
-        conformance checker.)
+        "<a scheme><code>about:legacy-compat</code></a>", then there is a [=parse error=].
 
         Append a {{DocumentType}} node to the {{Document}} node, with the {{DocumentType/name}}
         attribute set to the name given in the DOCTYPE token, or the empty string if the name was


### PR DESCRIPTION
 For issue #729 - removes the old legacy DOCTYPES as conforming.