### PR TITLE
Add quotation marks in figure element

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1404,7 +1404,7 @@
   unit from the main flow of the document.
 
   <p class="note">
-    Self-contained in this context does not necessarily mean independent. For example, each sentence
+    "Self-contained" in this context does not necessarily mean independent. For example, each sentence
     in a paragraph is self-contained; an image that is part of a sentence would be inappropriate for
     <{figure}>, but an entire sentence made of images would be fitting.
   </p>


### PR DESCRIPTION
Add quotation marks in figure element to prevent ambiguity ([#965](https://github.com/w3c/html/issues/965))