### PR TITLE
Fix output of entities table

### DIFF
--- a/includes/entities.include
+++ b/includes/entities.include
@@ -402,7 +402,7 @@
     <tr id="entity-DiacriticalAcute"> <td> <code>DiacriticalAcute;</code> </td> <td> U+000B4 </td> <td> <span class="glyph">´</span> </td> </tr>
     <tr id="entity-DiacriticalDot"> <td> <code>DiacriticalDot;</code> </td> <td> U+002D9 </td> <td> <span class="glyph">˙</span> </td> </tr>
     <tr id="entity-DiacriticalDoubleAcute"> <td> <code>DiacriticalDoubleAcute;</code> </td> <td> U+002DD </td> <td> <span class="glyph">˝</span> </td> </tr>
-    <tr id="entity-DiacriticalGrave"> <td> <code>DiacriticalGrave;</code> </td> <td> U+00060 </td> <td> <span class="glyph">`</span> </td> </tr>
+    <tr id="entity-DiacriticalGrave"> <td> <code>DiacriticalGrave;</code> </td> <td> U+00060 </td> <td> <span class="glyph">\`<!-- backslash prevents bikeshed from interpreting the character --></span> </td> </tr>
     <tr id="entity-DiacriticalTilde"> <td> <code>DiacriticalTilde;</code> </td> <td> U+002DC </td> <td> <span class="glyph">˜</span> </td> </tr>
     <tr id="entity-diam"> <td> <code>diam;</code> </td> <td> U+022C4 </td> <td> <span class="glyph">⋄</span> </td> </tr>
     <tr id="entity-Diamond"> <td> <code>Diamond;</code> </td> <td> U+022C4 </td> <td> <span class="glyph">⋄</span> </td> </tr>
@@ -680,7 +680,7 @@
     <tr id="entity-gnsim"> <td> <code>gnsim;</code> </td> <td> U+022E7 </td> <td> <span class="glyph">⋧</span> </td> </tr>
     <tr id="entity-Gopf"> <td> <code>Gopf;</code> </td> <td> U+1D53E </td> <td> <span class="glyph">𝔾</span> </td> </tr>
     <tr id="entity-gopf"> <td> <code>gopf;</code> </td> <td> U+1D558 </td> <td> <span class="glyph">𝕘</span> </td> </tr>
-    <tr id="entity-grave"> <td> <code>grave;</code> </td> <td> U+00060 </td> <td> <span class="glyph">`</span> </td> </tr>
+    <tr id="entity-grave"> <td> <code>grave;</code> </td> <td> U+00060 </td> <td> <span class="glyph">\`<!-- backslash prevents bikeshed from interpreting the character --></span> </td> </tr>
     <tr id="entity-GreaterEqual"> <td> <code>GreaterEqual;</code> </td> <td> U+02265 </td> <td> <span class="glyph">≥</span> </td> </tr>
     <tr id="entity-GreaterEqualLess"> <td> <code>GreaterEqualLess;</code> </td> <td> U+022DB </td> <td> <span class="glyph">⋛</span> </td> </tr>
     <tr id="entity-GreaterFullEqual"> <td> <code>GreaterFullEqual;</code> </td> <td> U+02267 </td> <td> <span class="glyph">≧</span> </td> </tr>

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -66,6 +66,7 @@
   Tomer Cohen,
   "Unor", <!-- https://github.com/unor-->
   Travis Leithead,
+  Wolfgang Illmeyer,
   and Yves Lafon
   
   Likewise this specification incorporates work of the <a href="">Web Performance Working Group</a>.


### PR DESCRIPTION
The table in "§8.5. Named character references" was missing
all entities after "DiacriticalGrave;" and before "GreaterEqual;"
because bikeshed interprets the literal ` in the html file
and returns everything in between them as inline-code,
which also made the table extremely wide.

addresses #1136