### PR TITLE
Added autocomplete to the list of select content attributes

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -7255,6 +7255,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
+    <dd><{select/autocomplete}> - Hint for form autofill feature</dd>
     <dd><{select/autofocus}> - Automatically focus the form control when the page is loaded</dd>
     <dd><{select/disabled}> - Whether the form control is disabled</dd>
     <dd><{select/form}> - Associates the control with a <{form}> element</dd>


### PR DESCRIPTION
This fixes [900](https://github.com/w3c/html/issues/900).
I added the same text as is used in the `textarea` definition.