### PR TITLE
Add quotation marks in figure element note

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -10,7 +10,7 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 <ul>
  <li>The <{input/inputmode}> attribute for <{input}> elements</li>
  <li>The <{menu}> and <{menubutton}> elements</li>
- <li>The <code>allow-presentation</code> sanboxing flag for the <{iframe/sandbox}> attribute of an <{iframe}></li>
+ <li>The <code>allow-presentation</code> sandboxing flag for the <{iframe/sandbox}> attribute of an <{iframe}></li>
  <li>The <{dialog}> element</li>
  <li>The <code>datetime</code> state for the <{input}> element</li>
  <li></li>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -2516,10 +2516,10 @@
     Authors are encouraged to make use of the following documents for guidance on using ARIA in HTML
     beyond that which is provided in this section:
 
-    * [=Notes on Using ARIA in HTML=] - A practical guide for developers on how to to add
+    * [=Using ARIA=] - A practical guide for developers on how to to add
         accessibility information to HTML elements using the Accessible Rich Internet Applications
         specification [[!wai-aria-1.1]].
-    * [=WAI-ARIA 1.1 Authoring Practices=] - An author's guide to understanding and implementing
+    * [=WAI-ARIA Authoring Practices 1.1=] - An author's guide to understanding and implementing
         Accessible Rich Internet Applications.
   </div>
 

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1404,7 +1404,7 @@
   unit from the main flow of the document.
 
   <p class="note">
-    Self-contained in this context does not necessarily mean independent. For example, each sentence
+    "Self-contained" in this context does not necessarily mean independent. For example, each sentence
     in a paragraph is self-contained; an image that is part of a sentence would be inappropriate for
     <{figure}>, but an entire sentence made of images would be fitting.
   </p>

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -1743,7 +1743,7 @@
 
     </dd>
 
-    <dt>Effect on... <code>link</code></dt>
+    <dt>Effect on... <{link}></dt>
 
     <dd>
 
@@ -1769,7 +1769,7 @@
 
     </dd>
 
-    <dt>Effect on... <{a}> and <code>area</code></dt>
+    <dt>Effect on... <{a}> and <{area}></dt>
 
     <dd>
 

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2502,12 +2502,11 @@ Linux demo 2.6.10-grsec+gg3+e+fhs6b+nfs+gr0501+++p3+c4a+gr2b-reslog-v6.189 #1 SM
     <dd>Use <code>HTMLElement</code>.</dd>
   </dl>
 
-  The <{sup}> element <a>represents</a> a superscript and the <code>sub</code>
-  element <a>represents</a> a subscript.
+  The <{sub}> element <a>represents</a> a subscript, and the <{sup}> element <a>represents</a> a superscript.
 
   These elements must be used only to mark up typographical conventions with specific meanings,
   not for typographical presentation for presentation's sake. For example, it would be inappropriate
-  for the <code>sub</code> and <{sup}> elements to be used in the name of the LaTeX
+  for the <{sub}> and <{sup}> elements to be used in the name of the LaTeX
   document preparation system. In general, authors should use these elements only if the
   <em>absence</em> of those elements would change the meaning of the content.
 
@@ -2538,8 +2537,8 @@ For example, the 10th point has coordinate
   </div>
 
   Mathematical expressions often use subscripts and superscripts. Authors are encouraged to use
-  MathML for marking up mathematics, but authors may opt to use <code>sub</code> and
-  <code>sup</code> if detailed mathematical markup is not desired. [[!MATHML]]
+  MathML for marking up mathematics, but authors may opt to use <{sub}> and
+  <{sup}> if detailed mathematical markup is not desired. [[!MATHML]]
 
   <div class="example">
     <pre highlight="html">

--- a/single-page.bs
+++ b/single-page.bs
@@ -1,17 +1,16 @@
 <pre class="metadata">
 Shortname: html
-Title: HTML 5.2
-Level: 5.2
+Title: HTML 5.3
+Level: 5.3
 Group: html
 Status: ED
 !Default Ref Status: snapshot
-TR: https://www.w3.org/TR/html52/
+TR: https://www.w3.org/TR/html53/
 ED: https://w3c.github.io/html/
 Repository: w3c/html
 Boilerplate: omit feedback-header
 !Participate: <a href="https://github.com/w3c/html/issues/new">File an issue</a> (<a href="https://github.com/w3c/html/issues">open issues</a>)
 !Others: <a href="single-page.html">Single page version</a>
-Previous Version: https://www.w3.org/TR/2016/WD-html51-20160503/
 
 Editor: Steve Faulkner, The Paciello Group, sfaulkner@paciellogroup.com
 Editor: Arron Eicholz, Microsoft, arronei@microsoft.com
@@ -22,7 +21,7 @@ Editor: Sangwhan Moon, Invited Expert, sangwhan@iki.fi
 Former Editor: Erika Doyle Navara, Microsoft, Erika.Doyle@microsoft.com
 Former Editor: Theresa O'Connor, Apple Inc., hober@apple.com
 Former Editor: Robin Berjon, W3C, http://berjon.com/
-Abstract: This specification defines the 5th major version, second minor revision of the core
+Abstract: This specification defines the 5th major version, third minor revision of the core
           language of the World Wide Web: the Hypertext Markup Language (HTML). In this version,
           new features continue to be introduced to help Web application authors, new elements
           continue to be introduced based on research into prevailing authoring practices, and

--- a/single-page.bs
+++ b/single-page.bs
@@ -128,7 +128,7 @@ url: https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLRENDERINGCONTEXT; ty
     text: WebGLRenderingContext
 url: https://www.w3.org/TR/jlreq/#positioning_of_jukugoruby; type: dfn; spec: jlreq;
     text: jukugo ruby rendering
-url: https://w3c.github.io/aria-in-html/#rec; type: dfn; spec: aria-in-html;
+url: https://w3c.github.io/using-aria/; type: dfn; spec: using-aria;
     text: Recommendations Table
 url: https://wiki.whatwg.org/wiki/PragmaExtensions#content; type: dfn;
     text: WHATWG Wiki PragmaExtensions page
@@ -291,10 +291,10 @@ urlPrefix: https://www.w3.org/TR/wai-aria-1.1/#; spec: aria;
         text: aria-valuenow
         text: aria-valuetext
 
-urlPrefix: https://w3c.github.io/aria-in-html/; type:dfn;
-    text: Notes on Using ARIA in HTML; url: #
-urlPrefix: https://w3c.github.io/aria/practices/aria-practices.html; type:dfn;
-    text: WAI-ARIA 1.1 Authoring Practices; url: #
+urlPrefix: https://w3c.github.io/using-aria/; type:dfn;
+    text: Using ARIA; url: #
+urlPrefix: http://w3c.github.io/aria-practices/; type:dfn;
+    text: WAI-ARIA Authoring Practices 1.1; url: #
 
 <!-- ************************ CONTENT SECURITY POLICY (CSP) ************************************ -->
 


### PR DESCRIPTION
Add quotation marks in figure element to prevent ambiguity ([#965](https://github.com/w3c/html/issues/965))