### PR TITLE
remove <menu> and <menuitem>

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -111,7 +111,7 @@
     </tr>
     <tr>
       <th><code>checked</code></th>
-      <td><{menuitem}>; <{input}></td>
+      <td><{input}></td>
       <td>Whether the command or control is checked</td>
       <td><a>Boolean attribute</a></td>
     </tr>
@@ -150,12 +150,6 @@
       <td><a>HTML elements</a></td>
       <td>Whether the element is editable</td>
       <td>"<code>true</code>"; "<code>false</code>"</td>
-    </tr>
-    <tr>
-      <th><{global/contextmenu}></th>
-      <td><a>HTML elements</a></td>
-      <td>The element's context menu</td>
-      <td><a>ID</a>*</td>
     </tr>
     <tr>
       <th><code>controls</code></th>
@@ -206,12 +200,6 @@
     </tr>
     <tr>
       <th><code>default</code></th>
-      <td><{menuitem}></td>
-      <td>Mark the command as being a default command</td>
-      <td><a>Boolean attribute</a></td>
-    </tr>
-    <tr>
-      <th><code>default</code></th>
       <td><{track}></td>
       <td>Enable the track if no other <a>text track</a> is more suitable</td>
       <td><a>Boolean attribute</a></td>
@@ -242,7 +230,7 @@
     </tr>
     <tr>
       <th><code>disabled</code></th>
-      <td><{button}>; <{menuitem}>; <{fieldset}>; <{input}>; <{optgroup}>; <{option}>; <{select}>; <{textarea}></td>
+      <td><{button}>; <{fieldset}>; <{input}>; <{optgroup}>; <{option}>; <{select}>; <{textarea}></td>
       <td>Whether the form control is disabled</td>
       <td><a>Boolean attribute</a></td>
     </tr>
@@ -367,12 +355,6 @@
       <td><a>Text</a>*</td>
     </tr>
     <tr>
-      <th><code>icon</code></th>
-      <td><{menuitem}></td>
-      <td>Icon for the command</td>
-      <td><a>Valid non-empty URL potentially surrounded by spaces</a></td>
-    </tr>
-    <tr>
       <th><code>id</code></th>
       <td><a>HTML elements</a></td>
       <td>The element's <a>ID</a></td>
@@ -392,7 +374,7 @@
     </tr>
     <tr>
       <th><code>label</code></th>
-      <td><{menuitem}>; <{menu}>; <{optgroup}>; <{option}>; <{track}></td>
+      <td><{optgroup}>; <{option}>; <{track}></td>
       <td>User-visible label</td>
       <td><a>Text</a></td>
     </tr>
@@ -455,12 +437,6 @@
       <td><{link}>; <{style}></td>
       <td>Applicable media</td>
       <td><a>Valid media query list</a></td>
-    </tr>
-    <tr>
-      <th><code>menu</code></th>
-      <td><{button}></td>
-      <td>Specifies the element's <a>designated pop-up menu</a></td>
-      <td><a>ID</a>*</td>
     </tr>
     <tr>
       <th><{form/method}></th>
@@ -587,12 +563,6 @@
       <td><{audio}>; <{video}></td>
       <td>Hints how much buffering the <a>media resource</a> will likely need</td>
       <td>"<code>none</code>"; "<code>metadata</code>"; "<code>auto</code>"</td>
-    </tr>
-    <tr>
-      <th><code>radiogroup</code></th>
-      <td><{menuitem}></td>
-      <td>Name of group of commands to treat as a radio button group</td>
-      <td><a>Text</a></td>
     </tr>
     <tr>
       <th><code>readonly</code></th>
@@ -790,12 +760,6 @@
       <td><a>Text</a></td>
     </tr>
     <tr>
-      <th><{menuitem/title}></th>
-      <td><{menuitem}></td>
-      <td>Hint describing the command</td>
-      <td><a>Text</a></td>
-    </tr>
-    <tr>
       <th><{link/title}></th>
       <td><{link}></td>
       <td>Title of the link</td>
@@ -823,7 +787,7 @@
       <th><{button/type}></th>
       <td><{button}></td>
       <td>Type of button</td>
-      <td>"<a attr-value for="button/type"><code>submit</code></a>"; "<code>reset</code>"; "<code>button</code>"; "<code>menu</code>"</td>
+      <td>"<a attr-value for="button/type"><code>submit</code></a>"; "<code>reset</code>"; "<code>button</code>"</td>
     </tr>
     <tr>
       <th><code>type</code></th>
@@ -836,18 +800,6 @@
       <td><{input}></td>
       <td>Type of form control</td>
       <td><code>input</code> type keyword</td>
-    </tr>
-    <tr>
-      <th><code>type</code></th>
-      <td><{menu}></td>
-      <td>Type of menu</td>
-      <td>"<code>context</code>"; "<code>toolbar</code>"</td>
-    </tr>
-    <tr>
-      <th><code>type</code></th>
-      <td><{menuitem}></td>
-      <td>Type of command</td>
-      <td>"<code>command</code>"; "<code>checkbox</code>"; "<code>radio</code>"</td>
     </tr>
     <tr>
       <th><code>type</code></th>
@@ -1000,12 +952,6 @@
         <th><code>onclose</code></th>
         <td><a>HTML elements</a></td>
         <td><a event for="global"><code>close</code></a> event handler</td>
-        <td><a>Event handler content attribute</a></td>
-      </tr>
-      <tr>
-        <th><code>oncontextmenu</code></th>
-        <td><a>HTML elements</a></td>
-        <td><a event for="global"><code>contextmenu</code></a> event handler</td>
         <td><a>Event handler content attribute</a></td>
       </tr>
       <tr>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -5,7 +5,21 @@
 
   Full details of all changes since 12 January 2016 are available from the <a href="https://github.com/w3c/html/commits/master">commit log</a> of the <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various editorial and linking fixes.
 
-  <h3 id="changes-wd7">Changes between this Working Draft and <a href="https://www.w3.org/TR/2017/WD-html52-20170509/">Working Draft 7</a></h3>
+  <h3 id="changes-cr">Changes since the <a href="https://www.w3.org/TR/2017/CR-html52-20170808/">2017-08-08 Candidate Recommendation</a></h3>
+  <dl>
+    <dt><a href="https://github.com/w3c/html/pull/1043/commits/5f3c0445ed781e5fb8be7fabcb73e59a12d431a1">Remove <code>menu</code> and <code>menuitem</code>.</a></dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/893">Issue 893</a></dd>
+    <dt><a href="https://github.com/w3c/html/commit/d62035faedb4a818d0af86e7c73510aeebd8f505">Remove <code>inputmode</code>.</a></dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/1015">Issue 1015</a></dd>
+    <dt><a href="https://github.com/w3c/html/commit/0e9a32c57220647322235753f1b852ba1edd8663">Fixed a broken step reference in the "fire a DND event" algorithm.</a></dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/999">Issue 999</a></dd>
+    <dt><a href="https://github.com/w3c/html/commit/8b2ac5e7dfb4c913fb080529c85c2c92ae71e06e">Remove input datetime.</a></dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/893">Issue 893</a></dd>
+    <dt><a href="https://github.com/w3c/html/commit/ea93b2386e9e71327555d54b228db0a94bfc4933">Added allowpaymentrequest to the attribute index.</a></dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/967">Issue 967</a></dd>
+  </dl>
+
+  <h3 id="changes-wd7">Changes between <a href="https://www.w3.org/TR/2017/WD-html52-20170718/">Working Draft 8</a> and <a href="https://www.w3.org/TR/2017/WD-html52-20170509/">Working Draft 7</a></h3>
   <dl>
     <dt><a href="https://github.com/w3c/html/commit/cbc4af11f7dddf722f699a7ed2788ca5dae31228">Introduce <i>serialized state</i></a></dt>
       <dd>Fixed <a href="https://github.com/w3c/html/issues/829">Issue 829</a></dd>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -625,7 +625,6 @@
       void blur();
       [CEReactions] attribute DOMString accessKey;
       [CEReactions] attribute boolean draggable;
-      [CEReactions] attribute HTMLMenuElement? contextMenu;
       [CEReactions] attribute boolean spellcheck;
       void forceSpellCheck();
       [CEReactions, TreatNullAs=EmptyString] attribute DOMString innerText;
@@ -922,7 +921,6 @@
     <li><{map}>
     <li><{mark}>
     <li>MathML <{math}>
-    <li><{menu}>
     <li><{meter}>
     <li><{nav}>
     <li><{noscript}>
@@ -1436,7 +1434,6 @@
     * <{global/accesskey}>
     * <{global/class}>
     * <{global/contenteditable}>
-    * <{global/contextmenu}>
     * <{global/dir}>
     * <{global/draggable}>
     * <{global/hidden}>
@@ -1536,7 +1533,6 @@
     * {{GlobalEventHandlers/onchange}}
     * {{GlobalEventHandlers/onclick}}
     * {{GlobalEventHandlers/onclose}}
-    * {{GlobalEventHandlers/oncontextmenu}}
     * {{GlobalEventHandlers/oncuechange}}
     * {{GlobalEventHandlers/ondblclick}}
     * {{GlobalEventHandlers/ondrag}}
@@ -1676,7 +1672,7 @@
   returns, with the algorithm being aborted once a value is returned. When the algorithm returns
   the empty string, then there is no advisory information.
 
-  1. If the element is a <{link}>, <{style}>, <{dfn}>, <{abbr}>, or <{menuitem}> element, then: if
+  1. If the element is a <{link}>, <{style}>, <{dfn}>, or <{abbr}>, then: if
       the element has a <{global/title}> attribute, return the value of that attribute, otherwise,
       return the empty string.
   2. Otherwise, if the element has a <{global/title}> attribute, then return its value.
@@ -1846,8 +1842,7 @@
     * <{meta/content}> on <{meta}> elements, if the <{meta/name}> attribute specifies a metadata
         name whose value is known to be translatable
     * <{links/download}> on <{a}> and <{area}> elements
-    * <code>label</code> on <{menuitem/label|menuitem}>, <{menu/label|menu}>,
-        <{optgroup/label|optgroup}>, <{option/label|option}>, and <{track/label|track}> elements
+    * <code>label</code> on <{optgroup/label|optgroup}>, <{option/label|option}>, and <{track/label|track}> elements
     * <{global/lang}> on [=HTML elements=]; must be "translated" to match the language used in the
         translation
     * <code>placeholder</code> on <{input/placeholder|input}> and <{textarea/placeholder|textarea}>
@@ -2045,8 +2040,7 @@
     * <code>alt</code> on <{area/alt|area}>, <{img/alt|img}>, and <{input/alt|input}> elements
     * <{meta/content}> on <{meta}> elements, if the <{meta/name}> attribute specifies a metadata
         name whose value is primarily intended to be human-readable rather than machine-readable
-    * <code>label</code> on <{menuitem/label|menuitem}>, <{menu/label|menu}>,
-        <{optgroup/label|optgroup}>, <{option/label|option}>, and <{track/label|track}> elements
+    * <code>label</code> on <{optgroup/label|optgroup}>, <{option/label|option}>, and <{track/label|track}> elements
     * <code>placeholder</code> on <{input/placeholder|input}> and <{textarea/placeholder|textarea}>
         elements
     * <{global/title}> on all [=HTML elements=]
