### PR TITLE
Remove ambiguity around last frame time for media's seekable attribute

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -8405,9 +8405,8 @@ zero or more <{track}> elements, then
     If the user agent can seek to anywhere in the <a>media resource</a>, e.g.,
   because it is a simple movie file and the user agent and the server support HTTP Range requests,
   then the attribute would return an object with one range, whose start is the time of the first
-  frame (the <a>earliest possible position</a>, typically zero), and whose end is the same as
-  the time of the first frame plus the <code>duration</code> attribute's
-  value (which would equal the time of the last frame, and might be positive Infinity).
+  frame (the <a>earliest possible position</a>, typically zero), and whose end is the
+  time of the last frame.
   </p>
 
   <p class="note">
@@ -8498,7 +8497,7 @@ zero or more <{track}> elements, then
     video.videoTracks.onaddtrack = function (event) {
        if (event.track.kind == 'sign') {
          var sign = document.createElement('video');
-         sign.src = url + '#track=' + event.track.id; 
+         sign.src = url + '#track=' + event.track.id;
           sign.autoplay = true;
           container.appendChild(sign);
           return;
@@ -11557,7 +11556,7 @@ red:89
 
   The <dfn element-attr for="area"><code>coords</code></dfn> attribute must, if specified,
   contain a <a>valid list of floating-point numbers</a>. This attribute gives the coordinates for the shape
-  described by the <code>shape</code> attribute. 
+  described by the <code>shape</code> attribute.
   The processing for this attribute is described as part of the <a>image map</a> processing model.
 
   In the <dfn state for="area" lt="Circle state|circle state">circle state</dfn>, <{area}> elements must
@@ -11990,7 +11989,7 @@ red:89
 
   <strong>Author requirements</strong>: The
   <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>width</code></dfn> and
-  <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>height</code></dfn> attributes 
+  <dfn element-attr for="media,img,iframe,embed,object,video,input"><code>height</code></dfn> attributes
   on <{img}>, <{iframe}>, <{embed}>, <{object}>, <{video}>, and, when their <code>type</code> attribute
   is in the <{input/Image|Image Button}> state, <{input}> elements may be
   specified to give the dimensions of the visual content of the element (the width and height


### PR DESCRIPTION
Fix #475 

[Editorial] Proposed text to clarify what time to use for the last frame available during seeking.