### PR TITLE
tighten up description of summary

### DIFF
--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -190,9 +190,9 @@
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
 
-  The <{summary}> element <a>represents</a> a summary, caption, or legend for the
-  rest of the contents of the <{summary}> element's parent <code>details</code>
-  element, if any.
+  The first <{summary}> child element of a <{details}> element
+  <a>represents</a> a summary, caption, or legend for the rest of the contents of the
+  parent <{details}> element, if any.
   
   <p>The activation behavior of <code>summary</code> elements is to run the following steps:</p>	
   <ol>	


### PR DESCRIPTION
Only the first summary child acts as a summary for a details element.