### PR TITLE
Strengthen advice to keep default context menu available

### DIFF
--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -629,18 +629,11 @@
   the user agent must <a>build and show</a> the menu for
   <var>menu</var> with <var>subject</var> as the subject.
 
-  The user agent may also provide access to its default context menu, if any, with the context
-  menu shown. For example, it could merge the menu items from the two menus together, or provide the
-  page's context menu as a submenu of the default menu. In general, user agents are encouraged to
-  de-emphasize their own contextual menu items, so as to give the author's context menu the
-  appearance of legitimacy — to allow documents to feel like "applications" rather than "mere
-  Web pages".
-
-  User agents may provide means for bypassing the context menu processing model, ensuring that
-  the user can always access the user agent's default context menus. For example, the user agent could
-  handle right-clicks that have the Shift key depressed in such a way that it does not fire the
-  <code>contextmenu</code> event and instead always shows the default
-  context menu.
+  The user agent should also provide access to its default context menu, with the context
+  menu shown. For example, it could merge the menu items from the two menus together,
+  provide the page's context menu as a submenu of the default menu, or
+  handle right-clicks that have the Shift key depressed by showing the default context menu
+  instead of firing the <code>contextmenu</code> event.
 
   <hr />
 

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -625,8 +625,8 @@
   the user agent must <a>build and show</a> the menu for
   <var>menu</var> with <var>subject</var> as the subject.
 
-  The user agent should also provide access to its default context menu, with the context
-  menu shown. For example, it could merge the menu items from the two menus together,
+  When it presents a context menu, the user agent should also provide access to its default context menu.
+  For example, it could merge the menu items from the two menus together,
   provide the page's context menu as a submenu of the default menu, or
   handle right-clicks that have the Shift key depressed by showing the default context menu
   instead of firing the <code>contextmenu</code> event.

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -42,7 +42,7 @@
     The <{details}> element is not appropriate for footnotes. Please see [[#footnotes]] for details on how to mark up footnotes.
   </p>
 
-  The <span class="impl">first</span> <{summary}> element child of the element, if any,
+  The first <{summary}> element child of the element, if any,
   <a>represents</a> the summary or legend of the details. If there is no
   child <{summary}> element, the user agent should provide its own legend (e.g.,
   in English "Details" or Spanish <span lang="es">"Detalles"</span>). 
@@ -478,8 +478,6 @@
   present, that the command is the one that would have been invoked if the user had directly
   activated the menu's subject instead of using the menu. The <code>default</code> attribute is a <a>boolean attribute</a>.
 
-  <div class="impl">
-
   <hr />
 
   The <dfn attribute for="HTMLMenuItemElement"><code>type</code></dfn> IDL attribute must
@@ -504,8 +502,6 @@
 
   If the element's <a facet for="menuitem">Disabled State</a> is true
   (disabled) then the element has no <a>activation behavior</a>.
-
-  </div>
 
   <p class="note">
     The <{menuitem}> element is not rendered except as <a element lt="menu">part of a context menu</a>.


### PR DESCRIPTION
This changes the suggestion that user agents "may" make the default context menu available to a should, and rationalises the two paragraphs of example implementation suggestions into one.

In practice the only current implementation of `menu` for context menus already does this.