### PR TITLE
Fix discrepancies between HTML and ARIA in HTML specs

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -7,10 +7,12 @@
 
   <h3 id="changes-wd1">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a>
   <dl>
+    <dt><a href="https://github.com/w3c/html/pull/1133">Fix discrepancies between HTML and ARIA in HTML specs</a></dt>
+      <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/894">issue 894</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1093">Don't require XML srcdoc in XHTML</a></dt>
       <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/890">issue 890</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1123">Removing magic alignment for <code>dialog</code> element</a></dt>
-        <dd>Removed due to lack of implementation. Fixed <a href="https://github.com/w3c/html/issues/1108">issue 1108</a></dd>  
+        <dd>Removed due to lack of implementation. Fixed <a href="https://github.com/w3c/html/issues/1108">issue 1108</a></dd>
   </dl>
 
   <h3 id="changes-wd1">Changes between the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a> and

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -34,7 +34,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -108,7 +108,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -197,7 +197,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a>.</dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -340,7 +340,9 @@
       link; alternative style sheet set name.
     </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>link</code></a> (default - <a><em>do not set</em></a>)
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
@@ -780,7 +782,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -1539,7 +1541,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -477,7 +477,7 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -705,13 +705,28 @@
     <dd><code>referrerpolicy</code> - <a>Referrer policy</a> for <a>fetches</a> initiated by the element</dd>
     <dd><{img/longdesc}> - A url that provides a link to an expanded description of the image, defined in [[!html-longdesc]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>presentation</code></a> or <a attr-value for="aria/role"><code>none</code></a>
-	role only, for an <{img}> element whose <code>alt</code> attribute's value is empty (<code>alt=""</code>), otherwise
-    <a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
+    <dd>
+      If <{img}> has an empty <code>alt</code> attribute value:
+      <a attr-value for="aria/role"><code>presentation</code></a>
+      or
+      <a attr-value for="aria/role"><code>none</code></a>
+      role only.
+    </dd>
+    <dd>
+      If <{img}> has a non-empty <code>alt</code> attribute value:
+      <a attr-value for="aria/role"><code>img</code></a> (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">any other role value</a> <strong>except <code>presentation</code> or <code>none</code></strong> roles.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      If <{img}> has an empty <code>alt</code> attribute value: <strong>No <code>aria-*</code> attributes</strong> except <code>aria-hidden</code>.
+    </dd>
+    <dd>
+      If <{img}> has a non-empty <code>alt</code> attribute value:
+      <a>Global aria-* attributes</a> and any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -3601,11 +3616,20 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd><code>height</code> - Vertical dimension</dd>
     <dd><code>referrerpolicy</code> - <a>Referrer policy</a> for <a>fetches</a> initiated by the element</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>application</code></a>, <a attr-value for="aria/role"><code>document</code></a>, or <a attr-value for="aria/role"><code>img</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>application</code></a>,
+      <a attr-value for="aria/role"><code>document</code></a>
+      or
+      <a attr-value for="aria/role"><code>img</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -4151,14 +4175,22 @@ My &lt;img src="heart.png" alt="heart"&gt; breaks.
     <dd><code>height</code>- Vertical dimension</dd>
     <dd>Any other attribute that has no namespace (see prose).</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>application</code></a>,
-    <a attr-value for="aria/role"><code>document</code></a> or
-    <a attr-value for="aria/role"><code>img</code></a> or
-    <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>application</code></a>,
+      <a attr-value for="aria/role"><code>document</code></a>,
+      <a attr-value for="aria/role"><code>img</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>
+      or
+      <a attr-value for="aria/role"><code>presentation</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -4492,12 +4524,20 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>application</code></a>, <a attr-value for="aria/role"><code>document</code></a> or <a attr-value for="aria/role"><code>img</code></a> or
-    <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>application</code></a>,
+      <a attr-value for="aria/role"><code>document</code></a>
+      or
+      <a attr-value for="aria/role"><code>img</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -5110,7 +5150,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -5213,11 +5253,13 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>application</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>application</code></a>
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <a href="#allowed-aria-roles-states-and-properties">applicable to the <code>application</code> role</a>.</dd>
 
     <dt><a>DOM interface</a>:</dt>
     <dd>
@@ -5531,11 +5573,13 @@ zero or more <{track}> elements, then
     <dd><code>muted</code> - Whether to mute the <a>media resource</a> by default</dd>
     <dd><{audio/controls}> - Show user agent controls</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>application</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>application</code></a>
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <a href="#allowed-aria-roles-states-and-properties">applicable to the <code>application</code> role</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
     <pre class="idl" data-highlight="webidl">
@@ -5626,7 +5670,7 @@ zero or more <{track}> elements, then
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -11404,7 +11448,7 @@ red:89
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -11519,11 +11563,17 @@ red:89
     <dd><code>type</code> - Hint for the type of the referenced resource</dd>
     <dd><code>referrerpolicy</code> - <a>Referrer policy</a> for <a>fetches</a> initiated by the element</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>link</code></a> role (default - <a><em>do not set</em></a>).</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>link</code></a> role (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the <code>link</code> role</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -760,13 +760,20 @@
     <dd><{form/novalidate}> - Bypass form control validation for [[#forms-form-submission]]</dd>
     <dd><{form/target}> - <a>browsing context</a> for [[#forms-form-submission]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    dd><code>form</code>
-    (default - <a><em>do not set</em></a>),  <a attr-value for="aria/role"><code>search</code></a> or
-    <a attr-value for="aria/role"><code>presentation</code></a>.
+    <dd>
+      <a attr-value for="aria/role"><code>form</code></a> (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>
+      or
+      <a attr-value for="aria/role"><code>search</code></a>.
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -1115,7 +1122,9 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -1331,11 +1340,15 @@ part of the form.</p>
     <dd>Also, the <{input/title}> attribute has special semantics on this element
     when used in conjunction with the <{input/pattern}> attribute.</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>Depends upon <a>state of the <code>type</code> attribute</a>.</dd>
+    <dd>
+      Depends upon <a>state of the <code>type</code> attribute</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -2682,14 +2695,14 @@ part of the form.</p>
 
 <h6 id="hidden-state-typehidden"><dfn element-state for="input">Hidden</dfn> state (<code>type=hidden</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd>None</dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Hidden}> state, the rules in this section apply.
@@ -2762,16 +2775,23 @@ part of the form.</p>
 <h6 id="text-typetext-state-and-search-state-typesearch"><dfn element-state for="input">Text</dfn> (<code>type=text</code>) state and <dfn element-state for="input">Search</dfn> state (<code>type=search</code>)</h6>
 
     <div class="note">
-    <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>textbox</code></a>, <code>searchbox</code> with no <{input/list}> attribute
-    (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
-    <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).</dd>
-	<dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
-    </dl>
+      <dl>
+        <dt>[=Allowed ARIA role attribute values=]:</dt>
+        <dd>
+          <a attr-value for="aria/role"><code>textbox</code></a>,
+          <a attr-value for="aria/role"><code>searchbox</code></a> with no <{input/list}> attribute
+          (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
+          <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).
+        </dd>
+        <dt>[=Allowed ARIA state and property attributes=]:</dt>
+        <dd>
+          <a>Global aria-* attributes</a>
+        </dd>
+        <dd>
+          Any <code>aria-*</code> attributes
+          <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+        </dd>
+      </dl>
     </div>
 
   When an <{input}> element's <{input/type}> attribute is in
@@ -2798,14 +2818,12 @@ part of the form.</p>
   the following steps:
 
   <ol>
-
     <li>Set the element's <{global/dir}> attribute to "<a attr-value for="global/dir">ltr</a>"
     if the user selected a left-to-right writing direction, and
     "<a attr-value for="global/dir"><code>rtl</code></a>" if the user selected a right-to-left writing
     direction.</li>
 
     <li><a>Queue a task</a> to <a>fire a simple event</a> that bubbles named <code>input</code> at the <{input}> element.</li>
-
   </ol>
 
   The <code>value</code> attribute, if specified, must have a value that
@@ -2874,18 +2892,20 @@ part of the form.</p>
 
 <h6 id="telephone-state-typetel"><dfn element-state for="input">Telephone</dfn> state (<code>type=tel</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-     <dd><a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute
-    (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
-    <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).</dd>
-	<dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
+        <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Telephone}> state, the rules in this section apply.
@@ -2972,18 +2992,21 @@ part of the form.</p>
 
 <h6 id="url-state-typeurl"><dfn element-state for="input">URL</dfn> state (<code>type=url</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-     <dd><a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute
-    (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
-    <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).</dd>
-	<dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
+        <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/URL}> state, the rules in this section apply.
@@ -3106,18 +3129,21 @@ part of the form.</p>
 
 <h6 id="email-state-typeemail"><dfn element-state for="input">E-mail</dfn> state (<code>type=email</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-     <dd><a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute
-    (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
-    <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).</dd>
-	<dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>textbox</code></a> with no <{input/list}> attribute (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
+        <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
 
   When an <{input}> element's <{input/type}> attribute is in
@@ -3350,14 +3376,14 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="password-state-typepassword"><dfn element-state for="input">Password</dfn> state (<code>type=password</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a> and <code>aria-required</code></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <a>Password</a> state, the rules in this section
@@ -3437,14 +3463,14 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="date-state-typedate"><dfn element-state for="input">Date</dfn> state (<code>type=date</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Date}> state, the rules in this section apply.
@@ -3582,14 +3608,14 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="month-state-typemonth"><dfn element-state for="input">Month</dfn> state (<code>type=month</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <a>Month</a> state, the rules in this section apply.
@@ -3714,14 +3740,14 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="week-state-typeweek"><dfn element-state for="input">Week</dfn> state (<code>type=week</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <a>Week</a> state, the rules in this section apply.
@@ -3845,14 +3871,14 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="time-state-typetime"><dfn element-state for="input">Time</dfn> state (<code>type=time</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <a>Time</a> state, the rules in this section apply.
@@ -4140,17 +4166,21 @@ ldh-str       = let-dig / "-" ; defined in <a>RFC 1034 section 3.5</a>
 
 <h6 id="number-state-typenumber"><dfn element-state for="input">Number</dfn> state (<code>type=number</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>spinbutton</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>spinbutton</code></a>
+        (default - <a><em>do not set</em></a>).
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Number}> state, the rules in this section apply.
@@ -4512,14 +4542,14 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="color-state-typecolor"><dfn element-state for="input">Color</dfn> state (<code>type=color</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Color}> state, the rules in this section apply.
@@ -4530,7 +4560,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
   <p class="note">
     In this state, there is always a color picked, and there is no way to set the
-  value to the empty string.
+    value to the empty string.
   </p>
 
   If the element is <a>mutable</a>, the user agent should allow the
@@ -4612,18 +4642,25 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="checkbox-state-typecheckbox"><dfn element-state for="input">Checkbox</dfn> state (<code>type=checkbox</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>checkbox</code></a>
-    (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>option</code></a> or <a attr-value for="aria/role"><code>switch</code></a>.</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>checkbox</code></a> (default - <a><em>do not set</em></a>),
+        <a attr-value for="aria/role"><code>button</code></a> (when used in conjunction with <code>aria-pressed</code>),
+        <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+        <a attr-value for="aria/role"><code>option</code></a>
+        or
+        <a attr-value for="aria/role"><code>switch</code></a>.
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Checkbox}> state, the rules in this section
@@ -4723,17 +4760,22 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="radio-button-state-typeradio"><dfn element-state for="input" lt="Radio">Radio Button</dfn> state (<code>type=radio</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>radio</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>radio</code></a>
+        (default - <a><em>do not set</em></a>)
+        or
+        <a attr-value for="aria/role"><code>menuitemradio</code></a>
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Radio|Radio Button}> state, the rules in this section
@@ -4866,14 +4908,14 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="file-upload-state-typefile"><dfn element-state for="input" lt="File">File Upload</dfn> state (<code>type=file</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>None</dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/File|File Upload}> state, the rules in this section
@@ -5106,13 +5148,17 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
   <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>button</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>button</code></a>
+        (default - <a><em>do not set</em></a>).
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
   </div>
 
@@ -5208,19 +5254,28 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="image-button-state-typeimage"><dfn element-state for="input" lt="Image">Image Button</dfn> state (<code>type=image</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>button</code></a>
-    (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>link</code></a>,
-    or <a attr-value for="aria/role"><code>radio</code></a>.</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>button</code></a>
+        (default - <a><em>do not set</em></a>),
+        <a attr-value for="aria/role"><code>link</code></a>,
+        <a attr-value for="aria/role"><code>menuitem</code></a>,
+        <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+        <a attr-value for="aria/role"><code>menuitemradio</code></a>,
+        <a attr-value for="aria/role"><code>radio</code></a>
+        or
+        <a attr-value for="aria/role"><code>switch</code></a>.
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Image|Image Button}> state, the rules in this section
@@ -5458,17 +5513,21 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="reset-button-state-typereset"><dfn element-state for="input" lt="Reset">Reset Button</dfn> state (<code>type=reset</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>button</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>button</code></a>
+        (default - <a><em>do not set</em></a>).
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <{input/Reset|Reset Button}> state, the rules in this section
@@ -5552,20 +5611,29 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
 
 <h6 id="button-state-typebutton"><dfn element-state for="input">Button</dfn> state (<code>type=button</code>)</h6>
 
-    <div class="note">
+  <div class="note">
     <dl>
-    <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>button</code></a>
-    (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>link</code></a>,
-    <a attr-value for="aria/role"><code>radio</code></a> or
-    <a attr-value for="aria/role"><code>switch</code></a>.</dd>
-    <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+      <dt>[=Allowed ARIA role attribute values=]:</dt>
+      <dd>
+        <a attr-value for="aria/role"><code>button</code></a> (default - <a><em>do not set</em></a>),
+        <a attr-value for="aria/role"><code>link</code></a>,
+        <a attr-value for="aria/role"><code>menuitem</code></a>,
+        <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+        <a attr-value for="aria/role"><code>menuitemradio</code></a>,
+        <a attr-value for="aria/role"><code>option</code></a>,
+        <a attr-value for="aria/role"><code>radio</code></a>,
+        <a attr-value for="aria/role"><code>switch</code></a>,
+        or
+        <a attr-value for="aria/role"><code>tab</code></a>.
+      </dd>
+      <dt>[=Allowed ARIA state and property attributes=]:</dt>
+      <dd><a>Global aria-* attributes</a></dd>
+      <dd>
+        Any <code>aria-*</code> attributes
+        <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+      </dd>
     </dl>
-    </div>
+  </div>
 
   When an <{input}> element's <{input/type}> attribute is in
   the <a>Button</a> state, the rules in this section apply.
@@ -6876,15 +6944,30 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{button/type}> - Type of button</dd>
     <dd><{button/value}> - Value to be used for [[#forms-form-submission]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>button</code></a>
-    (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>link</code></a>,
-    <a attr-value for="aria/role"><code>radio</code></a> or
-    <a attr-value for="aria/role"><code>switch</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>button</code></a> (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>checkbox</code></a>,
+      <a attr-value for="aria/role"><code>link</code></a>,
+      <a attr-value for="aria/role"><code>menuitem</code></a>,
+      <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+      <a attr-value for="aria/role"><code>menuitemradio</code></a>,
+      <a attr-value for="aria/role"><code>option</code></a>,
+      <a attr-value for="aria/role"><code>radio</code></a>,
+      <a attr-value for="aria/role"><code>switch</code></a>
+      or
+      <a attr-value for="aria/role"><code>tab</code></a>.
+    </dd>
+    <dd>
+      If <code>button type=menu</code>:
+      <a attr-value for="aria/role"><code>button</code></a> (default - <a><em>do not set</em></a>)
+      or
+      <a attr-value for="aria/role"><code>menuitem</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -7060,11 +7143,22 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{select/required}> - Whether the control is required for [[#forms-form-submission]]</dd>
     <dd><{select/size}> - Size of the control</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>(with NO <code>multiple</code> attribute and NO <code>size</code> attribute having value greater than <code>1</code>) <a attr-value for="aria/role"><code>combobox</code></a> or (with a multiple attribute or a size attribute having value greater than 1)  <a attr-value for="aria/role"><code>listbox</code></a> otherwise None.</dd>
+    <dd>
+      With <strong>NO</strong> <code>multiple</code> or <code>size</code> attribute having value greater than <code>1</code>:
+      <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>)
+      or
+      <a attr-value for="aria/role"><code>menu</code></a>.
+    </dd>
+    <dd>
+      With a <code>multiple</code> or <code>size</code> attribute having a value greater than <code>1</code>:
+      <a attr-value for="aria/role"><code>listbox</code></a> (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -7541,12 +7635,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>listbox</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>listbox</code></a>
+      (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -7646,9 +7744,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{optgroup/disabled}> - Whether the form control is disabled</dd>
     <dd><{optgroup/label}> - User-visible label</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>group</code></a>
+      (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -7743,12 +7848,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{option/selected}> - Whether the option is selected by default</dd>
     <dd><{option/value}> - Value to be used for [[#forms-form-submission]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>option</code></a>
-    (default - <a><em>do not set</em></a>) or <a attr-value for="aria/role"><code>separator</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>option</code></a>
+      (default - <a><em>do not set</em></a>)
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -7948,12 +8057,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{textarea/rows}> - Number of lines to show</dd>
     <dd><{textarea/wrap}> - How the value of the form control is to be wrapped for [[#forms-form-submission]]</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>textbox</code></a> with the <{aria/aria-multiline}> property set to "true"
-    (default - <a><em>do not set</em></a>).</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>textbox</code></a> with the <{aria/aria-multiline}> property set to "true"
+      (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -8376,12 +8489,18 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{output/form}> - Associates the control with a <{form}> element</dd>
     <dd><{output/name}> - Name of form control to use for [[#forms-form-submission]] and in the {{HTMLFormElement/elements|form.elements}} API   </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>status</code></a>
-    (default - <a><em>do not set</em></a>), <a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>status</code></a>
+      (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">any role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -8556,12 +8675,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd><{progress/value}> - Current value of the element</dd>
     <dd><{progress/max}> - Upper bound of range</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>progressbar</code></a>
-    (default - <a><em>do not set</em></a>).</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>progressbar</code></a>
+      (default - <a><em>do not set</em></a>).
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -9101,12 +9224,18 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <dd><{fieldset/form}> - Associates the control with a <{form}> element</dd>
     <dd><{fieldset/name}> - Name of form control to use for [[#forms-form-submission]] and in the {{HTMLFormElement/elements|form.elements}} API  </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>group</code></a>
-    or <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>
+      or
+      <a attr-value for="aria/role"><code>presentation</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -289,6 +289,12 @@
         interface HTMLHRElement : HTMLElement {};
       </pre>
     </dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagebreak"><code>doc-pagebreak</code></a>
+    </dd>
   </dl>
 
   The <{hr}> element <a>represents</a> a <a>paragraph</a>-level thematic break, e.g., a
@@ -1107,6 +1113,14 @@
         };
       </pre>
     </dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioentry"><code>doc-biblioentry</code></a>
+      or
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnote"><code>doc-endnote</code></a>
+    </dd>
   </dl>
 
   The <{li}> element <a>represents</a> a list item. If its parent element is an
@@ -1217,6 +1231,12 @@
       <pre class="idl" data-highlight="webidl">
         interface HTMLDListElement : HTMLElement {};
       </pre>
+    </dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary"><code>doc-glossary</code></a>
     </dd>
   </dl>
 

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -189,7 +189,7 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>group</code></a> role (default - <a><em>do not set</em></a>)</dd>
+    <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">
@@ -787,8 +787,17 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>,
-      <a attr-value for="aria/role"><code>radiogroup</code></a>, <a attr-value for="aria/role"><code>tablist</code></a>, <a attr-value for="aria/role"><code>toolbar</code></a> or
+      <a attr-value for="aria/role"><code>directory</code></a>,
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>listbox</code></a>,
+      <a attr-value for="aria/role"><code>menu</code></a>,
+      <a attr-value for="aria/role"><code>menubar</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>radiogroup</code></a>,
+      <a attr-value for="aria/role"><code>tablist</code></a>,
+      <a attr-value for="aria/role"><code>toolbar</code></a>
+      or
       <a attr-value for="aria/role"><code>tree</code></a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
@@ -993,8 +1002,18 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>directory</code></a>, <a attr-value for="aria/role"><code>group</code></a>, <a attr-value for="aria/role"><code>listbox</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>menubar</code></a>, <a attr-value for="aria/role"><code>radiogroup</code></a>, <a attr-value for="aria/role"><code>tablist</code></a>, <a attr-value for="aria/role"><code>toolbar</code></a> or
-      <a attr-value for="aria/role"><code>tree</code></a>.</dd>
+      <a attr-value for="aria/role"><code>directory</code></a>,
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>listbox</code></a>,
+      <a attr-value for="aria/role"><code>menu</code></a>,
+      <a attr-value for="aria/role"><code>menubar</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>radiogroup</code></a>,
+      <a attr-value for="aria/role"><code>tablist</code></a>,
+      <a attr-value for="aria/role"><code>toolbar</code></a>
+      or
+      <a attr-value for="aria/role"><code>tree</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
@@ -1064,8 +1083,18 @@
     <dd>If the element is not a child of an <{ul}>: <code>value</code></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>), <a attr-value for="aria/role"><code>option</code></a>, <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>radio</code></a>,
-      <a attr-value for="aria/role"><code>separator</code></a>, <a attr-value for="aria/role"><code>tab</code></a> or  <a attr-value for="aria/role"><code>treeitem</code></a>.
+      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>menuitem</code></a>,
+      <a attr-value for="aria/role"><code>menuitemcheckbox</code></a>,
+      <a attr-value for="aria/role"><code>menuitemradio</code></a>,
+      <a attr-value for="aria/role"><code>option</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>radio</code></a>,
+      <a attr-value for="aria/role"><code>separator</code></a>,
+      <a attr-value for="aria/role"><code>tab</code></a>
+      or
+      <a attr-value for="aria/role"><code>treeitem</code></a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -1176,7 +1205,10 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>group</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>
+      or
+      <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
@@ -1285,11 +1317,12 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd> None.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>)
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    None</dd>
+    <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
@@ -1341,7 +1374,9 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd>None</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>definition</code></a> role (default - <a><em>do not set</em></a>)
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1384,8 +1419,13 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><code>figure</code> role (default - <a><em>do not set</em></a>),
-    <a attr-value for="aria/role"><code>group</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>figure</code></a> role (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>
+      or
+      <a attr-value for="aria/role"><code>presentation</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1572,7 +1612,11 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>group</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a> or
+      <a attr-value for="aria/role"><code>presentation</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1600,13 +1644,12 @@
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>main</code></a> role (default - <a><em>do not set</em></a>) or
-      <a attr-value for="aria/role"><code>presentation</code></a>.
+      <a attr-value for="aria/role"><code>main</code></a> role (default - <a><em>do not set</em></a>).
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses <code>HTMLElement</code></dd>
   </dl>
@@ -2002,7 +2045,9 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
+    <dd>
+      <a href="#allowed-aria-roles-states-and-properties">Any role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -20,7 +20,9 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>open</code> - Whether the details are visible</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>group</code></a> role (default - <a><em>do not set</em></a>)</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>group</code></a> role (default - <a><em>do not set</em></a>)
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -183,9 +185,13 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a attr-value for="aria/role"><code>button</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      <a>Global aria-* attributes</a>
+    </dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the <code>button</code> role</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
@@ -436,13 +442,18 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>open</code> - Whether the dialog box is showing</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><a attr-value for="aria/role"><code>dialog</code></a>
-    (default - <a><em>do not set</em></a>) or
-    <a attr-value for="aria/role"><code>alertdialog</code></a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>dialog</code></a>
+      (default - <a><em>do not set</em></a>)
+      or
+      <a attr-value for="aria/role"><code>alertdialog</code></a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the <code>dialog</code> roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -1101,7 +1101,7 @@ o............A....e
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -132,9 +132,14 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>article</code></a> (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>application</code></a>, <a attr-value for="aria/role"><code>document</code></a>
-      <code>feed</code>, <a attr-value for="aria/role"><code>main</code></a> or 
-     <a attr-value for="aria/role"><code>region</code></a>.
+      <a attr-value for="aria/role"><code>application</code></a>,
+      <a attr-value for="aria/role"><code>document</code></a>,
+      <a attr-value for="aria/role"><code>feed</code></a>,
+      <a attr-value for="aria/role"><code>main</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>
+      or
+      <a attr-value for="aria/role"><code>region</code></a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -261,14 +266,25 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>region</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>alert</code></a>, <a attr-value for="aria/role"><code>alertdialog</code></a>, 
-      <a attr-value for="aria/role"><code>application</code></a>, <a attr-value for="aria/role"><code>contentinfo</code></a>
-    , <a attr-value for="aria/role"><code>dialog</code></a>, <a attr-value for="aria/role"><code>document</code></a>,
-      <code>feed</code>, <a attr-value for="aria/role"><code>log</code></a>, 
-      <a attr-value for="aria/role"><code>main</code></a>, <a attr-value for="aria/role"><code>marquee</code></a>,
-      <a attr-value for="aria/role"><code>presentation</code></a>, <a attr-value for="aria/role"><code>region</code></a>,
-     <a attr-value for="aria/role"><code>search</code></a>, <a attr-value for="aria/role"><code>status</code></a> or
-     <a attr-value for="aria/role"><code>tabpanel</code></a>.
+      <a attr-value for="aria/role"><code>alert</code></a>,
+      <a attr-value for="aria/role"><code>alertdialog</code></a>,
+      <a attr-value for="aria/role"><code>application</code></a>,
+      <a attr-value for="aria/role"><code>banner</code></a>,
+      <a attr-value for="aria/role"><code>complementary</code></a>,
+      <a attr-value for="aria/role"><code>contentinfo</code></a>,
+      <a attr-value for="aria/role"><code>dialog</code></a>,
+      <a attr-value for="aria/role"><code>document</code></a>,
+      <a attr-value for="aria/role"><code>feed</code></a>,
+      <a attr-value for="aria/role"><code>log</code></a>,
+      <a attr-value for="aria/role"><code>main</code></a>,
+      <a attr-value for="aria/role"><code>marquee</code></a>,
+      <a attr-value for="aria/role"><code>navigation</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>search</code></a>,
+      <a attr-value for="aria/role"><code>status</code></a>
+      or
+      <a attr-value for="aria/role"><code>tabpanel</code></a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -662,8 +678,13 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>complementary</code></a> role (default - <a><em>do not set</em></a>),
-      <code>feed</code>, <a attr-value for="aria/role"><code>note</code></a>, 
-      <a attr-value for="aria/role"><code>search</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.
+      <a attr-value for="aria/role"><code>feed</code></a>,
+      <a attr-value for="aria/role"><code>note</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>region</code></a>
+      or
+      <a attr-value for="aria/role"><code>search</code></a>
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -830,7 +851,10 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>heading</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>tab</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.
+      <a attr-value for="aria/role"><code>none</code></a>,
+      <a attr-value for="aria/role"><code>presentation</code></a>
+      or
+      <a attr-value for="aria/role"><code>tab</code></a>
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -950,7 +974,10 @@
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>banner</code></a> role (default - <a><em>do not set</em></a>),
-      <a attr-value for="aria/role"><code>group</code></a> or <a attr-value for="aria/role"><code>presentation</code></a>.
+      <a attr-value for="aria/role"><code>group</code></a>,
+      <a attr-value for="aria/role"><code>none</code></a>
+      or
+      <a attr-value for="aria/role"><code>presentation</code></a>
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
@@ -1102,7 +1129,8 @@
     
     : [=Allowed ARIA role attribute values=]:
     :: <a attr-value for="aria/role"><code>contentinfo</code></a> role (default - <a><em>do not set</em></a>),
-        <a attr-value for="aria/role"><code>group</code></a> or 
+        <a attr-value for="aria/role"><code>group</code></a>,
+        <a attr-value for="aria/role"><code>none</code></a> or
         <a attr-value for="aria/role"><code>presentation</code></a>.
     
     : [=Allowed ARIA state and property attributes=]:

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -292,6 +292,38 @@
     applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-abstract"><code>doc-abstract</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-acknowledgments"><code>doc-acknowledgments</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-afterword"><code>doc-afterword</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-appendix"><code>doc-appendix</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-bibliography"><code>doc-bibliography</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-chapter"><code>doc-chapter</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-colophon"><code>doc-colophon</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-conclusion"><code>doc-conclusion</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credit"><code>doc-credit</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credits"><code>doc-credits</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication"><code>doc-dedication</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes"><code>doc-endnotes</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epilogue"><code>doc-epilogue</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-errata"><code>doc-errata</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-example"><code>doc-example</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-foreword"><code>doc-foreword</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index"><code>doc-index</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-introduction"><code>doc-introduction</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-notice"><code>doc-notice</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist"><code>doc-pagelist</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-part"><code>doc-part</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-preface"><code>doc-preface</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-prologue"><code>doc-prologue</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote"><code>doc-pullquote</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-qna"><code>doc-qna</code></a>
+      or
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc"><code>doc-toc</code></a>
+    </dd>
   </dl>
 
   The <a element>section</a> element <a>represents</a> a generic section of a document or application.
@@ -480,6 +512,15 @@
     applicable to the default role</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index"><code>doc-index</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist"><code>doc-pagelist</code></a>
+      or
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc"><code>doc-toc</code></a>
+    </dd>
   </dl>
 
   The <{nav}> element <a>represents</a> a section of a page that links to other pages or to
@@ -691,6 +732,16 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-example"><code>doc-example</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote"><code>doc-footnote</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote"><code>doc-pullquote</code></a>
+      or
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-tip"><code>doc-tip</code></a>
+    </dd>
   </dl>
 
   The <{aside}> element <a>represents</a> a section of a page that consists of content that
@@ -866,6 +917,12 @@
         interface HTMLHeadingElement : HTMLElement {};
       </pre>
     </dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-subtitle"><code>doc-subtitle</code></a>
+    </dd>
   </dl>
 
   These elements <a>represent</a> headings for their sections.
@@ -984,6 +1041,12 @@
     <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote"><code>doc-footnote</code></a>
+    </dd>
   </dl>
 
   The <{header}> element <a>represents</a> introductory content for its nearest ancestor <{main}> 
@@ -1140,6 +1203,9 @@
         
     : [=DOM interface=]:
     :: Uses {{HTMLElement}}.
+        
+    : DPub Roles:
+    :: <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote"><code>doc-footnote</code></a>
   </dl>
 
   The <{footer}> element <a>represents</a> a footer for its nearest ancestor <{main}> 

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -22,8 +22,11 @@
     <dd><a>Global attributes</a></dd>
     <dd><code>border</code></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
-    <dd><code>table</code> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>table</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -117,9 +120,11 @@
   <table>
     <thead>
     <tr>
-      <th>Feature
-      </th><th>Indication
-    </th></tr></thead><tbody>
+      <th>Feature</th>
+      <th>Indication</th>
+    </tr>
+    </thead>
+    <tbody>
     <tr>
       <td>The use of the <code>role</code> attribute with the value <code>presentation</code>
       </td><td>Probably a layout table
@@ -147,7 +152,9 @@
     <tr>
       <td>The use of the non-conforming <code>summary</code> attribute
       </td><td>Not a good indicator (both layout and non-layout tables have historically been given this attribute)
-  </td></tr></tbody></table>
+  </td></tr>
+  </tbody>
+  </table>
 
   <p class="note">
     It is quite possible that the above suggestions are wrong. Implementors are urged
@@ -705,7 +712,7 @@ the cell that corresponds to the values of the two dice.
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -748,7 +755,7 @@ the cell that corresponds to the values of the two dice.
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
+    <dd>None</dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
     {{HTMLTableColElement}}, same as for <{colgroup}> elements. This interface defines one member,
@@ -794,8 +801,12 @@ the cell that corresponds to the values of the two dice.
   <{tfoot}> element, or if there is no more content in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dt>[=Allowed ARIA role attribute values=]:</dt>
+    <dd>
+      <a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -911,8 +922,11 @@ the cell that corresponds to the values of the two dice.
   <{tfoot}> element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -978,8 +992,11 @@ the cell that corresponds to the values of the two dice.
   there is no more content in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dd>
+      <a attr-value for="aria/role"><code>rowgroup</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1015,8 +1032,12 @@ the cell that corresponds to the values of the two dice.
   no more content in the parent element.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><a attr-value for="aria/role"><code>row</code></a> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dt>[=Allowed ARIA role attribute values=]:</dt>
+    <dd>
+      <a attr-value for="aria/role"><code>row</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1164,8 +1185,12 @@ the cell that corresponds to the values of the two dice.
     <dd><code>colspan</code> - Number of columns that the cell is to span</dd>
     <dd><code>rowspan</code> - Number of rows that the cell is to span</dd>
     <dd><code>headers</code> - The header cells for this cell</dd>
-    <dd><code>cell</code> role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dt>[=Allowed ARIA role attribute values=]:</dt>
+    <dd>
+      <a attr-value for="aria/role"><code>cell</code></a> role (default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.
+    </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes
@@ -1214,9 +1239,12 @@ the cell that corresponds to the values of the two dice.
     <dd><code>scope</code> - Specifies which cells the header cell applies to</dd>
     <dd><code>abbr</code> - Alternative label to use for the header cell when
     referencing the cell in other contexts</dd>
-    <dd><a attr-value for="aria/role"><code>columnheader</code></a> or <a attr-value for="aria/role"><code>rowheader</code></a>
-    role (default - <a><em>do not set</em></a>),
-    <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
+    <dt>[=Allowed ARIA role attribute values=]:</dt>
+    <dd>
+      <a attr-value for="aria/role"><code>columnheader</code></a>,
+      <a attr-value for="aria/role"><code>rowheader</code></a> role (each are default - <a><em>do not set</em></a>)
+      or
+      <a href="#allowed-aria-roles-states-and-properties">Any other role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
     <dd>Any <code>aria-*</code> attributes

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -34,10 +34,23 @@
     <dd><code>referrerpolicy</code> - <a>Referrer policy</a> for <a>fetches</a> initiated by the element</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>link</code></a> (default - <a><em>do not set</em></a>), <a attr-value for="aria/role"><code>button</code></a>,
+      If <{a/href}> is set:
+      <a attr-value for="aria/role"><code>link</code></a> (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>button</code></a>,
       <a attr-value for="aria/role"><code>checkbox</code></a>,
-      <a attr-value for="aria/role"><code>radio</code></a>, <a attr-value for="aria/role"><code>switch</code></a>,
-      <a attr-value for="aria/role"><code>tab</code></a> or <a attr-value for="aria/role"><code>treeitem</code></a>
+      <a attr-value for="aria/role"><code>menuitem</code></a>,
+      <a attr-value for="aria/role"><code>menucheckbox</code></a>,
+      <a attr-value for="aria/role"><code>menuradio</code></a>,
+      <a attr-value for="aria/role"><code>option</code></a>,
+      <a attr-value for="aria/role"><code>radio</code></a>,
+      <a attr-value for="aria/role"><code>switch</code></a>,
+      <a attr-value for="aria/role"><code>tab</code></a>
+      or
+      <a attr-value for="aria/role"><code>treeitem</code></a>
+    </dd>
+    <dd>
+      If no <{a/href}> is set:
+      <a href="#allowed-aria-roles-states-and-properties">Any role value</a>.
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -73,6 +73,16 @@
         HTMLAnchorElement implements HTMLHyperlinkElementUtils;
       </pre>
     </dd>
+    <dt>
+      DPub Roles:
+    </dt>
+    <dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink"><code>doc-backlink</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioref"><code>doc-biblioref</code></a>,
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossref"><code>doc-glossref</code></a>
+      or
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-noteref"><code>doc-noteref</code></a>
+    </dd>
   </dl>
 
   If the <{a}> element has an <{a/href}> attribute, then it <a>represents</a> a


### PR DESCRIPTION
Based on [issue 894](https://github.com/w3c/html/issues/894), I've reviewed each of the HTML elements and their allowed ARIA `role`s & `aria-*` attributes and have made multiple updates to align the HTML spec with the information provided in the latest editor's draft of [ARIA in HTML](https://w3c.github.io/html-aria/#allowed-aria-roles-states-and-properties).