### PR TITLE
Update semantics-embedded-content.include

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -8495,16 +8495,14 @@ zero or more <{track}> elements, then
     video.autoplay = true;
     video.controls = true;
     container.appendChild(video);
-    video.onloadedmetadata = function (event) {
-      for (var i = 0; i &lt; video.videoTracks.length; i += 1) {
-        if (video.videoTracks[i].kind == 'sign') {
-          var sign = document.createElement('video');
-          sign.src = url + '#track=' + video.videoTracks[i].id;
+    video.videoTracks.onaddtrack = function (event) {
+       if (event.track.kind == 'sign') {
+         var sign = document.createElement('video');
+         sign.src = url + '#track=' + event.track.id; 
           sign.autoplay = true;
           container.appendChild(sign);
           return;
         }
-      }
     };
   }
 &lt;/script&gt;


### PR DESCRIPTION
There is an inconsistency between 4.7.10.10 Media resources with multiple media tracks code example and loadedmetadata event specification. In HAVE_METADATA state
enough of the resource has been obtained that the duration of the resource is available. In the case of a video element, the dimensions of the video are also available. (According to this video track doesn't have to be ready yet)
According to the specification this example should rely on onaddtrack event.