### PR TITLE
minor editorial fixes: <main> and <article> elements

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1627,7 +1627,7 @@
   information, site logos and banners and search forms (unless the document or application's main
   function is that of a search form).
 
-  There must not be more than one visible <{main}> element in a document. If greater than one
+  There must not be more than one visible <{main}> element in a document. If more than one
   <{main}> element is present in a document, all other instances must be hidden using [[#the-hidden-attribute]].
 
   <div class="example">
@@ -1646,7 +1646,7 @@
 
 
   Authors must not include the <{main}> element as a descendant of an <{article}>,
-  <{aside}>, <{footer}>, <code>header</code> or <{nav}> element.
+  <{aside}>, <{footer}>, <{header}> or <{nav}> element.
 
   <p class="note">
     The <{main}> element is not suitable for use to identify the main <a>content areas</a> of sub

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -118,13 +118,13 @@
 
   <dl class="element">
     <dt><a>Categories</a>:</dt>
-    <dd><a>Flow content</a>, but with no <{main}> element descendants.</dd>
+    <dd><a>Flow content</a>.</dd>
     <dd><a>Sectioning content</a>.</dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a>.</dd>
+    <dd><a>Flow content</a>, but with no <{main}> element descendants.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>


### PR DESCRIPTION
## 1) [main element](https://w3c.github.io/html/grouping-content.html#the-main-element)

"""
There must not be more than one visible <{main}> element in a document. If **greater**
than one <{main}> element is present in a document, all other instances must be
hidden using [[#the-hidden-attribute]].
"""

I guess the 2nd sentence should better start with: "If **more** than one <{main}> element..."

## 2) [main element](https://w3c.github.io/html/grouping-content.html#the-main-element)

@prlbr mentioned in issue #960, which is related to the HTML 5.1 spec, that the header element isn't linked to its definition. It looks as if this also applies to the HTML 5.2 spec:

"""
Authors must not include the <{main}> element as a descendant of an
<{article}>, <{aside}>, <{footer}>, `<code>header</code>` or <{nav}> element.
"""

replaced: `<code>header</code>` by `<{header}>`

## 3) [article element](https://w3c.github.io/html/sections.html#the-article-element)

The "Categories" property of an element definition defines to which categories
an element belongs and the "Content model" property which content it may have.

For the article element the spec states:
- **Categories: Flow content, but with no `<main>` element descendants.**
- Content model: Flow content.

I believe it should state instead:
- Categories: Flow content.
- **Content model: Flow content, but with no `<main>` element descendants.**

Compare with these definitions: nav, aside, header, footer.

See also Fix No (2) - Authors must not include the main element as descendant
of an article ... element.
