### PR TITLE
Fixed a broken step reference in the "fire a DND event" algorithm.

### DIFF
--- a/sections/editing.include
+++ b/sections/editing.include
@@ -2969,6 +2969,8 @@
 
   <ol>
 
+    <li>Let <var>dataDragStoreWasChanged</var> be false.</li>
+
     <li>If no specific <var>related target</var> was provided, set <var>related target</var> to
     null.</li>
 
@@ -2976,13 +2978,10 @@
     object of the specified target element.</li>
 
     <li>
+    If <var>e</var> is <code>dragstart</code>, then set the <a>data store mode</a> to the
+    <a>read/write mode</a> and set <var>dataDragStoreWasChanged</var> to true.
 
-    If <var>e</var> is <code>dragstart</code>, set the <a>drag
-    data store mode</a> to the <a>read/write mode</a>.
-
-    If <var>e</var> is <code>drop</code>, set the <a>drag data store
-    mode</a> to the <a>read-only mode</a>.
-
+    If <var>e</var> is <code>drop</code>, set the <a>drag data store mode</a> to the <a>read-only mode</a>.
     </li>
 
     <li>Let <var>dataTransfer</var> be a newly created {{DataTransfer}} object
@@ -3090,7 +3089,8 @@
     <var>dataTransfer</var>'s {{DataTransfer/effectAllowed}}
     attribute. (It can only have changed value if <var>e</var> is <code>dragstart</code>.)</li>
 
-    <li>Set the <a>drag data store mode</a> back to the <a>protected mode</a> if it was changed in the first step.</li>
+    <li>If <var>dataDragStoreWasChanged</var> is true, then set the <a>drag data store mode</a> back to the
+    <a>protected mode</a>.</li>
 
     <li>Break the association between <var>dataTransfer</var> and the <a>drag data
     store</a>.</li>


### PR DESCRIPTION
This should fix [#999](https://github.com/w3c/html/issues/999)