@@ -3056,19 +3050,6 @@
         </td>
       </tr>
       <tr>
-        <td><a attr-value for="aria/role"><code>menu</code></a></td>
-        <td>A type of widget that offers a list of choices to the user.</td>
-        <td>none</td>
-        <td>
-          <ul class="brief">
-            * <{aria/aria-expanded}> (state)
-            * <{aria/aria-activedescendant}>
-            * <{aria/aria-expanded}> (state)
-            * <{aria/aria-orientation}>
-          </ul>
-        </td>
-      </tr>
-      <tr>
         <td><a attr-value for="aria/role"><code>menubar</code></a></td>
         <td>
           A presentation of menu that usually remains visible and is usually presented horizontally.
@@ -3080,46 +3061,6 @@
             * <{aria/aria-activedescendant}>
             * <{aria/aria-expanded}> (state)
             * <{aria/aria-orientation}>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td><a attr-value for="aria/role"><code>menuitem</code></a></td>
-        <td>
-          An option in a group of choices contained by a
-          <a attr-value for="aria/role"><code>menu</code></a> or
-          <a attr-value for="aria/role"><code>menubar</code></a>.
-        </td>
-        <td>none</td>
-        <td>none</td>
-      </tr>
-      <tr>
-        <td><a attr-value for="aria/role"><code>menuitemcheckbox</code></a></td>
-        <td>A checkable menuitem that has three possible values: true, false, or mixed.</td>
-        <td>
-          <ul class="brief">
-            * <{aria/aria-checked}> (state)
-          </ul>
-        </td>
-        <td>none</td>
-      </tr>
-      <tr>
-        <td><a attr-value for="aria/role"><code>menuitemradio</code></a></td>
-        <td>
-          A checkable menuitem in a group of
-          <a attr-value for="aria/role"><code>menuitemradio</code></a> roles, only one of which can
-          be checked at a time.
-        </td>
-        <td>
-          <ul class="brief">
-            * <{aria/aria-checked}> (state)
-          </ul>
-        </td>
-        <td>
-          <ul class="brief">
-            * <{aria/aria-posinset}>
-            * <{aria/aria-selected}> (state)
-            * <{aria/aria-setsize}>
           </ul>
         </td>
       </tr>
@@ -3336,7 +3277,7 @@
       <tr>
         <td><a attr-value for="aria/role"><code>separator</code></a></td>
         <td>
-          A divider that separates and distinguishes sections of content or groups of menuitems.
+          A divider that separates and distinguishes sections of content.
         </td>
         <td>
           <ul class="brief">

--- a/sections/editing.include
+++ b/sections/editing.include
@@ -686,8 +686,6 @@
 
       <li><{textarea}> elements</li>
 
-      <li><{menuitem}> elements</li>
-
       <li>Elements with a <{global/draggable}> attribute set, if that would
       enable the user agent to allow the user to begin a drag operations for those elements without
       the use of a pointing device</li>
@@ -1744,8 +1742,8 @@
 
   When the user presses the key combination corresponding to the <a>assigned access key</a>
   for an element, if the element defines a command, the
-  command's <a facet for="menuitem">Hidden State</a> facet is false (visible),
-  the command's <a facet for="menuitem">Disabled State</a> facet is also false
+  command's <a for="facet">Hidden State</a> facet is false (visible),
+  the command's <a for="facet">Disabled State</a> facet is also false
   (enabled), the element is <a>in a <code>Document</code></a> that has an associated
   <a>browsing context</a>, and neither the element nor any of its ancestors has a
   <{global/hidden}> attribute specified, then the user agent must either <a>focus</a> the element,

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -79,7 +79,6 @@
       <{map}>;
       <{mark}>;
       <{math}>;
-      <{menu}>;
       <{meter}>;
       <{nav}>;
       <{noscript}>;

--- a/sections/element-interfaces.include
+++ b/sections/element-interfaces.include
@@ -94,10 +94,6 @@
      </td><td> {{HTMLTableColElement}} : {{HTMLElement}}
 
     </td></tr><tr>
