### PR TITLE
marking registerContentHandler and friends at risk

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -11,5 +11,5 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 
 <ul>
  <li>The <{autocapitalize}> attribute</li>
- <li>The <{registerContentHandler()}> method, and related methods like like <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
+ <li><{registerContentHandler()}>, <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
 </ul>

--- a/includes/status.include
+++ b/includes/status.include
@@ -1,4 +1,4 @@
-<p>This document is proposed to the Working Group as a First Public Working Draft for HTML 5.3, 
+<p>This document is proposed to the Working Group as a First Public Working Draft for HTML 5.3,
 reflecting the "leading edge" of what is interoperably deployed as HTML.</p>
 
 <p>Review is particularly requested on significant changes made to the specification,
@@ -11,5 +11,5 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 
 <ul>
  <li>The <{autocapitalize}> attribute</li>
+ <li>The <{registerContentHandler()}> method, and related methods like like <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
 </ul>
-


### PR DESCRIPTION
For https://github.com/w3c/html/issues/1106 , marking `registerContentHandler` and friends at risk. 