### PR TITLE
Added guidance for how UI filtering for suggestions should work.

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -6714,6 +6714,9 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   User agents are encouraged to filter the suggestions represented by the <a>suggestions source element</a> when the number of suggestions is
   large, including only the most relevant ones (e.g., based on the user's input so far). No precise
   threshold is defined, but capping the list at four to seven values is reasonable.
+  User agents that perform filtering should implement substring matching on the <{option/label}> attribute.
+
+  <p class="warning">Existing user agents filter on either <{option/value}> or <{option/label}> so the behavior may be inconsistent.</p>
 
   How user selections of suggestions are handled depends on whether the element is a control
   accepting a single value only, or whether it accepts multiple values:


### PR DESCRIPTION
This is to address the points raised in issue #236 to encourage filtering on label, since the issue noted that values could be UUIDs, random keys, etc.