### PR TITLE
update preload and add the as attribute

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -5,6 +5,12 @@
 
   Full details of all changes since 12 January 2016 are available from the <a href="https://github.com/w3c/html/commits/master">commit log</a> of the <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various editorial and linking fixes.
 
+  <h3 id="changes-cr">Changes since <a href="https://www.w3.org/TR/html52/">HTML 5.2</a></h3>
+  <dl>
+    <dt><a href="https://github.com/w3c/html/pull/1053/commits/349377f180dc483a13e06b9ce3eb34a824f81046">Update the <code>preload</code> Link type and add the <code>as</code> attribute</dt>
+    <dd>Fixed <a href="https://github.com/w3c/html/issues/1044">Issue 1044</a></dd>
+  </dl>
+
   <h3 id="changes-cr">Changes since the <a href="https://www.w3.org/TR/2017/CR-html52-20170808/">2017-08-08 Candidate Recommendation</a></h3>
   <dl>
     <dt><a href="https://github.com/w3c/html/pull/1043/commits/5f3c0445ed781e5fb8be7fabcb73e59a12d431a1">Remove <code>menu</code> and <code>menuitem</code>.</a></dt>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -3829,20 +3829,22 @@ INFRASTRUCTURE
   then, on getting, the IDL attribute must return the conforming value associated with the state
   the attribute is in (in its canonical case), if any, or the empty string if the attribute is in
   a state that has no associated keyword value or if the attribute is not in a defined state (e.g.,
-  the attribute is missing and there is no <i>missing value default</i>); and on setting, the
+  the attribute is missing and there is no <i>missing value default</i>). On setting, the
   content attribute must be set to the specified new value.
 
   If a reflecting IDL attribute is a nullable <code>DOMString</code> attribute whose content
   attribute is an <a>enumerated attribute</a>, then, on getting, if the corresponding content
   attribute is in its <i>missing value default</i> then the IDL attribute must return null,
   otherwise, the IDL attribute must return the conforming value associated with the state the
-  attribute is in (in its canonical case); and on setting, if the new value is null, the content
+  attribute is in (in its canonical case). On setting, if the new value is null, the content
   attribute must be removed, and otherwise, the content attribute must be set to the specified new
   value.
 
   If a reflecting IDL attribute is a <code>DOMString</code> or <a type><code>USVString</code></a>
   attribute but doesn't fall into any of the above categories, then the getting and setting must be
   done in a transparent, case-preserving manner.
+
+  If a reflecting IDL attribute is an <a>IDL enumeration</a> attribute, then, on getting, if the corresponding content attribute's value [=case-sensitively=] matches one of the enumerated values, then the IDL attribute must return the content attribute's value; otherwise it must return the content attribute's default value. On setting, the content attribute must be set to the specified new value.
 
   If a reflecting IDL attribute is a <code>boolean</code> attribute, then on getting the IDL
   attribute must return true if the content attribute is set, and false if it is absent. On

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -334,6 +334,7 @@
     <dd><code>type</code> — Hint for the type of the referenced resource</dd>
     <dd><code>referrerpolicy</code> - <a>Referrer policy</a> for <a>fetches</a> initiated by the element</dd>
     <dd><code>sizes</code> — Sizes of the icons (for <{link/rel}>="<code>icon</code>")</dd>
+    <dd><code>as</code> — Destination for a preload request (for <{link/rel}>="<code>preload</code>")</dd>
     <dd>
       Also, the <{link/title}> attribute has special semantics on this element:  Title of the
       link; alternative style sheet set name.
@@ -350,6 +351,7 @@
           [CEReactions] attribute DOMString? crossOrigin;
           [CEReactions] attribute DOMString rel;
           [CEReactions] attribute DOMString rev;
