### PR TITLE
Returns class and id attributes to global attribs per #949

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -221,6 +221,7 @@
   "spixi", <!-- https://github.com/spixi-->
   "<a href="https://github.com/stasoid">stasoid</a>", 
   Stefan Judis,
+  Steve Comstock,
   Steve Faulkner,
   Steven Atkin,
   Steven Lambert,

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1473,7 +1473,7 @@
 
   <hr />
 
-  The DOM specification defines the user agent requirements for the
+  The DOM specification defines additional user agent requirements for the
   <dfn element-attr for="global"><code>class</code></dfn>,
   <dfn element-attr for="global"><code>id</code></dfn>, and
   <dfn element-attr for="global"><code>slot</code></dfn> attributes for any element in any

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1434,11 +1434,13 @@
 
   <ul class="brief">
     * <{global/accesskey}>
+    * <{global/class}>
     * <{global/contenteditable}>
     * <{global/contextmenu}>
     * <{global/dir}>
     * <{global/draggable}>
     * <{global/hidden}>
+    * <{global/id}>
     * <{global/lang}>
     * <{global/spellcheck}>
     * <{global/style}>


### PR DESCRIPTION
This was reported offline by Steve Comstock (the person added to the acknowledgements file).

I can't find out when/why these two attributes were removed. Making this a PR for review rather than a simple editorial update, just in case there was a reason for their removal in the first place.