### PR TITLE
removing magic alignment mode from dialog element

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -8,13 +8,15 @@
   <h3 id="changes-wd1">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a>
   <dl>
     <dt><a href="https://github.com/w3c/html/pull/1093">Don't require XML srcdoc in XHTML</a></dt>
-      <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/890">issue 890</a></dd> 
+      <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/890">issue 890</a></dd>
+    <dt><a href="https://github.com/w3c/html/pull/1123">Removing magic alignment for <code>dialog</code> element</a></dt>
+        <dd>Removed due to lack of implementation. Fixed <a href="https://github.com/w3c/html/issues/1108">issue 1108</a></dd>  
   </dl>
 
   <h3 id="changes-wd1">Changes between the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a> and
   <a href="https://www.w3.org/TR/html52/">HTML 5.2</a></h3>
   <dl>
-    <dt><a href="https://github.com/w3c/html/pull/1098">Refactor <code>document.domain</code> setter, 
+    <dt><a href="https://github.com/w3c/html/pull/1098">Refactor <code>document.domain</code> setter,
     adding concept of "is a registrable domain suffix of or is equal to"</a></dt>
       <dd>Fixed <a href="https://github.com/w3c/html/issues/769">Issue 769</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1088">Adds the <code>ping</code> attribute</a></dt>
@@ -24,7 +26,7 @@
     <dt><a href="https://github.com/w3c/html/pull/1053/commits/349377f180dc483a13e06b9ce3eb34a824f81046">Update the <code>preload</code> Link type and add the <code>as</code> attribute</a></dt>
       <dd>Fixed <a href="https://github.com/w3c/html/issues/1044">Issue 1044</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1072">Add the <code>autocapitalize</code> attribute</a></dt>
-      <dd>Fixed <a href="https://github.com/w3c/html/issues/208">Issue 208</a></dd>		
+      <dd>Fixed <a href="https://github.com/w3c/html/issues/208">Issue 208</a></dd>
   </dl>
 
   </section>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -701,8 +701,8 @@
 
   <hr />
 
-  All <{dialog}> elements are always in one of three modes: <dfn>normal alignment</dfn>,
-  <dfn>centered alignment</dfn>, and <dfn lt="magically aligned|magic alignment">magic alignment</dfn>. When a <{dialog}> element
+  All <{dialog}> elements are always in one of two modes: <dfn>normal alignment</dfn> and
+  <dfn>centered alignment</dfn>. When a <{dialog}> element
   is created, it must be placed in the <a>normal alignment</a> mode. In this mode, normal CSS
   requirements apply to the element. The <a>centered alignment</a> mode is only used for
   <{dialog}> elements that are in the <a>top layer</a>. [[!FULLSCREEN]] [[!CSS-2015]]
@@ -754,158 +754,7 @@
 
     </li>
 
-    <li>Put <var>subject</var> in the <a>magic alignment</a> mode, aligned to <var>anchor element</var>.</li>
-
   </ol>
