### PR TITLE
change paragraph to label in multi select example

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -7507,8 +7507,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     Sometimes, a user has to select one or more items. This example shows such an interface.
 
     <pre highlight="html">
-&lt;p&gt;Select the songs from that you would like on your Act II Mix Tape:&lt;/p&gt;
-&lt;select multiple required name="act2"&gt;
+&lt;label for="multiselect"&gt;Select the songs from that you would like on your Act II Mix Tape:&lt;/label&gt;
+&lt;select multiple required id="multiselect" name="act2"&gt;
   &lt;option value="s1"&gt;It Sucks to Be Me (Reprize)
   &lt;option value="s2"&gt;There is Life Outside Your Apartment
   &lt;option value="s3"&gt;The More You Ruv Someone


### PR DESCRIPTION
Presently the multiple select example (example 51) uses a `p` for what could be considered a label for the `select`.

This PR changes the `p` to a `label` with a `for` attribute pointing to a new `id` on the `select`.