### PR TITLE
minor fixes for 2.4.2, 4.3.9, 4.11.1 and 5.1

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -68,9 +68,8 @@
 
   <div class="example">
     For example, it would be incorrect to use the <{links/href}> attribute to link to a
-    section marked with the <{global/hidden}>
-    attribute. If the content is not applicable or relevant, then there
-    is no reason to link to it.
+    section marked with the <{global/hidden}> attribute. If the content is not applicable
+    or relevant, then there is no reason to link to it.
 
     It would be fine, however, to use the ARIA <{aria/aria-describedby}> attribute to
     refer to descriptions that are themselves <{global/hidden}>. While hiding the descriptions
@@ -104,21 +103,6 @@
   Because some User Agents have flattened hidden content when
   exposing such content to AT, authors should not reference <{global/hidden}> content which would lose essential
   meaning when flattened.
-
-  <div class="example">
-    For example, it would be incorrect to use the <{links/href}>
-    attribute to link to a section marked with the <{global/hidden}> attribute.
-    If the content is not applicable or relevant, then there is no reason to link to it.
-
-    It would be fine, however, to use the ARIA <{aria/aria-describedby}> attribute to refer to descriptions that are
-    themselves <{global/hidden}>. While hiding the descriptions implies that
-    they are not useful alone, they could be written in such a way that they are useful in the
-    specific context of being referenced from the images that they describe.
-
-    Similarly, a <{canvas}> element with the <{global/hidden}>
-    attribute could be used by a scripted graphics engine as an off-screen buffer, and a form control
-    could refer to a hidden <{form}> element using its <code>form</code> attribute.
-  </div>
 
   Elements in a section hidden by the <{global/hidden}> attribute are still
   active, e.g., scripts and form controls in such sections still execute and submit respectively.

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1853,6 +1853,11 @@
   trailing white space.
 
   <p class="note">