-
-  While an element <var>A</var> has <a>magic alignment</a>, aligned to an element
-  <var>B</var>, the following requirements apply:
-
-  <ul>
-
-    <li>
-
-    If at any time either <var>A</var> or <var>B</var> cease having rendered
-    boxes, <var>A</var> and <var>B</var> cease being in the same
-    {{Document}}, or <var>B</var> ceases being earlier than <var>A</var> in <a>tree order</a>, then, if <var>subject</var> is in the
-    <a>pending dialog stack</a>, let <var>subject</var>'s mode become <a>centered
-    alignment</a>, otherwise, let <var>subject</var>'s mode become <a>normal
-    alignment</a>.
-
-    </li>
-
-    <li>
-
-    <var>A</var>'s 'position' property must compute to the keyword '<a>absolute-anchored</a>' rather than whatever it would
-    otherwise compute to (i.e., the 'position' property's <a>specified value</a> is ignored).
-
-    <p class="note">
-    The '<a>absolute-anchored</a>'
-    keyword's requirements are described below.
-  </p>
-
-    </li>
-
-    <li>
-
-    The anchor points for <var>A</var> and <var>B</var> are defined as per the
-    appropriate entry in the following list:
-
-    <dl class="switch">
-
-      <dt>If the computed value of 'anchor-point' is ''anchor-point/none'' on both <var>A</var> and <var>B</var>
-
-      </dt><dd>
-      The anchor points of <var>A</var> and <var>B</var> are the center points
-      of their respective first boxes' <a>border boxes</a>.
-
-      </dd><dt>If the computed value of 'anchor-point' is ''anchor-point/none'' on <var>A</var> and a specific
-      point on <var>B</var>
-
-      </dt><dd>
-      The anchor point of <var>B</var> is the point given by its 'anchor-point'
-      property.
-
-      If the anchor point of <var>B</var> is the center point of <var>B</var>'s
-      first box's <a>border box</a>, then <var>A</var>'s anchor point is the center point of its
-      first box's <a>margin box</a>.
-
-      Otherwise, <var>A</var>'s anchor point is on one of its <a>margin edges</a>. Consider
-      four hypothetical half-infinite lines L1, L2, L3, and L4 that each start in the center of <var>B</var>'s first box's <a>border box</a>, and that extend respectively through the top left
-      corner, top right corner, bottom right corner, and bottom left corner of <var>B</var>'s first box's <a>border box</a>. <var>A</var>'s anchor point is determined
-      by the location of <var>B</var>'s anchor point relative to these four hypothetical
-      lines, as follows:
-
-      If the anchor point of <var>B</var> lies on L1 or L2, or inside the area bounded
-      by L1 and L2 that also contains the points above <var>B</var>'s first box's border
-      box, then let <var>A</var>'s anchor point be the horizontal center of <var>A</var>'s bottom <a>margin edge</a>.
-
-      Otherwise, if the anchor point of <var>B</var> lies on L3 or L4, or inside the
-      area bounded by L3 and L4 that also contains the points below <var>B</var>'s first
-      box's <a>border box</a>, then let <var>A</var>'s anchor point be the horizontal center of
-      <var>A</var>'s top <a>margin edge</a>.
-
-      Otherwise, if the anchor point of <var>B</var> lies inside the area bounded by L4
-      and L1 that also contains the points to the left of <var>B</var>'s first box's border
-      box, then let <var>A</var>'s anchor point be the vertical center of <var>A</var>'s right <a>margin edge</a>.
-
-      Otherwise, the anchor point of <var>B</var> lies inside the area bounded by L2 and
-      L3 that also contains the points to the right of <var>B</var>'s first box's border
-      box; let <var>A</var>'s anchor point be the vertical center of <var>A</var>'s left <a>margin edge</a>.
-
-      </dd><dt>If the computed value of 'anchor-point' is a specific point on <var>A</var> and
-      ''anchor-point/none'' on <var>B</var>
-
-      </dt><dd>
-      The anchor point of <var>A</var> is the point given by its 'anchor-point'
-      property.
-
-      If the anchor point of <var>A</var> is the center point of <var>A</var>'s
-      first box's <a>margin box</a>, then <var>B</var>'s anchor point is the center point of its
-      first box's <a>border box</a>.
-
-      Otherwise, <var>B</var>'s anchor point is on one of its <a>border edges</a>. Consider
-      four hypothetical half-infinite lines L1, L2, L3, and L4 that each start in the center of <var>A</var>'s first box's <a>margin box</a>, and that extend respectively through the top left
-      corner, top right corner, bottom right corner, and bottom left corner of <var>A</var>'s first box's <a>margin box</a>. <var>B</var>'s anchor point is determined
-      by the location of <var>A</var>'s anchor point relative to these four hypothetical
-      lines, as follows:
-
-      If the anchor point of <var>A</var> lies on L1 or L2, or inside the area bounded
-      by L1 and L2 that also contains the points above <var>A</var>'s first box's margin
-      box, then let <var>B</var>'s anchor point be the horizontal center of <var>B</var>'s bottom <a>border edge</a>.
-
-      Otherwise, if the anchor point of <var>A</var> lies on L3 or L4, or inside the
-      area bounded by L3 and L4 that also contains the points below <var>A</var>'s first
-      box's <a>margin box</a>, then let <var>B</var>'s anchor point be the horizontal center of
-      <var>B</var>'s top <a>border edge</a>.
-
-      Otherwise, if the anchor point of <var>A</var> lies inside the area bounded by L4
-      and L1 that also contains the points to the left of <var>A</var>'s first box's margin
-      box, then let <var>B</var>'s anchor point be the vertical center of <var>B</var>'s right <a>border edge</a>.
-
-      Otherwise, the anchor point of <var>A</var> lies inside the area bounded by L2 and
-      L3 that also contains the points to the right of <var>A</var>'s first box's margin
-      box; let <var>B</var>'s anchor point be the vertical center of <var>B</var>'s left <a>border edge</a>.
-
-      </dd><dt>If the computed value of 'anchor-point' is a specific point on both <var>A</var>
-      and <var>B</var>
-
-      </dt><dd>
-      The anchor points of <var>A</var> and <var>B</var> are the points given
-      by their respective 'anchor-point' properties.
-
-    </dd></dl>
-
-    <p class="note">
-    The rules above generally use <var>A</var>'s <em>margin</em> box, but
-    <var>B</var>'s <em>border</em> box. This is because while <var>A</var> always
-    has a <a>margin box</a>, and using the <a>margin box</a> allows for the dialog to be positioned offset from
-    the box it is annotating, <var>B</var> sometimes does not have a <a>margin box</a> (e.g., if it
-    is a table-cell), or has a <a>margin box</a> whose position may be not entirely clear (e.g., in the face
-    of <a>margin collapsing</a> and 'clear' handling of <a>in-flow</a> blocks).
-    </p>
-
-    In cases where <var>B</var> does not have a <a>border box</a> but its <a>border box</a> is used by
-    the algorithm above, user agents must use its first box's <a>content area</a> instead. (This is in
-    particular an issue with boxes in tables that have 'border-collapse' set to ''collapse''.)
-  </li>
-
-    <li>
-
-    When an element's 'position' property computes to '<dfn>absolute-anchored</dfn>', the 'float' property does not
-    apply and must compute to ''anchor-point/none'', the 'display' property must compute to a value as described by
-    the table in the section of CSS
-    2.1 describing the <cite>relationships between 'display', 'position', and 'float'</cite>,
-    and the element's box must be positioned using the rules for absolute positioning but with its
-    static position set such that if the box is positioned in its static position, its anchor point
-    is exactly aligned over the anchor point of the element to which it is <a>magically aligned</a>. Elements aligned in this way are <i>absolutely
-    positioned</i>. For the purposes of determining the <a>containing block</a> of other elements, the
-    '<a>absolute-anchored</a>' keyword must be treated
-    like the ''absolute'' keyword.
-
-    </li>
-
-  </ul>
 
   <p class="note">
     The trivial example of an element that does not have a rendered box is one whose


### PR DESCRIPTION
For fixing https://github.com/w3c/html/issues/1108 - No browser supports this, so removing it. CC'ing @chaals 

Signed-off-by: Shwetank Dixit <emailshwetank@gmail.com>