### PR TITLE
Added note that removes the restriction of <style> in <head>

### DIFF
--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -1540,8 +1540,9 @@
   by default styles apply to all media.
 
   <p class="note">
-    A <{style}> element is restricted to
-    appearing in the <{head}> of the document.
+    A <{style}> element should preferably be used in the <{head}> of the document.
+    The use of <{style}> in the <{body}> of the document may cause restyling, trigger layout
+    and/or cause repainting, and hence, should be used with care.
   </p>
 
   The <dfn element-attr for="style"><code>nonce</code></dfn> attribute represents a cryptographic


### PR DESCRIPTION
Restriction on <style> placement has been changed to point out that use in the body can trigger unwanted side effects. See Issue #544 - also, as per @travisleithead note: #516 (comment) we need style in body for the web components case anyway.