+          [CEReactions] attribute DOMString as;  // (default "")
           [CEReactions, SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
           [CEReactions] attribute DOMString media;
           [CEReactions] attribute DOMString nonce;
@@ -501,6 +503,13 @@
 
   <!-- def <{link/as}> -->
 
+  The <dfn element-attr for="link"><code>as</code></dfn> attribute specifies the <a>potential destination</a> for a preload request for the resource given by the <code>href</code> attribute. It is an [=enumerated attribute=]. Each <a>potential destination</a> is a keyword for this attribute, mapping to a state of the same name. The attribute must be specified on <{link}> elements that have a <{link/rel}> attribute that contains the <{link/preload}> keyword, but must not be specified on <{link}> elements which do not. The processing model for how the <{link/as}> attribute is used is given in the steps to <a>obtain the resource</a>.
+
+  <p class="note">The attribute does not have a [=missing value default=] or [=invalid value default=], meaning that invalid or missing values for the attribute map to no state. This is accounted for in the processing
+  model.</p>
+
+  <hr>
+
   <!-- def <{link/scope}> -->
 
   <!-- def <{link/usecache}> -->
@@ -510,7 +519,6 @@
   <!-- def <{link/color}> -->
 
   The IDL attributes
-  <!-- <dfn attribute for="HTMLLinkElement"><code>as</code></dfn>, -->
   <dfn attribute for="HTMLLinkElement"><code>href</code></dfn>,
   <dfn attribute for="HTMLLinkElement"><code>hreflang</code></dfn>,
   <!-- <dfn attribute for="HTMLLinkElement"><code>integrity</code></dfn>, -->
@@ -534,6 +542,10 @@
 
   The IDL attribute <dfn attribute for="HTMLLinkElement"><code>relList</code></dfn> must
   <a>reflect</a> the <{link/rel}> content attribute.
+
+  <!-- def {{HTMLLinkElement/as}} -->
+
+  <p>The <dfn attribute for="HTMLLinkElement"><code>as</code></dfn> IDL attribute must <a>reflect</a> the <{link/as}> content attribute, <a>limited to only known values</a>.
 
   <!-- def {{HTMLLinkElement/useCache}} -->
 
@@ -639,7 +651,11 @@
       <{link}> element's <{link/nonce}> content attribute.
   7. Set <var>request</var>'s <a>referrer policy</a> to the current state of the
       <{link}> element's <{link/referrerpolicy}> content attribute.
-  8. <a>Fetch</a> <var>request</var>.
+  8. If the <{link/rel}> attribute contains the <{link/preload}> keyword, then:
+    1. Let <var>as</var> be the current state of the <{link/as}> attribute.
+    2. If <var>as</var> is no state, then return.
+    3. Set <var>request</var>'s <a>destination</a> to the result of <a>translating<a> <var>as</var>.
+  9. <a>Fetch</a> <var>request</var>.
 
   User agents may opt to only try to obtain such resources when they are needed, instead of
   pro-actively fetching all the external resources that are not applied.

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -169,6 +169,8 @@
   associated with the resource to determine its language, not metadata included in the link to the
   resource.
 
+  The <dfn element-attr for="a,links"><code>as</code></dfn> attribute specifies the <a>destination</a> for a preload request for the resource given by the <code>href</code> attribute. If the attribute is present, the value must [=case-sensitively=] match one of the <a>destination keywords</a>. The default value is the empty string. The attribute may be omitted. The attribute must not be specified on <{link}> elements that do not have a <{links/rel}> attribute that contains the <{link/preload}> keyword. User agents must implement the processing model of the <{link/as}> attribute described in the Preload specification. [[!Preload]]
+
   The <dfn element-attr for="a,links"><code>type</code></dfn> attribute, if present, gives the
   <a>MIME type</a> of the linked resource. It is purely advisory. The value must be a
   <a>valid mime type</a>. User agents must not consider the <code>type</code> attribute authoritative — upon fetching the
@@ -1046,12 +1048,20 @@
       <td>Requires that the user agent not send an HTTP <a http-header><code>Referer</code></a> (sic) header if the user follows the hyperlink.</td>
     </tr>
 
-<tr>
+    <tr>
       <td><code>prefetch</code></td>
       <td><a>External Resource</a></td>
-      <td><a>External Resource</a></td>
+      <td><em>not allowed</em></td>
       <td class="yes"> Yes </td>
-      <td>Specifies that the target resource should be preemptively cached.</td>
+      <td>Specifies that the target resource should be preemptively cached and cache the target resource as it is likely to be required for a followup <a>navigation</a>.</td>
+    </tr>
+
+    <tr>
+      <td><code>preload</code></td>
+      <td><a>External Resource</a></td>
+      <td><em>not allowed</em></td>
+      <td class="yes"> Yes </td>
+      <td>Specifies that the user agent must preemptively <a>fetch</a> and cache the target resource for current <a>navigation</a> according to the <a>potential destination</a> given by the <{link/as}> attribute (and the <a>priority</a> associated with the <a>corresponding</a> <a>destination</a>).</td>
     </tr>
 
     <tr>
@@ -1500,6 +1510,14 @@
   <code highlight="html">&lt;a href="..." rel="noreferrer" target="_blank"></code> has the same
   behavior as
   <code highlight="html">&lt;a href="..." rel="noreferrer noopener" target="_blank"></code>.</p>
+
+<h5 id="link-type-preload">Link type "<dfn element-state for="link"><code>preload</code></dfn>"</h5>
+
+  The <{link/preload}> keyword may be used with <{link}>. This keyword creates an <a>external resource link</a>. This keyword is <a>body-ok</a>.
+
+  The <{link/preload}> keyword indicates that the user agent must preemptively fetch and cache the specified resource according to the <a>potential destination</a> given by the <{link/as}> attribute (and the <a>priority</a> associated with the <a>corresponding</a> <a>destination</a>), as it is highly likely that the user will require this resource for current navigation. User agents must implement the processing model of the <{link/preload}> keyword described in the Preload specification. [[!Preload]]
+  
+  There is no default type for resources given by the <{link/preload}> keyword.
 
 <h5 id="link-type-search">Link type "<dfn element-state for="link"><code>search</code></dfn>"</h5>
 

--- a/single-page.bs
+++ b/single-page.bs
@@ -573,6 +573,9 @@ urlPrefix: https://fetch.spec.whatwg.org/#; type: dfn; spec: FETCH;
     urlPrefix: concept-
         text: body
         text: CORS-cross-origin; url: cors-check
+        url: potential-destination-translate
+            text: corresponding 
+            text: translating
         url: fetch
             text: fetch
             text: fetching algorithm
@@ -605,6 +608,7 @@ urlPrefix: https://fetch.spec.whatwg.org/#; type: dfn; spec: FETCH;
             text: cryptographic nonce metadata; url: nonce-metadata
             text: origin
             text: parser metadata
+            text: priority
             text: redirect mode
             text: referrer
             text: target browsing context
@@ -630,6 +634,7 @@ urlPrefix: https://fetch.spec.whatwg.org/#; type: dfn; spec: FETCH;
     text: ok status
     text: process response
     text: RequestCredentials
+    text: RequestDestination
     text: same-origin data-URL flag
     text: synchronous flag
     text: unsafe-request flag
@@ -685,6 +690,11 @@ urlPrefix: https://www.w3.org/TR/html-longdesc/; type: element-attr; for: img;
 
 urlPrefix: https://www.w3.org/TR/payment-request/#; type: dfn; spec: PaymentRequest
     url: dom-paymentrequest; text: PaymentRequest
+
+<!--  ************************** Preload ************************************* -->
+
+urlPrefix: https://www.w3.org/TR/preload/#; type: dfn; spec: Preload
+    url: dfn-preload-link; text: preload
 
 <!-- ********************************** RESOURCE-HINTS ***************************************** -->
 
@@ -867,6 +877,7 @@ urlPrefix: https://www.w3.org/TR/WebIDL-1/#; spec: WEBIDL-1
             text: long
             text: unrestricted double
             text: unsigned long
+            text: enumeration
             text: DOMException
             url: DOMString
                 text: DOMString


### PR DESCRIPTION
- define the `preload` keyword;
- add the `as` attribute to the `link` element;

To fix #1044 , [tests](https://wpt.fyi/preload/reflected-as-value.html) are already in place.