-     <td> <{menuitem}>
-     </td><td> {{HTMLMenuItemElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
      <td> <{data}>
      </td><td> {{HTMLDataElement}} : {{HTMLElement}}
 
@@ -256,10 +252,6 @@
     </td></tr><tr>
      <td> <{mark}>
      </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{menu}>
-     </td><td> {{HTMLMenuElement}} : {{HTMLElement}}
 
     </td></tr><tr>
      <td> <{meta}>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -234,7 +234,6 @@
          <{button/formmethod}>;
          <{button/formnovalidate}>;
          <{button/formtarget}>;
-         <{button/menu}>;
          <{button/name}>;
          <{button/type}>;
          <{button/value}></td>
@@ -744,7 +743,6 @@
      <td>none</td>
      <td><{ol}>;
          <{ul}>;
-         <{menu}>*;
          <{template}></td>
      <td><a>flow</a></td>
      <td><a>globals</a>;
@@ -808,40 +806,6 @@
      <td><a>phrasing</a></td>
      <td><a>globals</a></td>
      <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{menu}></th>
-     <td>Menu of commands</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a>;
-         <{menu}>*</td>
-     <td><{li}>*;
-         <a>flow</a>*;
-         <{menuitem}>*;
-         <{hr}>*;
-         <{menu}>*;
-         <a>script-supporting elements</a>*</td>
-     <td><a>globals</a>;
-         <{menu/type}>;
-         <{menu/label}></td>
-     <td>{{HTMLMenuElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{menuitem}></th>
-     <td>Menu command</td>
-     <td>none</td>
-     <td><{menu}>;
-         <{template}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{menuitem/type}>;
-         <{menuitem/label}>;
-         <{menuitem/icon}>;
-         <{menuitem/disabled}>;
-         <{menuitem/default}></td>
-     <td>{{HTMLMenuItemElement}}</td>
     </tr>
 
     <tr>

--- a/sections/events.include
+++ b/sections/events.include
@@ -85,12 +85,6 @@
         <td><{dialog}> elements, <code>WebSocket</code></td>
         <td>Fired at <a><code>dialog</code></a> elements when they are closed, and at <code>WebSocket</code> elements when the connection is terminated</td>
       </tr>
-      <tr> <!-- contextmenu -->
-        <td><dfn event for="global"><code>contextmenu</code></dfn></td>
-        <td>{{Event}}</td>
-        <td>Elements</td>
-        <td>Fired at elements when the user requests their context menu</td>
-      </tr>
       <tr> <!-- copy -->
         <td><dfn event for="global"><code>copy</code></dfn></td>
         <td>{{Event}}</td>
@@ -234,12 +228,6 @@
         <td>{{Event}}</td>
         <td>Form controls</td>
         <td>Fired at form controls when their text selection is adjusted (whether by an API or by the user)</td>
-      </tr>
-      <tr> <!-- show -->
-        <td><dfn event for="global"><code>show</code></dfn></td>
-        <td>{{RelatedEvent}}</td>
-        <td><{menu}> elements</td>
-        <td>Fired at a <{menu}> element when it is shown as a context menu</td>
       </tr>
       <tr> <!-- storage -->
         <td><dfn event for="global"><code>storage</code></dfn></td>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1283,11 +1283,7 @@ INFRASTRUCTURE
         <li><a attr-value for="aria/role"><code>main</code></a>
         <li><a attr-value for="aria/role"><code>marquee</code></a>
         <li><a attr-value for="aria/role"><code>math</code></a>
-        <li><a attr-value for="aria/role"><code>menu</code></a>
         <li><a attr-value for="aria/role"><code>menubar</code></a>
-        <li><a attr-value for="aria/role"><code>menuitem</code></a>
-        <li><a attr-value for="aria/role"><code>menuitemcheckbox</code></a>
-        <li><a attr-value for="aria/role"><code>menuitemradio</code></a>
         <li><a attr-value for="aria/role"><code>navigation</code></a>
         <li><a attr-value for="aria/role"><code>none</code></a>
         <li><a attr-value for="aria/role"><code>note</code></a>

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -135,6 +135,8 @@
   : <dfn element><code>center</code></dfn>
   : <dfn element><code>font</code></dfn>
   : <{marquee}>
+  : <dfn element><code>menu</code></dfn>
+  : <dfn element><code>menuitem</code></dfn>
   : <dfn element><code>multicol</code></dfn>
   : <dfn element><code>nobr</code></dfn>
   : <dfn element><code>spacer</code></dfn>

--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -101,7 +101,7 @@ Rendering {#rendering}
   <pre highlight="css">
     @namespace url(http://www.w3.org/1999/xhtml);
 
-    [hidden], area, base, basefont, datalist, head, link, menu[type=context i], meta,
+    [hidden], area, base, basefont, datalist, head, link, meta,
     noembed, noframes, param, rp, script, source, style, template, track, title {
       display: none;
     }
@@ -501,7 +501,7 @@ Rendering {#rendering}
     address, blockquote, center, div, figure, figcaption, footer, form, header, hr,
     legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2,
     h3, h4, h5, h6, hgroup, nav, section, table, caption, colgroup, col, thead,
-    tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output,
+    tbody, tfoot, tr, td, th, dir, dd, dl, dt, ol, ul, li, bdi, output,
     [dir=ltr i], [dir=rtl i], [dir=auto i] {
       unicode-bidi: isolate;
     }
@@ -535,7 +535,7 @@ Rendering {#rendering}
     address, blockquote, center, div, figure, figcaption, footer, form, header, hr,
     legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2,
     h3, h4, h5, h6, hgroup, nav, section, table, caption, colgroup, col, thead,
-    tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, [dir=ltr i],
+    tbody, tfoot, tr, td, th, dir, dd, dl, dt, ol, ul, li, [dir=ltr i],
     [dir=rtl i], [dir=auto i], *|* {
       unicode-bidi: bidi-override;
     }
@@ -608,27 +608,27 @@ path: includes/cldr.include
   <pre highlight="css">
     @namespace url(http://www.w3.org/1999/xhtml);
 
-    dir, dd, dl, dt, menu, ol, ul { display: block; }
+    dir, dd, dl, dt, ol, ul { display: block; }
     li { display: list-item; }
 
-    dir, dl, menu, ol, ul { margin-block-start: 1em; margin-block-end: 1em; }
+    dir, dl, ol, ul { margin-block-start: 1em; margin-block-end: 1em; }
 
-    :matches(dir, dl, menu, ol, ul) :matches(dir, dl, menu, ol, ul) {
+    :matches(dir, dl, ol, ul) :matches(dir, dl, ol, ul) {
       margin-block-start: 0; margin-block-end: 0;
     }
 
     dd { margin-inline-start: 40px; }
-    dir, menu, ol, ul { padding-inline-start: 40px; }
+    dir, ol, ul { padding-inline-start: 40px; }
 
     ol { list-style-type: decimal; }
 
-    dir, menu, ul {
+    dir, ul {
       list-style-type: disc;
     }
-    :matches(dir, menu, ol, ul) :matches(dir, menu, ul) {
+    :matches(dir, ol, ul) :matches(dir, ul) {
       list-style-type: circle;
     }
-    :matches(dir, menu, ol, ul) :matches(dir, menu, ol, ul) :matches(dir, menu, ul) {
+    :matches(dir, ol, ul) :matches(dir, ol, ul) :matches(dir, ul) {
       list-style-type: square;
     }
   </pre>
@@ -999,7 +999,7 @@ path: includes/cldr.include
 
   The <dfn lt="elements with default margins|element with default margins">elements with default margins</dfn>
   are the following elements: <{blockquote}>, <{dir}>, <{dl}>, <{h1}>, <{h2}>, <{h3}>, <{h4}>,
-  <{h5}>, <{h6}>, <{listing}>, <{menu}>, <{ol}>, <{p}>, <{plaintext}>, <{pre}>, <{ul}>, <{xmp}>
+  <{h5}>, <{h6}>, <{listing}>, <{ol}>, <{p}>, <{plaintext}>, <{pre}>, <{ul}>, <{xmp}>
 
   In [=quirks mode=], any [=element with default margins=] that is the child of a <{body}>, <{td}>,
   or <{th}> element and has no [=substantial=] previous siblings is expected to have a user-agent
@@ -1268,9 +1268,7 @@ path: includes/cldr.include
   be easily clickable. In a visual environment, for instance, icons could be 16 pixels by 16 pixels
   square, or 1em by 1em if the images are scalable. In an audio environment, the icon could be a
   short bleep. The icons are intended to indicate to the user that they can be used to get to
-  whatever options the user agent provides for images, and, where appropriate, are expected to
-  provide access to the context menu that would have come up if the user interacted with the actual
-  image.
+  whatever options the user agent provides for images.
 
   ---
 
@@ -1408,10 +1406,6 @@ path: includes/cldr.include
 
   The <{button}> element is expected to render as an ''inline-block'' box rendered as a button whose
   contents are the contents of the element.
-
-  When the <{button}> element's <{button/type}> attribute is in the <{button/Menu}> state, the user
-  agent is expected to indicate that activating the element will display a menu, e.g., by displaying
-  a down-pointing triangle after the button's label.
 
 ### The <{details}>  and <{summary}> elements ### {#the-details-element-rendering}
 
@@ -1751,7 +1745,7 @@ path: includes/cldr.include
   fashion that indicates that no valid option is currently selected.
 
   User agents are expected to render the labels in a <{select}> in such a manner that any alignment
-  remains consistent whether the label is being displayed as part of the page or in a menu control.
+  remains consistent whether the label is being displayed as part of the page.
 
 ### The <{textarea}> element ### {#the-textarea-element-rendering}
 
@@ -2005,7 +1999,7 @@ path: includes/cldr.include
 
   User agents are expected to honor the Unicode semantics of text that is exposed in user
   interfaces, for example supporting the bidirectional algorithm in text shown in dialogs, title
-  bars, pop-up menus, and tooltips. Text from the contents of elements is expected to be rendered in
+  bars, and tooltips. Text from the contents of elements is expected to be rendered in
   a manner that honors [=the directionality=] of the element from which the text was obtained. Text
   from attributes is expected to be rendered in a manner that honours the
   [=directionality of the attribute=].

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -10611,7 +10611,7 @@ red:89
   Even when the attribute is absent, however, user agents may provide controls to affect playback
   of the media resource (e.g., play, pause, seeking, track selection, and volume controls), but
   such features should not interfere with the page's normal rendering. For example, such features
-  could be exposed in the <a>media element</a>'s context menu, platform media keys, or a remote
+  could be exposed in the <a>media element</a>'s platform media keys, or a remote
   control. The user agent may implement this simply by <a>exposing a user interface to the user</a>
   as described above (as if the <{mediaelements/controls}> attribute was present).
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -4556,7 +4556,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
     <dl>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a attr-value for="aria/role"><code>checkbox</code></a>
-    (default - <a><em>do not set</em></a>), <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+    (default - <a><em>do not set</em></a>),
     <a attr-value for="aria/role"><code>option</code></a> or <a attr-value for="aria/role"><code>switch</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -4666,7 +4666,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
     <dl>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a attr-value for="aria/role"><code>radio</code></a>
-    (default - <a><em>do not set</em></a>) or <a attr-value for="aria/role"><code>menuitemradio</code></a>.</dd>
+    (default - <a><em>do not set</em></a>).</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -5150,10 +5150,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a attr-value for="aria/role"><code>button</code></a>
     (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>link</code></a>,
-      <a attr-value for="aria/role"><code>menuitem</code></a>,
-    <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
-      <a attr-value for="aria/role"><code>menuitemradio</code></a>
+    <a attr-value for="aria/role"><code>link</code></a>, 
     or <a attr-value for="aria/role"><code>radio</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -5496,9 +5493,6 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
     <dd><a attr-value for="aria/role"><code>button</code></a>
     (default - <a><em>do not set</em></a>),
     <a attr-value for="aria/role"><code>link</code></a>,
-    <a attr-value for="aria/role"><code>menuitem</code></a>,
-    <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
-    <a attr-value for="aria/role"><code>menuitemradio</code></a>,
     <a attr-value for="aria/role"><code>radio</code></a> or
     <a attr-value for="aria/role"><code>switch</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
@@ -6736,7 +6730,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{button/formmethod}> - HTTP method to use for [[#forms-form-submission]]</dd>
     <dd><{button/formnovalidate}> - Bypass form control validation for [[#forms-form-submission]]</dd>
     <dd><{button/formtarget}> - <a>browsing context</a> for [[#forms-form-submission]]</dd>
-    <dd><{button/menu}> - Specifies the element's <a>designated pop-up menu</a></dd>
     <dd><{button/name}> - Name of form control to use for [[#forms-form-submission]] and in the {{HTMLFormElement/elements|form.elements}} API </dd>
     <dd><{button/type}> - Type of button</dd>
     <dd><{button/value}> - Value to be used for [[#forms-form-submission]]</dd>
@@ -6744,9 +6737,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><a attr-value for="aria/role"><code>button</code></a>
     (default - <a><em>do not set</em></a>),
     <a attr-value for="aria/role"><code>link</code></a>,
-    <a attr-value for="aria/role"><code>menuitem</code></a>,
-    <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
-    <a attr-value for="aria/role"><code>menuitemradio</code></a>,
     <a attr-value for="aria/role"><code>radio</code></a> or
     <a attr-value for="aria/role"><code>switch</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
@@ -6768,7 +6758,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
           attribute DOMString name;
           attribute DOMString type;
           attribute DOMString value;
-          attribute HTMLMenuElement? menu;
 
           readonly attribute boolean willValidate;
           readonly attribute ValidityState validity;
@@ -6812,11 +6801,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
       <td><dfn attr-value for="button/type"><code>button</code></dfn>
       </td><td><dfn element-state for="button/type">Button</dfn>
       </td><td>Does nothing.
-    </td></tr><tr>
-      <td><dfn attr-value for="button/type"><code>menu</code></dfn>
-      </td><td><dfn element-state for="button/type" lt="Menu|menu button">Menu</dfn>
-      </td><td>Shows a menu.
-  </td></tr></tbody></table>
+    </td></tr></tbody></table>
 
   The <i>missing value default</i> is the <a element-state for="button/type">submit button</a> state.
 
@@ -6824,8 +6809,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <a element-state for="button/type">submit button</a>.
 
   <strong>Constraint validation</strong>: If the <{input/type}>
-  attribute is in the <a element-state for="button/type">reset button</a> state, the
-  <a element-state for="button/type">Button</a> state, or the <a element-state for="button/type">Menu</a> state, the element is barred from constrain validation.
+  attribute is in the <a element-state for="button/type">reset button</a> state, or the
+  <a element-state for="button/type">Button</a> state, the element is barred from constrain validation.
 
   When a <{button}> element is not disabled,
   its <a>activation behavior</a> element is to run the steps defined in the following list for
@@ -6848,35 +6833,6 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt> <a element-state for="button/type">Button</a>
 
     </dt><dd>Do nothing.</dd>
-
-    <dt> <a element-state for="button/type">Menu</a>
-
-    </dt><dd>
-
-    The element must follow these steps:
-
-    <ol>
-
-      <li>If the <{button}> is not <a>being rendered</a>, abort these
-      steps.</li>
-
-      <li>If the <{button}> element's <a>node document</a> is not <a>fully
-      active</a>, abort these steps.</li>
-
-      <li>Let <var>menu</var> be the element's <a>designated pop-up menu</a>, if
-      any. If there isn't one, then abort these steps.</li>
-
-      <li><a>Fire</a> a <a>trusted</a> event with the name <code>show</code> at <var>menu</var>, using the <code>RelatedEvent</code>
-      interface, with the <code>relatedTarget</code> attribute
-      initialized to the <{button}> element. The event must be cancelable. </li>
-
-      <li>If the event is not canceled, then <a>build and
-      show</a> the menu for <var>menu</var>, with the <{button}> element as the
-      subject.</li>
-
-    </ol>
-
-    </dd>
 
   </dl>
 
@@ -6904,22 +6860,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   <hr />
 
-  If the element's <{input/type}> attribute is in the <a element-state for="button/type">Menu</a> state, the <dfn element-attr for="button"><code>menu</code></dfn> attribute must be specified to give the element's
-  menu. The value must be the <a>ID</a> of a <{menu}> element in
-  the same <a>tree</a> whose <{input/type}> attribute is in
-  the <a state for="menu">context menu</a> state. The attribute must not be specified if
-  the element's <{input/type}> attribute is not in the <a element-state for="button/type">Menu</a> state.
-
-  A <{button}> element's <dfn>designated pop-up menu</dfn> is the first element in the
-  <{button}>'s <a>tree</a> whose ID is that given by the <{button}>
-  element's <code>menu</code> attribute, if there is such an element and
-  its <{input/type}> attribute is in the <a state for="menu">context menu</a> state; otherwise, the element has no <a>designated pop-up
-  menu</a>.
-
-  <hr />
-
-  The <dfn attribute for="HTMLButtonElement"><code>value</code></dfn> and
-  <dfn attribute for="HTMLButtonElement"><code>menu</code></dfn> IDL attributes must <a>reflect</a>
+  The <dfn attribute for="HTMLButtonElement"><code>value</code></dfn> IDL attributes must <a>reflect</a>
   the content attributes of the same name.
 
   The <dfn attribute for="HTMLButtonElement"><code>type</code></dfn> IDL attribute must
@@ -6977,9 +6918,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{select/required}> - Whether the control is required for [[#forms-form-submission]]</dd>
     <dd><{select/size}> - Size of the control</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>(with NO <code>multiple</code> attribute and NO <code>size</code> attribute having value greater than <code>1</code>) <a attr-value for="aria/role"><code>combobox</code> or (with a multiple attribute or a size attribute having value greater than 1)  <a attr-value for="aria/role"><code>listbox</code></a>
-    (default - <a><em>do not set</em></a>) or
-    (with NO <code>multiple</code> attribute and NO <code>size</code> attribute having value greater than <code>1</code>) <a attr-value for="aria/role"><code>menu</code></a> otherwise None.</dd>
+    <dd>(with NO <code>multiple</code> attribute and NO <code>size</code> attribute having value greater than <code>1</code>) <a attr-value for="aria/role"><code>combobox</code> or (with a multiple attribute or a size attribute having value greater than 1)  <a attr-value for="aria/role"><code>listbox</code></a> otherwise None.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -7084,7 +7023,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   user to pick an <{option}> element in its <a>list
   of options</a> that is itself not disabled. Upon
   this <{option}> element being <dfn>picked</dfn> (either
-  through a click, or through unfocusing the element after changing its value, or through a <a>menu command</a>, or through any other mechanism), and before the
+  through a click, or through unfocusing the element after changing its value, or through any other mechanism), and before the
   relevant user interaction event  is queued (e.g., before the
   <code>click</code> event), the user agent must set the <a state for="option">selectedness</a> of the picked <{option}> element
   to true, set its <a state for="option">dirtiness</a> to true, and then
@@ -7133,7 +7072,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   element is not disabled, then the user agent should
   allow the user to <dfn>toggle</dfn> the <a state for="option">selectedness</a> of the <{option}> elements in
   its <a>list of options</a> that are themselves not disabled. Upon such an element being <a>toggled</a>
-  (either through a click, or through a <a>menu command</a>, or any other mechanism), and before the
+  (either through a click, or any other mechanism), and before the
   relevant user interaction event  is queued (e.g., before a related <code>click</code> event),
   the <a state for="option">selectedness</a> of the <{option}> element must
   be changed (from true to false or false to true), the <a state for="option">dirtiness</a>
@@ -7663,10 +7602,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{option/value}> - Value to be used for [[#forms-form-submission]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a attr-value for="aria/role"><code>option</code></a>
-    (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>menuitem</code></a>,
-    <a attr-value for="aria/role"><code>menuitemradio</code></a>
-    or <a attr-value for="aria/role"><code>separator</code></a>.</dd>
+    (default - <a><em>do not set</em></a>) or <a attr-value for="aria/role"><code>separator</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -8897,9 +8833,9 @@ and a height of &lt;meter value=2&gt;2cm&lt;/meter&gt;.&lt;/p&gt; &lt;!-- BAD! -
     The following markup:
     <pre highlight="html">
 &lt;h3&gt;Suggested groups&lt;/h3&gt;
-&lt;menu type="toolbar"&gt;
+&lt;span type="toolbar"&gt;
   &lt;a href="?cmd=hsg" onclick="hideSuggestedGroups()"&gt;Hide suggested groups&lt;/a&gt;
-&lt;/menu&gt;
+&lt;/span&gt;
 &lt;ul&gt;
   &lt;li&gt;
   &lt;p&gt;&lt;a href="/group/comp.infosystems.www.authoring.stylesheets/view"&gt;comp.infosystems.www.authoring.stylesheets&lt;/a&gt; -

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -17,7 +17,7 @@
       A <{p}> element's <a>end tag</a> may be omitted if the <{p}> element is
       immediately followed by an <{address}>, <{article}>, <{aside}>, <{blockquote}>, <{details}>,
       <{div}>, <{dl}>, <{fieldset}>, <{figcaption}>, <{figure}>, <{footer}>, <{form}>, <{h1}>,
-      <{h2}>, <{h3}>, <{h4}>, <{h5}>, <{h6}>, <{header}>, <{hr}>, <{main}>, <{menu}>, <{nav}>,
+      <{h2}>, <{h3}>, <{h4}>, <{h5}>, <{h6}>, <{header}>, <{hr}>, <{main}>, <{nav}>,
       <{ol}>, <{p}>, <{pre}>, <{section}>, <{table}>, or <{ul}>, element, or if
       there is no more content in the parent element and the parent element is an
       <a>HTML element</a> that is not an <{a}>, <{audio}>, <{del}>, <{ins}>, <{map}>, <{noscript}>,
@@ -787,8 +787,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>,
-      <a attr-value for="aria/role"><code>menu</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>,
       <a attr-value for="aria/role"><code>radiogroup</code></a>, <a attr-value for="aria/role"><code>tablist</code></a>, <a attr-value for="aria/role"><code>toolbar</code></a> or
       <a attr-value for="aria/role"><code>tree</code></a>.
     </dd>
@@ -994,9 +993,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>,
-      <a attr-value for="aria/role"><code>menu</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>,
-      <a attr-value for="aria/role"><code>radiogroup</code></a>, <a attr-value for="aria/role"><code>tablist</code></a>, <a attr-value for="aria/role"><code>toolbar</code></a> or
+      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>radiogroup</code></a>, <a attr-value for="aria/role"><code>tablist</code></a>, <a attr-value for="aria/role"><code>toolbar</code></a> or
       <a attr-value for="aria/role"><code>tree</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -1064,12 +1061,10 @@
     </dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd>If the element is not a child of an <{ul}> or <{menu}> element: <code>value</code></dd>
+    <dd>If the element is not a child of an <{ul}>: <code>value</code></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>menuitem</code></a>, <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
-      <a attr-value for="aria/role"><code>menuitemradio</code></a>, <a attr-value for="aria/role"><code>option</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>radio</code></a>,
+      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>), <a attr-value for="aria/role"><code>option</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>radio</code></a>,
       <a attr-value for="aria/role"><code>separator</code></a>, <a attr-value for="aria/role"><code>tab</code></a> or  <a attr-value for="aria/role"><code>treeitem</code></a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
@@ -1086,7 +1081,7 @@
   </dl>
 
   The <{li}> element <a>represents</a> a list item. If its parent element is an
-  <{ol}>, <{ul}>, or <{menu}> element, then the element is an item of the
+  <{ol}>, or <{ul}>, then the element is an item of the
   parent element's list, as defined for those elements. Otherwise, the list item has no defined
   list-related relationship to any other <{li}> element.
 

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -205,504 +205,26 @@
   </li>
   </ol>
 
-<h4 id="the-menu-element">The <dfn element><code>menu</code></dfn> element</h4>
-
-  <dl class="element">
-    <dt><a>Categories</a>:</dt>
-    <dd><a>Flow content</a>.</dd>
-    <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>Where <a>flow content</a> is expected.</dd>
-    <dd>As the child of a <{menu}> element whose <code>type</code> attribute is in the <a state for="menu">context menu</a> state.</dd>
-    <dt><a>Content model</a>:</dt>
-    <dd>If the element's <code>type</code> attribute is in the <a state for="menu">context menu</a> state: in any order, zero or more <{menuitem}> elements, zero or more <{hr}> elements, zero or more <{menu}> elements whose <code>type</code> attributes are in the <a state for="menu">context menu</a> state, and zero or more <a>script-supporting elements</a>.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>type</code> - Type of menu</dd>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>menu</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.</dd>
-    <dt><a>DOM interface</a>:</dt>
-    <dd>
-      <pre class="idl" data-highlight="webidl">
-        interface HTMLMenuElement : HTMLElement {
-          attribute DOMString type;
-          attribute DOMString label;
-        };
-      </pre>
-    </dd>
-  </dl>
-
-  The <{menu}> element represents a group of commands.
-
-  The <dfn element-attr for="menu"><code>type</code></dfn> attribute is an <a>enumerated
-  attribute</a> indicating the kind of menu being declared. The attribute has one state. The
-  "<dfn attr-value for="menu/type"><code>context</code></dfn>" keyword maps to the
-  <dfn state for="menu">context menu</dfn> state, in which the element is declaring a context menu.
-  The <i>missing value default</i> is the <code>null</code>.
-
-  If a <{menu}> element's <code>type</code> attribute is in the
-  <a state for="menu">context menu</a> state, then the element <a>represents</a>
-  commands for a context menu. The user can only examine and interact with the commands if that
-  context menu is activated.
-
-  The <dfn element-attr for="menu"><code>label</code></dfn> attribute gives the label of the
-  menu, to display nested menus in the UI: a context menu containing
-  another menu would use the nested menu's <code>label</code> attribute for
-  the submenu's menu label. The <code>label</code> attribute must only be
-  specified on <{menu}> elements whose parent element is a <{menu}> element.
-
-
-  <hr />
-
-  A <code>menu</code> is a <dfn>currently relevant <{menu}> element</dfn> if it is the
-  child of a <span>currently relevant <{menu}> element</span>, or if it is the
-  <a>designated pop-up menu</a> of a <{button}> element that is not
-  <a>inert</a>, does not have a <{global/hidden}> attribute, and is not
-  the descendant of an element with a <{global/hidden}> attribute.
-
-  <hr />
-
-  A <dfn>menu construct</dfn> consists of an ordered list of zero or more <dfn>menu item constructs</dfn>, which can be any of:
-
-  <ul class="brief">
-    <li><a>Commands</a>, which can be marked as <dfn>default commands</dfn> (<code>menuitem</code>)</li>
-    <li><dfn>Separators</dfn> (<code>hr</code>)</li>
-    <li>Other <a>menu constructs</a>, each with an associated <dfn>submenu label</dfn>, which allows the list to be nested (<code>menu</code>)</li>
-  </ul>
-
-  To <dfn lt="build and show|build and show a menu">build and show a menu</dfn> for a particular <{menu}> element
-  <var>source</var> and with a particular element <var>subject</var> as a subject, the user agent
-  must run the following steps:
-
-  <ol>
-
-    <li>Let <var>pop-up menu</var> be the <a>menu construct</a> created by the <a>build a
-    menu construct</a> algorithm when passed the <var>source</var> element.
-
-    </li><li>
-
-    Display <var>pop-up menu</var> to the user, and let the algorithm that invoked this one continue.
-
-    If the user selects a <a>menu item construct</a> that corresponds to an element
-    that still represents a <a>command</a> when the user selects it, then the user agent must invoke that
-    command's <a>Action</a>. If the command's <a>Action</a> is defined as <a>firing
-    a <code>click</code> event</a>, either directly or via the <a>run
-    synthetic click activation steps</a> algorithm, then the <code>relatedTarget</code> attribute
-    of that <code>click</code> event must be initialized to <var>subject</var>.
-
-    Pop-up menus must not, while being shown, reflect changes in the DOM. The menu is constructed
-    from the DOM before being shown, and is then immutable.
-
-    </li>
-
-  </ol>
-
-  To <dfn>build a menu construct</dfn> for an element <var>source</var>, the user agent must run
-  the following steps, which return a <a>menu construct</a>:
-
-  <ol>
-
-    <li>Let <var>generated menu</var> be an empty <a>menu construct</a>.</li>
-
-    <li>
-
-    Run the <a>menu item generator</a> steps for the <{menu}> element using <var>generated menu</var>
-    as the output.
-
-    The <dfn>menu item generator</dfn> steps for a <{menu}> element using a specific <a>menu construct</a> <var>output</var> as
-    output are as follows: For each child node of the <code>menu</code> in <a>tree order</a>,
-    run the appropriate steps from the following list:
-
-    <dl class="switch">
-
-      <dt>If the child is a <{menuitem}> element that <a for="menuitem">defines a command</a></dt>
-
-      <dd>Append the <a>command</a> to <var>output</var>, respecting the command's <a>facets</a>. If the <{menuitem}> element has a <code>default</code> attribute, mark the <a>command</a> as being a <a>default
-      command</a>.</dd>
-
-      <dt>If the child is an <{hr}> element</dt>
-
-      <dd>Append a <a>separator</a> to <var>output</var>.</dd>
-
-      <dt>If the child is a <{menu}> element with no <code>label</code> attribute</dt>
-
-      <dd>Append a <a>separator</a> to <var>output</var>, then run
-      the <a>menu item generator</a> steps for this child <{menu}> element, using
-      <var>output</var> as the output, then append another <a>separator</a> to <var>output</var>.</dd>
-
-      <dt>If the child is a <{menu}> element with a <code>label</code> attribute</dt>
-
-      <dd>Let <var>submenu</var> be the result of running the <a>build a menu construct</a> steps for the child <{menu}> element. Then, append <var>submenu</var> to <var>output</var>, using the value of the child
-      <{menu}> element's <code>label</code> attribute as the <a>submenu label</a>.</dd>
-
-      <dt>Otherwise</dt>
-
-      <dd><a>Ignore</a> the child node.</dd>
-
-    </dl>
-
-    </li>
-
-    <li>Remove from <var>output</var> any <a>menu construct</a> whose <a>submenu
-    label</a> is the empty string.</li>
-
-    <li>Remove from <var>output</var> any <a>menu item construct</a> representing a <a>command</a> whose <a>Label</a> is
-    the empty string.</li>
-
-    <li>Collapse all sequences of two or more adjacent <a>separators</a> in <var>output</var>
-    to a single <a>separator</a>.</li>
-
-    <li>If the first <a>menu item construct</a> in <var>output</var> is a <a>separator</a>, then remove it.</li>
-
-    <li>If the last <a>menu item construct</a> in <var>output</var> is a <a>separator</a>, then remove it.</li>
-
-    <li>Return <var>output</var>.</li>
-
-  </ol>
-
-  <hr />
-
-  The <dfn attribute for="HTMLMenuElement"><code>type</code></dfn> IDL attribute must <a>reflect</a>
-  the content attribute of the same name, <a>limited to only known values</a>.
-
-  The <dfn attribute for="HTMLMenuElement"><code>label</code></dfn> IDL attribute must
-  <a>reflect</a> the content attribute of the same name.
-
-
-
-<h4 id="the-menuitem-element">The <dfn element><code>menuitem</code></dfn> element</h4>
-
-  <dl class="element">
-    <dt><a>Categories</a>:</dt>
-    <dd>None.</dd>
-    <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>As a child of a <{menu}> element whose <code>type</code> attribute is in the <a state for="menu">context menu</a> state.</dd>
-    <dt><a>Content model</a>:</dt>
-    <dd><a>Text content</a>.</dd>
-    <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
-    <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>type</code> - Type of command</dd>
-    <dd><code>label</code> - User-visible label</dd>
-    <dd><code>icon</code> - Icon for the command</dd>
-    <dd><code>disabled</code> Whether the command or control is disabled</dd>
-    <dd><code>default</code> - Mark the command as being a default command</dd>
-    <dd>Also, the <{menuitem/title}> attribute has special semantics on this element.</dd>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>menuitem</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.</dd>
-    <dt><a>DOM interface</a>:</dt>
-    <dd>
-      <pre class="idl" data-highlight="webidl">
-        interface HTMLMenuItemElement : HTMLElement {
-          attribute DOMString type;
-          attribute DOMString label;
-          attribute DOMString icon;
-          attribute boolean disabled;
-          attribute boolean default;
-        };
-      </pre>
-    </dd>
-  </dl>
-
-  The <{menuitem}> element represents a command that the user can invoke from a popup
-  menu (either a <a>context menu</a> or the menu of a <a element-state for="button/type">menu button</a>).
-
-  A <{menuitem}> element with a <code>label</code> attribute, or with
-  <a>text content</a> defines a new command.
-
-  <hr />
-
-  The <dfn element-attr for="menuitem"><code>type</code></dfn> attribute is an
-  <a>enumerated attribute</a> with one keyword and state. The
-  "<dfn attr-value for="menuitem/type"><code>command</code></dfn>" keyword maps to the
-  <a state for="menuitem">Command</a> state.
-  The <i>missing value default</i> is the <a state for="menuitem">Command</a> state.
-
-  <dl>
-
-    <dt>The <dfn state for="menuitem">Command</dfn> state</dt>
-
-    <dd>The element <a>represents</a> a normal command with an associated action.</dd>
-
-  </dl>
-
-  The <dfn element-attr for="menuitem"><code>label</code></dfn> attribute can be used to give
-  the name of the command, as shown to the user. If the attribute is
-  specified, it must have a value that is not the empty string.
-
-  If the <{menuitem/label}> attribute is not present, and there is text content in the element,
-  that provides the name of the content as shown to the user.
-
-  The <dfn element-attr for="menuitem"><code>icon</code></dfn> attribute gives a picture that
-  represents the command. If the attribute is specified, the attribute's value must contain a
-  <a>valid non-empty URL potentially surrounded by spaces</a>. To obtain the <a>absolute URL</a> of
-  the icon when the attribute's value is not the empty string, the attribute's value must be
-  <a>parsed</a> relative to the element's <a>node document</a>. When the attribute is absent, or its
-  value is the empty string, or <a>parsing</a> its value fails, there is no icon.
-
-  The <dfn element-attr for="menuitem"><code>disabled</code></dfn> attribute is a
-  <a>boolean attribute</a> that, if present, indicates that the command is not available in
-  the current state.
-
-  <p class="note">
-    The distinction between <code>disabled</code> and
-  <{global/hidden}> is subtle. A command would be disabled if, in the same
-  context, it could be enabled if only certain aspects of the situation were changed. A command
-  would be marked as hidden if, in that situation, the command will never be enabled. For example,
-  in the context menu for a water faucet, the command "open" might be disabled if the faucet is
-  already open, but the command "eat" would be marked hidden since the faucet could never be
-  eaten.
-  </p>
-
-  <hr />
-
-  The <dfn element-attr for="menuitem"><code>title</code></dfn> attribute gives a hint describing
-  the command, which might be shown to the user to help him.
-
-  The <dfn element-attr for="menuitem"><code>default</code></dfn> attribute indicates, if
-  present, that the command is the one that would have been invoked if the user had directly
-  activated the menu's subject instead of using the menu. The <code>default</code> attribute is a <a>boolean attribute</a>.
-
-  <hr />
-
-  The <dfn attribute for="HTMLMenuItemElement"><code>type</code></dfn> IDL attribute must
-  <a>reflect</a> the content attribute of the same name, <a>limited to only known
-  values</a>.
-
-  The <dfn attribute for="HTMLMenuItemElement"><code>label</code></dfn>,
-  <dfn attribute for="HTMLMenuItemElement"><code>icon</code></dfn>,
-  <dfn attribute for="HTMLMenuItemElement"><code>disabled</code></dfn>, and
-  <dfn attribute for="HTMLMenuItemElement"><code>default</code></dfn> IDL attributes must <a>reflect</a>
-  the respective content attributes of the same name.
-
-  <hr />
-
-  If the element's <a facet for="menuitem">Disabled State</a> is false
-  (enabled) then the element's <a>activation behavior</a> is to do nothing.
-
-  <p class="note">
-    Firing a synthetic <code>click</code> event at the element
-  does not cause any of the actions described above to happen.
-  </p>
-
-  If the element's <a facet for="menuitem">Disabled State</a> is true
-  (disabled) then the element has no <a>activation behavior</a>.
-
-  <p class="note">
-    The <{menuitem}> element is not rendered except as <a element lt="menu">part of a context menu</a>.
-  </p>
-
-  <div class="example">
-    Here is an example of a pop-up menu button with three options that let the user toggle between
-    left, center, and right alignment. One could imagine such a toolbar as part of a text editor. The
-    menu also has a separator followed by another menu item labeled "Publish", though that menu item
-    is disabled.
-
-    <pre highlight="html">
-&lt;button contextmenu="editmenu"&gt;Commands...&lt;/button&gt;
-&lt;menu type="context" id="editmenu"&gt;
-  &lt;menuitem label="Left" icon="icons/alL.png" onclick="setAlign('left')"&gt;
-  &lt;/menuitem&gt;
-  &lt;menuitem label="Center" icon="icons/alC.png" onclick="setAlign('center')"&gt;
-  &lt;/menuitem&gt;
-  &lt;menuitem label="Right" icon="icons/alR.png" onclick="setAlign('right')"&gt;
-  &lt;/menuitem&gt;
-  &lt;hr&gt;
-  &lt;menuitem disabled label="Publish" icon="icons/pub.png" onclick="publish()"&gt;
-  &lt;/menuitem&gt;
-&lt;/menu&gt;
-    </pre>
-
-  </div>
-
-<h4 id="context-menus"><dfn lt="context menu">Context menus</dfn></h4>
-
-<h5 id="declaring-a-context-menu">Declaring a context menu</h5>
-
-  The <dfn element-attr for="global"><code>contextmenu</code></dfn> attribute gives the element's
-  context menu. The value must be the <a>ID</a> of a <{menu}>
-  element in the same <a>tree</a> whose <code>type</code>
-  attribute is in the <a state for="menu">context menu</a> state.
-
-  <p class="note">
-    When a user right-clicks on an element with a <{global/contextmenu}> attribute, the user agent will first fire a <code>contextmenu</code> event at the element, and then, if that event is not
-  canceled, a <code>show</code> event at the <{menu}> element.
-  </p>
-
-  <div class="example">
-    Here is an example of a context menu for an input control:
-
-    <pre highlight="html">
-&lt;form name="npc"&gt;
-  &lt;label&gt;Character name: &lt;input name=char type=text contextmenu=namemenu required&gt;&lt;/label&gt;
-  &lt;menu type=context id=namemenu&gt;
-  &lt;menuitem label="Pick random name" onclick="document.forms.npc.elements.char.value = getRandomName()"&gt;
-    &lt;/menuitem&gt;
-  &lt;menuitem label="Prefill other fields based on name" onclick="prefillFields(document.forms.npc.elements.char.value)"&gt;
-    &lt;/menuitem&gt;
-  &lt;/menu&gt;
-&lt;/form&gt;
-    </pre>
-
-    This adds two items to the control's context menu, one called "Pick random name", and one
-    called "Prefill other fields based on name". They invoke scripts that are not shown in the
-    example above.
-
-  </div>
-
-
-<h5 id="context-menu-processing-model">Processing model</h5>
-
-  Each element has an <dfn>assigned context menu</dfn>, which can be null.
-  If an element <var>A</var> has a <{global/contextmenu}> attribute, and there is
-  an element with the ID given by <var>A</var>'s <{global/contextmenu}> attribute's value in <var>A</var>'s
-  <a>tree</a>, and the first such element in <a>tree order</a> is a
-  <{menu}> element, then <var>A</var>'s <a>assigned context menu</a> is that element.
-  Otherwise, if <var>A</var> has a parent element,
-  then <var>A</var>'s <a>assigned context menu</a> is the <a>assigned context menu</a> of its parent element.
-  Otherwise, <var>A</var>'s <a>assigned context menu</a> is null.
-
-  When an element's context menu is requested (e.g., by the user right-clicking the element, or
-  pressing a context menu key), the user agent must apply the appropriate rules from the following
-  list:
-
-  <dl class="switch">
-
-    <dt>If the user requested a context menu using a pointing device</dt>
-
-    <dd>The user agent must <a>fire</a> a <a>trusted</a> event with the name <code>contextmenu</code>, that bubbles and is cancelable, and that uses the
-    <code>MouseEvent</code> interface, at the element for which the menu was requested. The context
-    information of the event must be initialized to the same values as the last
-    <code>MouseEvent</code> user interaction event that was fired as part of the gesture that was
-    interpreted as a request for the context menu.</dd>
-
-    <dt>Otherwise</dt>
-
-    <dd>The user agent must <a>fire a synthetic mouse
-    event named <code>contextmenu</code></a> that bubbles and is
-    cancelable at the element for which the menu was requested.</dd>
-
-  </dl>
-
-  <p class="note">
-    Typically, therefore, the firing of the <code>contextmenu</code> event will be the
-  default action of a <code>mouseup</code> or <code>keyup</code> event. The exact
-  sequence of events is user agent-dependent, as it will vary based on platform conventions.
-  </p>
-
-  The default action of the <code>contextmenu</code> event depends on
-  whether or not the element for which the menu was requested has a non-null <a>assigned context
-  menu</a> when the event dispatch has completed, as follows.
-
-  If the <a>assigned context menu</a> of the element for which the menu was requested is
-  null, the default action must be for the user agent to show its default context menu, if it has
-  one.
-
-  Otherwise, let <var>subject</var> be the element for which the menu was requested, and let
-  <var>menu</var> be the <a>assigned context menu</a> of <var>target</var> immediately after
-  the <code>contextmenu</code> event's dispatch has completed. The user
-  agent must <a>fire</a> a <a>trusted</a> event with the name <code>show</code> at <var>menu</var>,
-  using the <code>RelatedEvent</code> interface,
-  with the <code>relatedTarget</code> attribute initialized
-  to <var>subject</var>. The event must be cancelable.
-
-  If <em>this</em> event (the <code>show</code> event) is not canceled, then
-  the user agent must <a>build and show</a> the menu for
-  <var>menu</var> with <var>subject</var> as the subject.
-
-  When it presents a context menu, the user agent should also provide access to its default context menu.
-  For example, it could merge the menu items from the two menus together,
-  provide the page's context menu as a submenu of the default menu, or
-  handle right-clicks that have the Shift key depressed by showing the default context menu
-  instead of firing the <code>contextmenu</code> event.
-
-  <hr />
-
-  <div class="example">
-    In this example, an image of cats is given a context menu with four possible commands:
-
-    <pre highlight="html">
-&lt;img src="cats.jpeg" alt="Cats" contextmenu=catsmenu&gt;
-&lt;menu type="context" id="catsmenu"&gt;
-  &lt;menuitem label="Pet the kittens" onclick="kittens.pet()"&gt;
-  &lt;menuitem label="Cuddle with the kittens" onclick="kittens.cuddle()"&gt;
-  &lt;menu label="Feed the kittens"&gt;
-    &lt;menuitem label="Fish" onclick="kittens.feed(fish)"&gt;
-    &lt;menuitem label="Chicken" onclick="kittens.feed(chicken)"&gt;
-  &lt;/menu&gt;
-&lt;/menu&gt;
-    </pre>
-
-    When a user of a mouse-operated visual Web browser right-clicks on the image, the browser
-    might pop up a context menu like this:
-
-    <img src="images/contextmenu-collapsed.png" alt="A context menu, shown over a picture of cats, with four lines: the first two offering the menu items described in the markup above ('Pet the kittens' and 'Cuddle with the kittens'), the third giving a submenu labeled 'Feed the kittens', and the fourth, after a horizontal splitter, consisting of only a downwards-pointing disclosure triangle." />
-
-    When the user clicks the disclosure triangle, such a user agent would expand the context menu
-    in place, to show the browser's own commands:
-
-    <img src="images/contextmenu-expanded.png" alt="This would result in the same basic interface, but with a longer menu; the disclosure triangle having been replaced by items such as 'View Image', 'Copy Image', 'Copy Image Location', and so forth." />
-
-  </div>
-
-<h5 id="the-relatedevent-interfaces">The <code>RelatedEvent</code> interfaces</h5>
-
-  <pre class="idl" data-highlight="webidl">
-    [Constructor(DOMString type, optional RelatedEventInit eventInitDict)]
-    interface RelatedEvent : Event {
-      readonly attribute EventTarget? relatedTarget;
-    };
-
-    dictionary RelatedEventInit : EventInit {
-      EventTarget? relatedTarget = null;
-    };
-  </pre>
-
-  <dl class="domintro">
-    <dt><var>event</var> . <code>relatedTarget</code></dt>
-    <dd>
-      Returns the other event target involved in this event. For example, when a <code>show</code>
-      event fires on a <{menu}> element, the other event target involved in the event would be the
-      element for which the menu is being shown.
-    </dd>
-  </dl>
-
-  The <dfn attribute for="RelatedEvent"><code>relatedTarget</code></dfn> attribute must return the
-  value it was initialized to. It represents the other event target that is related to the event.
-
 <h4 id="commands">Commands</h4>
 
 <h5 id="facets">Facets</h5>
 
-  A <dfn for="menuitem" lt="defines a command|command">command</dfn> is the abstraction behind menu
-  items, buttons, and links. Once a command is defined, other parts of the interface can refer to
+  A <dfn lt="defines a command|command">command</dfn> is the abstraction behind buttons, and links. Once a command is defined, other parts of the interface can refer to
   the same command, allowing many access points to a single feature to share facets such as the
-  <a facet for="menuitem">Disabled State</a>.
+  <a facet>Disabled State</a>.
 
-  Commands are defined to have the following <dfn for="menuitem">facets</dfn>:
+  Commands are defined to have the following <dfn>facets</dfn>:
 
-  : <dfn facet for="menuitem">Label</dfn>
+  : <dfn for="facet">Label</dfn>
   :: The name of the command as seen by the user.
-  : <dfn facet for="menuitem">Access Key</dfn>
+  : <dfn for="facet">Access Key</dfn>
   :: A key combination selected by the user agent that triggers the command. A command might not
       have an Access Key.
-  : <dfn facet for="menuitem">Hidden State</dfn>
-  :: Whether the command is hidden or not (basically, whether it should be shown in menus).
-  : <dfn facet for="menuitem">Disabled State</dfn>
+  : <dfn for="facet">Hidden State</dfn>
+  :: Whether the command is hidden or not.
+  : <dfn for="facet">Disabled State</dfn>
   :: Whether the command is relevant and can be triggered or not.
-  : <dfn facet for="menuitem">Action</dfn>
+  : <dfn for="facet">Action</dfn>
   :: The actual effect that triggering the command will have. This could be a scripted event
       handler, a [=url/URL=] to which to <a>navigate</a>, or a form submission.
 
@@ -710,60 +232,55 @@
 
   <ul class="brief">
 
-    <li>The <a facet for="menuitem">Hidden State</a> facet is false (visible)</li>
+    <li>The <a for="facet">Hidden State</a> facet is false (visible)</li>
 
     <li>The element is <a>in a <code>Document</code></a> that has an associated <a>browsing context</a>.</li>
 
     <li>Neither the element nor any of its ancestors has a <{global/hidden}>
     attribute specified.</li>
 
-    <li>The element is not a <{menuitem}> element, or it is a child of a <a>currently
-    relevant <code>menu</code> element</a>, or it has an <a facet for="menuitem">Access Key</a>.</li>
-
   </ul>
 
-  User agents are encouraged to do this especially for commands that have <a facet for="menuitem" lt="Access Key">Access Keys</a>, as a way to advertise those keys to the
+  User agents are encouraged to do this especially for commands that have <a for="facet" lt="Access Key">Access Keys</a>, as a way to advertise those keys to the
   user.
-
-  <p class="example">For example, such commands could be listed in the user agent's menu bar.</p>
 
 
 <h5 id="using-the-a-element-to-define-a-command">Using the <{a}> element to define a command</h5>
 
   An <{a}> element with an <{a/href}> attribute defines a command.
 
-  The <a facet for="menuitem">Label</a> of the command is the string given by the
+  The <a for="facet">Label</a> of the command is the string given by the
   element's {{Node/textContent}} IDL attribute.
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>, if any.
 
-  The <a facet for="menuitem">Hidden State</a> of the command is true (hidden)
+  The <a for="facet">Hidden State</a> of the command is true (hidden)
   if the element has a <{global/hidden}> attribute, and false otherwise.
 
-  The <a facet for="menuitem">Disabled State</a> facet of the command is
+  The <a for="facet">Disabled State</a> facet of the command is
   true if the element or one of its ancestors is <a>inert</a>, and false otherwise.
 
-  The <a facet for="menuitem">Action</a> of the command, if the element has a
+  The <a for="facet">Action</a> of the command, if the element has a
   defined <a>activation behavior</a>, is to <a>run synthetic click activation steps</a>
   on the element. Otherwise, it is just to <a>fire a <code>click</code>
   event</a> at the element.
 
 <h5 id="using-the-button-element-to-define-a-command">Using the <{button}> element to define a command</h5>
 
-  A <{button}> element always <a for="menuitem">defines a command</a>.
+  A <{button}> element always <a for="facet">defines a command</a>.
 
-  The <a facet for="menuitem">Label</a>, <a facet for="menuitem">Access Key</a>, <a facet for="menuitem">Hidden State</a>, and <a facet for="menuitem">Action</a> facets of the command are determined <span>as for <{a}> elements</span> (see the previous section).
+  The <a for="facet">Label</a>, <a for="facet">Access Key</a>, <a for="facet">Hidden State</a>, and <a for="facet">Action</a> facets of the command are determined <span>as for <{a}> elements</span> (see the previous section).
 
-  The <a facet for="menuitem">Disabled State</a> of the command is true if
+  The <a for="facet">Disabled State</a> of the command is true if
   the element or one of its ancestors is <a>inert</a>, or if the element's disabled state is set, and false otherwise.
 
 <h5 id="using-the-input-element-to-define-a-command">Using the <{input}> element to define a command</h5>
 
   An <{input}> element whose <code>type</code> attribute is in
-  one of the <{input/Submit|Submit Button}>, <{input/Reset|Reset Button}>, <{input/Image|Image Button}>, <{input/Button}>, <{input/Radio|Radio Button}>, or <{input/Checkbox}> states <a for="menuitem">defines a command</a>.
+  one of the <{input/Submit|Submit Button}>, <{input/Reset|Reset Button}>, <{input/Image|Image Button}>, <{input/Button}>, <{input/Radio|Radio Button}>, or <{input/Checkbox}> states <a for="facet">defines a command</a>.
 
-  The <a facet for="menuitem">Label</a> of the command is determined as
+  The <a for="facet">Label</a> of the command is determined as
   follows:
 
   <ul>
@@ -776,7 +293,7 @@
     absent.</li>
 
     <li>Otherwise, if the element is a <a>labeled control</a>, then the
-    <a facet for="menuitem">Label</a> is the string given by the
+    <a for="facet">Label</a> is the string given by the
     {{Node/textContent}} of the first <{label}> element in <a>tree order</a>
     whose <a>labeled control</a> is the element in question. (In DOM terms, this is the
     string given by <code><var>element</var>.labels[0].textContent</code>.)</li>
@@ -788,81 +305,58 @@
 
   </ul>
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>, if any.
 
-  The <a facet for="menuitem">Hidden State</a> of the command is true (hidden)
+  The <a for="facet">Hidden State</a> of the command is true (hidden)
   if the element has a <{global/hidden}> attribute, and false otherwise.
 
-  The <a facet for="menuitem">Disabled State</a> of the command is true if
+  The <a for="facet">Disabled State</a> of the command is true if
   the element or one of its ancestors is <a>inert</a>, or if the element's disabled state is set, and false otherwise.
 
-  The <a facet for="menuitem">Action</a> of the command, if the element has a
+  The <a for="facet">Action</a> of the command, if the element has a
   defined <a>activation behavior</a>, is to <a>run synthetic click activation steps</a>
   on the element. Otherwise, it is just to <a>fire a <code>click</code>
   event</a> at the element.
 
-<h5 id="using-the-option-element-to-define-a-command"><dfn lt="menu command">Using the <{option}> element to define a command</dfn></h5>
+<h5 id="using-the-option-element-to-define-a-command"><dfn lt="facet command">Using the <{option}> element to define a command</dfn></h5>
 
   An <{option}> element with an ancestor <{select}> element and either no <code>value</code> attribute or a <code>value</code>
   attribute that is not the empty string defines a command.
 
-  The <a facet for="menuitem">Label</a> of the command is the value of the
+  The <a for="facet">Label</a> of the command is the value of the
   <{option}> element's <code>label</code> attribute, if there is
   one, or else the value of <{option}> element's {{Node/textContent}} IDL attribute,
   with <a>leading and trailing white space
   stripped</a>, and with any sequences of two or more <a>space
   characters</a> replaced by a single U+0020 SPACE character.
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>, if any.
 
-  The <a facet for="menuitem">Hidden State</a> of the command is true (hidden)
+  The <a for="facet">Hidden State</a> of the command is true (hidden)
   if the element has a <{global/hidden}> attribute, and false otherwise.
 
-  The <a facet for="menuitem">Disabled State</a> of the command is true if
+  The <a for="facet">Disabled State</a> of the command is true if
   the element is disabled, or if its nearest ancestor
   <{select}> element is disabled, or if it or one
   of its ancestors is <a>inert</a>, and false otherwise.
 
-  If the <code>option</code>'s nearest ancestor <{select}> element has a <code>multiple</code> attribute, the <a facet for="menuitem">Action</a> of the command is to <a>pick</a> the <{option}> element. Otherwise, the <a>Action</a> is to <a>toggle</a> the <{option}> element.
-
-<h5 id="using-the-menuitem-element-to-define-a-command">Using the <{menuitem}> element to define a
-  command</h5>
-
-  A <{menuitem}> element always <a for="menuitem">defines a command</a>.
-
-  The <a facet for="menuitem">Label</a> of the command is the value of the element's
-  <code>label</code> attribute, if there is one, or the empty string if
-  it doesn't.
-
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
-  <a>assigned access key</a>, if any.
-
-  The <a facet for="menuitem">Hidden State</a> of the command is true (hidden)
-  if the element has a <{global/hidden}> attribute, and false otherwise.
-
-  The <a facet for="menuitem">Disabled State</a> of the command is true if
-  the element or one of its ancestors is <a>inert</a>, or if the element has a <code>disabled</code> attribute, and false otherwise.
-
-  The <a facet for="menuitem">Action</a> of the command, if the element has a
-  defined <a>activation behavior</a>, is to
-  <a>run synthetic click activation steps</a> on the element. Otherwise, it is just to
-  <a>fire a <code>click</code> event</a> at the element.
+  If the <code>option</code>'s nearest ancestor <{select}> element has a <code>multiple</code> attribute, the <a for="facet">Action</a> of the command is to <a>pick</a> the <{option}> element. Otherwise, the <a>Action</a> is to <a>toggle</a> the <{option}> element.
 
 <h5 id="using-the-accesskey-attribute-on-a-label-element-to-define-a-command">Using the <code>accesskey</code> attribute
   on a <{label}> element to define a command</h5>
 
   A <{label}> element that has an <a>assigned access key</a> and a <a>labeled
-  control</a> and whose <a>labeled control</a> <a for="menuitem">defines a command</a>, itself defines a command.
+  control</a> and whose <a>labeled control</a> <a for="facet">defines a command</a>, itself defines a command.
 
-  The <a facet for="menuitem">Label</a> of the command is the string given by the
+  The <a for="facet">Label</a> of the command is the string given by the
   element's {{Node/textContent}} IDL attribute.
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>.
 
-  The <a facet for="menuitem">Hidden State</a>, <a facet for="menuitem">Disabled State</a>, and <a facet for="menuitem">Action</a> facets of the command are the same as the respective
+  The <a for="facet">Hidden State</a>, <a for="facet">Disabled State</a>, and <a for="facet">Action</a> facets of the command are the same as the respective
   facets of the element's <a>labeled control</a>.
 
 <h5 id="using-the-accesskey-attribute-on-a-legend-element-to-define-a-command">Using the <code>accesskey</code> attribute
@@ -873,13 +367,13 @@
   <{legend}> element and is neither a <{label}> element nor a <code>legend</code>
   element but that defines a command, itself defines a command.
 
-  The <a facet for="menuitem">Label</a> of the command is the string given by the
+  The <a for="facet">Label</a> of the command is the string given by the
   element's {{Node/textContent}} IDL attribute.
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>.
 
-  The <a facet for="menuitem">Hidden State</a>, <a facet for="menuitem">Disabled State</a>, and <a facet for="menuitem">Action</a> facets of the command are the same as the respective
+  The <a for="facet">Hidden State</a>, <a for="facet">Disabled State</a>, and <a for="facet">Action</a> facets of the command are the same as the respective
   facets of the first element in <a>tree order</a> that is a descendant of the parent of the
   <{legend}> element that defines a command but is not
   a descendant of the <{legend}> element and is neither a <code>label</code> nor a
@@ -888,30 +382,30 @@
 <h5 id="using-the-accesskey-attribute-to-define-a-command-on-other-elements">Using the <code>accesskey</code>
   attribute to define a command on other elements</h5>
 
-  An element that has an <a>assigned access key</a> <a for="menuitem">defines a command</a>.
+  An element that has an <a>assigned access key</a> <a for="facet">defines a command</a>.
 
-  If one of the earlier sections that define elements that <a for="menuitem" lt="command">define commands</a> define that this element defines a command,
+  If one of the earlier sections that define elements that <a for="facet" lt="command">define commands</a> define that this element defines a command,
   then that section applies to this element, and this section does not. Otherwise, this section
   applies to that element.
 
-  The <a facet for="menuitem">Label</a> of the command depends on the element. If
+  The <a for="facet">Label</a> of the command depends on the element. If
   the element is a <a>labeled control</a>, the {{Node/textContent}} of the first
   <{label}> element in <a>tree order</a> whose <a>labeled control</a> is the
-  element in question is the <a facet for="menuitem">Label</a> (in DOM terms, this is
+  element in question is the <a for="facet">Label</a> (in DOM terms, this is
   the string given by <code><var>element</var>.labels[0].textContent</code>). Otherwise,
   the <a>Label</a> is the {{Node/textContent}} of the element
   itself.
 
-  The <a facet for="menuitem">Access Key</a> of the command is the element's
+  The <a for="facet">Access Key</a> of the command is the element's
   <a>assigned access key</a>.
 
-  The <a facet for="menuitem">Hidden State</a> of the command is true (hidden)
+  The <a for="facet">Hidden State</a> of the command is true (hidden)
   if the element has a <{global/hidden}> attribute, and false otherwise.
 
-  The <a facet for="menuitem">Disabled State</a> of the command is true if
+  The <a for="facet">Disabled State</a> of the command is true if
   the element or one of its ancestors is <a>inert</a>, and false otherwise.
 
-  The <a facet for="menuitem">Action</a> of the command is to run the following
+  The <a for="facet">Action</a> of the command is to run the following
   steps:
 
   <ol>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -1251,7 +1251,6 @@ o............A....e
     <dd>Or: The content model of <{fieldset}> elements.</dd>
     <dd>Or: The content model of <{select}> elements.</dd>
     <dd>Or: The content model of <{details}> elements.</dd>
-    <dd>Or: The content model of <{menu}> elements whose <code>type</code> attribute is in the <a state for="menu">context menu</a> state.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -35,8 +35,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>link</code></a> (default - <a><em>do not set</em></a>), <a attr-value for="aria/role"><code>button</code></a>,
-      <a attr-value for="aria/role"><code>checkbox</code></a>, <a attr-value for="aria/role"><code>menuitem</code></a>,
-      <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>, <a attr-value for="aria/role"><code>menuitemradio</code></a>,
+      <a attr-value for="aria/role"><code>checkbox</code></a>,
       <a attr-value for="aria/role"><code>radio</code></a>, <a attr-value for="aria/role"><code>switch</code></a>,
       <a attr-value for="aria/role"><code>tab</code></a> or <a attr-value for="aria/role"><code>treeitem</code></a>
     </dd>
@@ -2445,7 +2444,7 @@ Linux demo 2.6.10-grsec+gg3+e+fhs6b+nfs+gr0501+++p3+c4a+gr2b-reslog-v6.189 #1 SM
   the input as it was echoed by the system.
 
   When the <{kbd}> element <em>contains</em> a <{samp}> element, it represents
-  input based on system output, for example invoking a menu item.
+  input based on system output.
 
   When the <{kbd}> element is nested inside another <{kbd}> element, it
   represents an actual key or other single unit of input as appropriate for the input mechanism.

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -84,8 +84,6 @@ path: sections/semantics-common-idioms.include
 
     <li>an <{option}> element that is disabled</li>
 
-    <li>a <{menuitem}> element that has a <code>disabled</code> attribute</li>
-
     <li>a <{fieldset}> element that is a <a>disabled fieldset</a></li>
 
   </ul>
@@ -231,10 +229,6 @@ path: sections/semantics-common-idioms.include
           between the time that the element received the <code>keydown</code> event and the time the
           element received the <code>keyup</code> event.</p>
 
-      : If the element is a <{menuitem}> element
-      :: The element is <a>being activated</a> if it is <a>in a formal activation state</a> and it
-          does not have a <{disabledformelements/disabled}> attribute.
-
       : If the element is an <{a}> element that has an <{links/href}> attribute
       : If the element is an <{area}> element that has an <{links/href}> attribute
       : If the element is a <{link}> element that has an <{link/href}> attribute
@@ -298,7 +292,6 @@ path: sections/semantics-common-idioms.include
       * a <{textarea}> element that is not disabled
       * an <{optgroup}> element that does not have a <{optgroup/disabled}> attribute
       * an <{option}> element that is not disabled
-      * a <{menuitem}> element that does not have a <{menuitem/disabled}> attribute
       * a <{fieldset}> element that is not a <a>disabled fieldset</a>
 
   : '':disabled''

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -519,7 +519,7 @@
   A <{p}> element's [=end tag=] may be omitted if the <{p}> element is immediately followed by an
   <{address}>, <{article}>, <{aside}>, <{blockquote}>, <{details}>, <{div}>, <{dl}>, <{fieldset}>,
   <{figcaption}>, <{figure}>, <{footer}>, <{form}>, <{h1}>, <{h2}>, <{h3}>, <{h4}>, <{h5}>, <{h6}>,
-  <{header}>, <{hr}>, <{main}>, <{menu}>, <{nav}>, <{ol}>, <{p}>, <{pre}>, <{section}>, <{table}>,
+  <{header}>, <{hr}>, <{main}>, <{nav}>, <{ol}>, <{p}>, <{pre}>, <{section}>, <{table}>,
   or <{ul}> element, or if there is no more content in the parent element and the parent element is
   an [=HTML element=] that is not an <{a}>, <{audio}>, <{del}>, <{ins}>, <{map}>, <{noscript}>, or
   <{video}> element, or an [=autonomous custom element=].
@@ -544,10 +544,6 @@
   An <{option}> element's [=end tag=] may be omitted if the <{option}> element is immediately
   followed by another <{option}> element, or if it is immediately followed by an <{optgroup}>
   element, or if there is no more content in the parent element.
-
-  A <{menuitem}> element's [=end tag=] may be omitted if the <{menuitem}> element is immediately
-  followed by a <{menuitem}>, <{hr}>, or <{menu}> element, or if there is no more content in the
-  parent element.
 
   A <{colgroup}> element's [=start tag=] may be omitted if the first thing inside the <{colgroup}>
   element is a <{col}> element, and if the element is not immediately preceded by another
@@ -885,10 +881,7 @@
   [[#syntax|the HTML syntax]], then it is an [=HTML document=].
 
   <p class="note">As stated in the terminology section, references to [=element types=] that do
-  not explicitly specify a namespace always refer to elements in the [=HTML namespace=]. For
-  example, if the spec talks about "a <{menuitem}> element", then that is an element with the local
-  name `menuitem`, the namespace "`http://www.w3.org/1999/xhtml`", and the interface
-  {{HTMLMenuItemElement}}. Where possible, references to such elements are hyperlinked to their
+  not explicitly specify a namespace always refer to elements in the [=HTML namespace=]. Where possible, references to such elements are hyperlinked to their
   definition.</p>
 
 ### Overview of the parsing model ### {#overview-of-the-parsing-model}
@@ -1525,7 +1518,7 @@
       <{dd}>, <{details}>, <{dir}>, <{div}>, <{dl}>, <{dt}>, <{embed}>, <{fieldset}>,
       <{figcaption}>, <{figure}>, <{footer}>, <{form}>, <{frame}>, <{frameset}>, <{h1}>, <{h2}>,
       <{h3}>, <{h4}>, <{h5}>, <{h6}>, <{head}>, <{header}>, <{hr}>, <{html}>, <{iframe}>, <{img}>,
-      <{input}>, <{li}>, <{link}>, <{listing}>, <{main}>, <{marquee}>, <{menu}>, <{meta}>, <{nav}>,
+      <{input}>, <{li}>, <{link}>, <{listing}>, <{main}>, <{marquee}>, <{meta}>, <{nav}>,
       <{noembed}>, <{noframes}>, <{noscript}>, <{object}>, <{ol}>, <{p}>, <{param}>, <{plaintext}>,
       <{pre}>, <{script}>, <{section}>, <{select}>, <{source}>, <{style}>, <{summary}>, <{table}>,
       <{tbody}>, <{td}>, <{template}>, <{textarea}>, <{tfoot}>, <{th}>, <{thead}>, <{title}>,
@@ -4043,7 +4036,7 @@
 #### Closing elements that have implied end tags #### {#closing-elements-that-have-implied-end-tags}
 
   When the steps below require the UA to <dfn>generate implied end tags</dfn>, then, while the
-  [=current node=] is a <{dd}> element, a <{dt}> element, an <{li}> element, a <{menuitem}> element,
+  [=current node=] is a <{dd}> element, a <{dt}> element, an <{li}> element,
   an <{optgroup}> element, an <{option}> element, a <{p}> element, an <{rb}> element, an <{rp}>
   element, an <{rt}> element, or an <{rtc}> element, the UA must pop the [=current node=] off the
   [=stack of open elements=].
@@ -4610,7 +4603,7 @@
         Otherwise, follow these steps:
 
         1. If there is a node in the [=stack of open elements=] that is not either a <{dd}> element,
-            a <{dt}> element, an <{li}> element, a <{menuitem}> element, an <{optgroup}> element, an
+            a <{dt}> element, an <{li}> element, an <{optgroup}> element, an
             <{option}> element, a <{p}> element, an <{rb}> element, an <{rp}> element, an <{rt}>
             element, an <{rtc}> element, a <{tbody}> element, a <{td}> element, a <{tfoot}> element,
             a <{th}> element, a <{thead}> element, a <{tr}> element, the <{body}> element, or the
@@ -4622,7 +4615,7 @@
         is a [=parse error=]; ignore the token.
 
         Otherwise, if there is a node in the [=stack of open elements=] that is not either a <{dd}>
-        element, a <{dt}> element, an <{li}> element, a <{menuitem}> element, an <{optgroup}>
+        element, a <{dt}> element, an <{li}> element, an <{optgroup}>
         element, an <{option}> element, a <{p}> element, an <{rb}> element, an <{rp}> element, an
         <{rt}> element, an <{rtc}> element, a <{tbody}> element, a <{td}> element, a <{tfoot}>
         element, a <{th}> element, a <{thead}> element, a <{tr}> element, the <{body}> element, or
@@ -4635,7 +4628,7 @@
         is a [=parse error=]; ignore the token.
 
         Otherwise, if there is a node in the [=stack of open elements=] that is not either a <{dd}>
-        element, a <{dt}> element, an <{li}> element, a <{menuitem}> element, an <{optgroup}>
+        element, a <{dt}> element, an <{li}> element, an <{optgroup}>
         element, an <{option}> element, a <{p}> element, an <{rb}> element, an <{rp}> element, an
         <{rt}> element, an <{rtc}> element, a <{tbody}> element, a <{td}> element, a <{tfoot}>
         element, a <{th}> element, a <{thead}> element, a <{tr}> element, the <{body}> element, or
@@ -4650,15 +4643,6 @@
         "header", "main", "nav", "ol", "p", "section", "summary", "ul"
     :: If the [=stack of open elements=] <a>has a `p` element in button scope</a>, then
         <a>close a `p` element</a>.
-
-        [=Insert an HTML element=] for the token.
-
-    : A start tag whose tag name is "menu"
-    :: If the [=stack of open elements=] <a>has a `p` element in button scope</a>, then
-        <a>close a `p` element</a>.
-
-        If the [=current node=] is a <{menuitem}> element, pop that node from the
-        [=stack of open elements=].
 
         [=Insert an HTML element=] for the token.
 
@@ -4768,7 +4752,7 @@
 
     : An end tag whose tag name is one of: "address", "article", "aside", "blockquote", "button",
         "center", "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure",
-        "footer", "header", "listing", "main", "menu", "nav", "ol", "pre", "section", "summary",
+        "footer", "header", "listing", "main", "nav", "ol", "pre", "section", "summary",
         "ul"
     :: If the [=stack of open elements=] does not [=in scope|have an element in scope=] that is an
         [=HTML element=] with the same tag name as that of the token, then this is a
@@ -4968,9 +4952,6 @@
     :: If the [=stack of open elements=] <a>has a `p` element in button scope</a>, then
         <a>close a `p` element</a>.
 
-        If the [=current node=] is a <{menuitem}> element, pop that node from the
-        [=stack of open elements=].
-
         [=Insert an HTML element=] for the token. Immediately pop the [=current node=] off the
         [=stack of open elements=].
 
@@ -5025,14 +5006,6 @@
 
     : A start tag whose tag name is one of: "optgroup", "option"
     :: If the [=current node=] is an <{option}> element, then pop the [=current node=] off the
-        [=stack of open elements=].
-
-        [=Reconstruct the active formatting elements=], if any.
-
-        [=Insert an HTML element=] for the token.
-
-    : A start tag whose tag name is "menuitem"
-    :: If the [=current node=] is a <{menuitem}> element, then pop the [=current node=] off the
         [=stack of open elements=].
 
         [=Reconstruct the active formatting elements=], if any.
@@ -6168,7 +6141,7 @@
 
     : A start tag whose tag name is one of:  "b", "big", "blockquote", "body", "br", "center",
         "code", "dd", "div", "dl", "dt", "em", "embed", "h1", "h2", "h3", "h4", "h5", "h6", "head",
-        "hr", "i", "img", "li", "listing", "menu", "meta", "nobr", "ol", "p", "pre", "ruby", "s",
+        "hr", "i", "img", "li", "listing", "meta", "nobr", "ol", "p", "pre", "ruby", "s",
         "small", "span", "strong", "strike", "sub", "sup", "table", "tt", "u", "ul", "var"
     : A start tag whose tag name is "font", if the token has any attributes named "color", "face",
         or "size"

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1725,7 +1725,6 @@
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onchange</code></dfn> <td> <code>change</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onclick</code></dfn> <td> <code>click</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onclose</code></dfn> <td> <code>close</code>
-    <tr><td><dfn attribute for="GlobalEventHandlers"><code>oncontextmenu</code></dfn> <td> <code>contextmenu</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>oncuechange</code></dfn> <td> <code>cuechange</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>ondblclick</code></dfn> <td> <code>dblclick</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>ondrag</code></dfn> <td> <code>drag</code>
@@ -1869,7 +1868,6 @@
       attribute EventHandler onchange;
       attribute EventHandler onclick;
       attribute EventHandler onclose;
-      attribute EventHandler oncontextmenu;
       attribute EventHandler oncuechange;
       attribute EventHandler ondblclick;
       attribute EventHandler ondrag;
@@ -1965,7 +1963,7 @@
   bubble (except where otherwise stated) and is not cancelable (except where otherwise stated), and
   which uses the {{Event}} interface, must be created and <a>dispatched</a> at the given target.
 
-  <dfn lt="fire a synthetic mouse event named contextmenu|Firing a synthetic mouse event named e|firing a synthetic mouse event named click">Firing a synthetic mouse event named <var>e</var></dfn>
+  <dfn lt="Firing a synthetic mouse event named e|firing a synthetic mouse event named click">Firing a synthetic mouse event named <var>e</var></dfn>
   means that an event with the name <var>e</var>, which is <a>trusted</a> (except where otherwise
   stated), does not bubble (except where otherwise stated), is not cancelable (except where
   otherwise stated), and which uses the {{MouseEvent}} interface, must be created and <a>dispatched</a> at

--- a/single-page.bs
+++ b/single-page.bs
@@ -204,11 +204,7 @@ urlPrefix: https://www.w3.org/TR/wai-aria-1.1/#; spec: aria;
         text: main
         text: marquee
         text: math
-        text: menu
         text: menubar
-        text: menuitem
-        text: menuitemcheckbox
-        text: menuitemradio
         text: navigation
         text: none
         text: note


### PR DESCRIPTION
Clean up the at-risk features in #893 :

- remove the` <menu> `element;
- remove the `<menuitem>` element;
- remove Context menu;
- remove the contextmenu event;
- keep menubar which is defined in wai-aria-1.1;


