### PR TITLE
Adds allow-presentation to iframe sandbox flags

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -657,6 +657,7 @@
         "<code>allow-forms</code>",
         "<code>allow-pointer-lock</code>",
         "<code>allow-popups</code>",
+        "<code>allow-presentation</code>",
         "<code>allow-same-origin</code>",
         "<code>allow-scripts</code> and
         "<code>allow-top-navigation</code>"

--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -2218,6 +2218,14 @@
 
     </dd>
 
+    <dt>The <dfn>sandboxed presentation browsing context flag</dfn></dt>
+
+    <dd>
+
+    This flag disables the Presentation API. [[!PRESENTATION-API]]
+
+    </dd>
+
   </dl>
 
   When the user agent is to <dfn lt="parse the sandboxing directive|parse a sandboxing directive">parse a sandboxing directive</dfn>, given a string <var>input</var>, a <a>sandboxing flag set</a> <var>output</var>, and
@@ -2299,6 +2307,9 @@
       keyword.</li>
 
       <li>The <a>sandboxed modals flag</a>, unless <var>tokens</var> contains the <dfn><code>allow-modals</code></dfn> keyword.</li>
+
+      <li>The <a>sandboxed presentation browsing context flag</a>, unless <var>tokens</var>
+      contains the <dfn><code>allow-presentation</code></dfn> keyword.</li>
 
     </ul>
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3879,7 +3879,7 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   The <dfn element-attr for="iframe"><code>sandbox</code></dfn> attribute, when specified,
   enables a set of extra restrictions on any content hosted by the <{iframe}>. Its value
   must be an <a>unordered set of unique space-separated tokens</a> that are <a>ASCII
-  case-insensitive</a>. The allowed values are <code>allow-forms</code>, <code>allow-pointer-lock</code>, <code>allow-popups</code>, <code>allow-same-origin</code>, <code>allow-scripts</code>, and <code>allow-top-navigation</code>.
+  case-insensitive</a>. The allowed values are <code>allow-forms</code>, <code>allow-pointer-lock</code>, <code>allow-popups</code>, <code>allow-presentation</code>, <code>allow-same-origin</code>, <code>allow-scripts</code>, and <code>allow-top-navigation</code>.
 
   When the attribute is set, the content is treated as being from a unique
   [=concept/origin=],
@@ -3889,8 +3889,8 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
   the content to be treated as being from its real origin instead of forcing it into a unique
   origin; the <code>allow-top-navigation</code>
   keyword allows the content to <a>navigate</a> its <a>top-level browsing context</a>;
-  and the <code>allow-forms</code>, <code>allow-pointer-lock</code>, <code>allow-popups</code> and <code>allow-scripts</code> keywords re-enable forms, the
-  pointer lock API, popups, and scripts respectively. [[!POINTERLOCK]]
+  and the <code>allow-forms</code>, <code>allow-pointer-lock</code>, <code>allow-popups</code>, <code>allow-presentation</code> and <code>allow-scripts</code> keywords re-enable forms, the
+  pointer lock API, popups, the presentation API, and scripts respectively. [[!POINTERLOCK]] [[!PRESENTATION-API]]
 
   <p class="warning">Setting both the <code>allow-scripts</code> and <code>allow-same-origin</code> keywords together when the
   embedded page has the <a>same origin</a> as the page containing the <code>iframe</code>


### PR DESCRIPTION
The Presentation API uses the "allow-presentation" iframe sandbox flag to enable the API in nested browsing contexts. See issue #437.