### PR TITLE
For img[ismap], remove the extra border calculation

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -112,12 +112,12 @@
         <code>ismap</code> attribute specified, then server-side image map processing must be
         performed, as follows:
         1. If the <code>click</code> event was a real pointing-device-triggered <code>click</code>
-            event on the <{img}> element, then let <var>x</var> be the distance in CSS
-            pixels from the left edge of the image's left border, if it has one, or the left edge of
-            the image otherwise, to the location of the click, and let <var>y</var> be the distance
-            in CSS pixels from the top edge of the image's top border, if it has one, or the top
-            edge of the image otherwise, to the location of the click. Otherwise, let <var>x</var>
-            and <var>y</var> be zero.
+            event on the <{img}> element, then let |x| be the distance in CSS
+            pixels from the left edge of the image
+            to the location of the click, and let |y| be the distance
+            in CSS pixels from the top edge of the image
+            to the location of the click. Otherwise, let |x|
+            and |y| be zero.
         2. Let <var>hyperlink suffix</var> be a U+003F QUESTION MARK character, the value of
             <var>x</var> expressed as a base-ten integer using <a>ASCII digits</a>, a U+002C COMMA
             character (,), and the value of <var>y</var> expressed as a base-ten integer using


### PR DESCRIPTION
Fix #492 

Images with the ismap attribute should now report coordinates based purely on the image's left/top coordinate (the content-box). Previously this may have included the border-box.

Chrome/Firefox have converged on this behavior. Bugs filed in other browsers to converge them as well.

This commit based on whatwg/html commit 87c078dfd7c36d65328db4bb7bfc3c8f411e5997