### PR TITLE
make undomanager an Informative Reference

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -11,7 +11,7 @@
       <dd>Fixed <a href="https://github.com/w3c/html/issues/829">Issue 829</a></dd>
     <dt><a href="https://github.com/w3c/html/commit/8b477d2f1448bef9d04559e51083432ffa9937dc">Incorporate Referrer Policy</a>
      [[REFERRERPOLICY]]</dt>
-      <dd>Fixed <a href="https://github.com/w3c/html/issues/560">Issue 560</a> - the <code>referrerpolicy</attribute> can be used with elements that initiate network requests, such as <{a}>, <{img}>, or <{link}>.</dd>
+      <dd>Fixed <a href="https://github.com/w3c/html/issues/560">Issue 560</a> - the <code>referrerpolicy</code> can be used with elements that initiate network requests, such as <{a}>, <{img}>, or <{link}>.</dd>
     <dt><a href="https://github.com/w3c/html/commit/bd8316cb694d5e2c21eb3cebfa846c69497a52a9">Clarify that browsers should represent punycode addresses as natural text</a></dt>
       <dd>Fixed <a href="https://github.com/w3c/html/issues/538">Issue 538</a></dd>
     <dt><a href="https://github.com/w3c/html/commit/4556dc52c4ff8e74504a480b1da942a26807f556">Stop media resrouce requests from non-network sources delaying the <code>load</code> event</a></dt>

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -1904,7 +1904,7 @@
   <dfn method for="Document" lt="queryCommandValue()|queryCommandValue(commandId)"><code>queryCommandValue()</code></dfn>
   methods, text selections, and the <dfn>delete the selection</dfn> algorithm are defined in the
   HTML Editing APIs specification. The interaction of editing and the undo/redo features in user
-  agents is defined by the UndoManager and DOM Transaction specification. [[!EDITING]] [[!UNDO]]
+  agents is defined by the UndoManager and DOM Transaction specification. [[!EDITING]] [[UNDO]]
 
 <h4 id="spelling-and-grammar-checking">Spelling and grammar checking</h4>
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1032,7 +1032,7 @@
       <p class="note">
         User agents are also encouraged to implement the features described in the
         <cite>HTML Editing APIs</cite> and <cite><code>UndoManager</code> and DOM Transaction</cite>
-        specifications. [[!EDITING]] [[!UNDO]]
+        specifications. [[!EDITING]] [[UNDO]]
       </p>
 
       The following parts of the Fullscreen specification are referenced from this specification, in


### PR DESCRIPTION
* Make the [UndoManager and DOM Transaction spec](https://dvcs.w3.org/hg/undomanager/raw-file/tip/undomanager.html) an information reference since it's a weak reference;
* Fix a mark-up error in the changes section.