+    A boolean attribute without a value assigned to it (e.g. checked) is implicitly equivalent to
+    one that has the empty string assigned to it (i.e. checked=""). As a consequence, it represents the true value.
+  </p>
+
+  <p class="note">
     The values "true" and "false" are not allowed on <a>boolean attributes</a>. To represent a false value,
     the attribute has to be omitted altogether.
   </p>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -42,10 +42,10 @@
     The <{details}> element is not appropriate for footnotes. Please see [[#footnotes]] for details on how to mark up footnotes.
   </p>
 
-  If the <{details}> element has a <{summary}> child element, then the first summary child element
-  <a>represents</a> the summary or legend of the details element. If there is no summary child
-  element, a user agent should provide its own legend (e.g. in English "Details"
-  or Spanish <span lang="es">"Detalles"</span>).
+  The first <{summary}> element child of the element, if any,
+  <a>represents</a> the summary or legend of the details. If there is no
+  child <{summary}> element, the user agent should provide its own legend (e.g.,
+  in English "Details" or Spanish <span lang="es">"Detalles"</span>).
 
   <p class="note">The legend text should be presented in the language determined from the computed
   language of the element, if available, rather than from the locale of the browser/system.</p>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -42,10 +42,10 @@
     The <{details}> element is not appropriate for footnotes. Please see [[#footnotes]] for details on how to mark up footnotes.
   </p>
 
-  The first <{summary}> element child of the element, if any,
-  <a>represents</a> the summary or legend of the details. If there is no
-  child <{summary}> element, the user agent should provide its own legend (e.g.,
-  in English "Details" or Spanish <span lang="es">"Detalles"</span>).
+  If the <{details}> element has a <{summary}> child element, then the first summary child element
+  <a>represents</a> the summary or legend of the details element. If there is no summary child
+  element, a user agent should provide its own legend (e.g. in English "Details"
+  or Spanish <span lang="es">"Detalles"</span>).
 
   <p class="note">The legend text should be presented in the language determined from the computed
   language of the element, if available, rather than from the locale of the browser/system.</p>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1255,10 +1255,10 @@
   The <code>h1</code>–<code>h6</code> elements are headings.
 
   The first element of <a>heading content</a> in an element of <a>sectioning content</a>
-  <a>represents</a> the heading for that (explicit) section. Subsequent headings of equal or higher
-  <a>rank</a> start new (implied) subsections that are part of the previous section's parent section.
-  Subsequent headings of lower <a>rank</a> start new (implied) subsections that are part of the previous
-  one. In both cases, the element <a>represents</a> the heading of the implied section.
+  <a>represents</a> the heading for that explicit section. Subsequent headings of equal or higher <a>rank</a>
+  start new implied subsections that are part of the previous section's parent section. Subsequent
+  headings of lower <a>rank</a> start new implied subsections that are part of the previous one.
+  In both cases, the element <a>represents</a> the heading of the implied section.
 
   <code>h1</code>–<code>h6</code> elements must not be used to markup subheadings, subtitles,
   alternative titles and taglines unless intended to be the heading for a new section or subsection.
@@ -1393,8 +1393,8 @@
       </pre>
 
       ...exemplifies how to recursively traverse the node tree and when to trigger the <i>enter</i>
-      and <i>exit</i> events. See <a href="#code-fragments">Code fragments</a> for a possible,
-      non-recursive JavaScript implementation.
+      and <i>exit</i> events. See the <a href="#javascript-tree-walk-example">JavaScript example</a>
+      for a possible, non-recursive JavaScript implementation.
     </div>
 
   The <dfn>outline</dfn> for a <a>sectioning content</a> element or a <a>sectioning root</a> element
@@ -1645,11 +1645,7 @@
       preferences, the user agent implementor's preferences, etc.
     </div>
 
-<h6 id="code-fragments">Code fragments</h6>
-
-  <em>This section is non-normative.</em>
-
-    <div class="note">
+    <div class="example" id="javascript-tree-walk-example">
       The following JavaScript function shows how the tree walk could be implemented. The
       <var>root</var> argument is the root of the tree to walk (either a <a>sectioning content</a>
       element or a <a>sectioning root</a> element), and the <var>enter</var> and <var>exit</var>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1255,10 +1255,10 @@
   The <code>h1</code>–<code>h6</code> elements are headings.
 
   The first element of <a>heading content</a> in an element of <a>sectioning content</a>
-  <a>represents</a> the heading for that explicit section. Subsequent headings of equal or higher <a>rank</a>
-  start new (implied) subsections that are part of the previous section's parent section. Subsequent
-  headings of lower <a>rank</a> start new implied subsections that are part of the previous one.
-  In both cases, the element <a>represents</a> the heading of the implied section.
+  <a>represents</a> the heading for that (explicit) section. Subsequent headings of equal or higher
+  <a>rank</a> start new (implied) subsections that are part of the previous section's parent section.
+  Subsequent headings of lower <a>rank</a> start new (implied) subsections that are part of the previous
+  one. In both cases, the element <a>represents</a> the heading of the implied section.
 
   <code>h1</code>–<code>h6</code> elements must not be used to markup subheadings, subtitles,
   alternative titles and taglines unless intended to be the heading for a new section or subsection.
@@ -1392,8 +1392,9 @@
           onExit(node)
       </pre>
 
-      ...exemplifies how to traverse the node tree and when to trigger the <i>entered</i> and
-      <i>exited</i> events.
+      ...exemplifies how to recursively traverse the node tree and when to trigger the <i>enter</i>
+      and <i>exit</i> events. See <a href="#code-fragments">Code fragments</a> for a possible,
+      non-recursive JavaScript implementation.
     </div>
 
   The <dfn>outline</dfn> for a <a>sectioning content</a> element or a <a>sectioning root</a> element
@@ -1458,10 +1459,8 @@
             Pop that element from the stack.
           </dd>
 
-          <dt>
-            If the top of the stack is a <a>heading content</a> element or an element with a
-            <{global/hidden}> attribute
-          </dt>
+          <dt>If the top of the stack is a <a>heading content</a> element or an element with a
+            <{global/hidden}> attribute</dt>
           <dd>Do nothing.</dd>
 
           <dt>When entering an element with a <{global/hidden}> attribute</dt>
@@ -1526,10 +1525,8 @@
                 that element.
           </dd>
 
-          <dt>
-            When exiting a <a>sectioning content</a> element or a <a>sectioning root</a> element
-            (when the stack is empty)
-          </dt>
+          <dt>When exiting a <a>sectioning content</a> element or a <a>sectioning root</a> element
+            (when the stack is empty)</dt>
           <dd>
             <p class="note">
               The <var>current outline owner</var> is the element being exited, and it is the
@@ -1647,6 +1644,10 @@
       this specification, and might vary with the user's language, the page's language, the user's
       preferences, the user agent implementor's preferences, etc.
     </div>
+
+<h6 id="code-fragments">Code fragments</h6>
+
+  <em>This section is non-normative.</em>
 
     <div class="note">
       The following JavaScript function shows how the tree walk could be implemented. The
@@ -1851,7 +1852,5 @@
 
   Comments on an article are not part of the <{article}> on which they are commenting, but are
   related, therefore may be contained in their own nested <{article}>.
-
-
 
 </section>


### PR DESCRIPTION

Feel free to further edit these changes.
My goal is merely to point out locations that could be improved:

2.4.2 [Boolean attributes](https://w3c.github.io/html/infrastructure.html#sec-boolean-attributes)

* file - infrastructure.include
* the example in that section contains the 'checked' and 'disabled' attributes
  with no value assigned to them; e.g. "checked" vs. "checked=...". this somewhat
  contradicts the 2nd paragraph, which (as is) implies that a boolean attribute,
  if present, always must appear with a value assigned to it.
* **changes** added a note to include the use without a value assignment.

4.3.9 Headings and sections / [tree order traversal](https://w3c.github.io/html/sections.html#creating-an-outline)

* file - semantics-sections.include
* refers to the changes merged in #915.
* first I introduce the "enter" and "exit" events,
  then I mention the "entered" and "exited" events.
* **changes** only mention "enter" and "exit", which should be less irritating.
* **changes** added reference to "4.3.9.2 Code fragments".

4.3.9.1 Creating an outline / [unneeded indentation](https://w3c.github.io/html/sections.html#creating-an-outline)

* file - semantics-sections.include
* the 2nd step of point 4 has an indent, which the others don't have.
* the same applies to step 8.
* **changes** removed the unneeded indentation

4.3.9.2 Code fragments (new sub-chapter)

* file - semantics-sections.include
* as an (important) additional content, the JavaScript code fragment on the tree
  traversal, looks a little lost behind the last example.
* **changes** moved the JavaScript code fragment into its own sub-chapter, which
  also allows to reference these fragments from inside "4.3.9 Headings and sections".

4.11.1 The [details element](https://w3c.github.io/html/interactive-elements.html#the-details-element)

* file - semantics-interactive-elements.include
* after the first note there is: The first summary element child of the element ...
* **changes** If the details element has a summary child element, then the first
  summary child element represents ... If it doesn't have such a summary child
  element, a user agent should ...

5.1 The [hidden attribute](https://w3c.github.io/html/editing.html#the-hidden-attribute)

* file - editing.include
* examples 2 and 3 in that file have different source formatting,
  but have, other than that, identical content.
* **changes** reformatted example 2 and removed example 3
