### PR TITLE
media elements attached to a media provider object do not delay the load event

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -6709,6 +6709,9 @@ zero or more <{track}> elements, then
       Otherwise, if the data stream is pre-decoded, then the format is the format given by the
       relevant specification.
 
+      Set the element’s [=delaying-the-load-event flag=] to false. This stops
+      [=delay the load event|delaying the load event=] when the resource is local.
+
       Whenever new data for the <var>current media resource</var> becomes available, <a>queue
       a task</a> to run the first appropriate steps from the <a>media data processing steps
       list</a> below.


### PR DESCRIPTION
Fix #428

This requires resource requests (for media) the end-up in the
resource fetch algorithm but are attached to a media provider
object or have a URL whose object is a media provider object
(e.g., URL.createObjectURL() from a media provider like a Blob)
to not delay the load event. These resources are treated as non
network providers and thus don't delay the load event.