### PR TITLE
Clarify parsing hexadeximal numbers

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -3502,6 +3502,11 @@
   Consume the [=next input character=]:
 
   <dl class="switch">
+    : [=ASCII digit=]
+    :: Multiply the [=character reference code=] by 16. Add a numeric version of the
+        [=current input character=] (subtract 0x0030 from the character's code point) to the
+        [=character reference code=].
+
     : [=Uppercase ASCII hex digit=]
     :: Multiply the [=character reference code=] by 16. Add a numeric version of the
         [=current input character=] as a hexadecimal digit (subtract 0x0037 from the character's
@@ -3511,11 +3516,6 @@
     :: Multiply the [=character reference code=] by 16. Add a numeric version of the
         [=current input character=] as a hexademical digit (subtract 0x0057 from the character's
         code point) to the [=character reference code=].
-
-    : [=ASCII digit=]
-    :: Multiply the [=character reference code=] by 16. Add a numeric version of the
-        [=current input character=] (subtract 0x0030 from the character's code point) to the
-        [=character reference code=].
 
     : U+003B SEMICOLON character (;)
     :: Switch to the [=numeric character reference end state=].


### PR DESCRIPTION
Fix #1025

Remove an ambiguity (resulting from a parenthetical suggestion that is
wrong) in the parsing of hexadecimal character references.

Thanks Todor Todorov for picking this up.