### PR TITLE
Change link term

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -131,7 +131,7 @@
   type <{button}>, meaning they have the local name "<{button}>" and (implicitly as
   defined above) the <a>HTML namespace</a>.
 
-  Attribute names are said to be <dfn for="xml-compatible">XML-compatible</dfn> if they match the
+  Attribute names are said to be <dfn>XML-compatible</dfn> if they match the
   <code>[=xml/Name=]</code> production defined in XML and they contain no U+003A COLON
   characters (:). [[!XML]]
 


### PR DESCRIPTION
fix #919
this changes the id of the term definition, from xml-compatible-xml-compatible to xml-compatible.

As far as I can tell the spec doesn't refer to this concept. I am not sure if some other specification does, in which case we are probably better leaving old links working.

So I suggest not merging and marking #919 wontfix, but editors may think otherwise. In any event this is purely editorial in terms of conformance…