### PR TITLE
Updates end tag omission for multiple elements

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -54,7 +54,7 @@
   The <{table}> element <a>represents</a> data with more than one dimension, in
   the form of a <a>table</a>.
 
-  The <{table}> element takes part in the <a>table model</a>. 
+  The <{table}> element takes part in the <a>table model</a>.
   Tables have rows, columns, and cells given by their descendants. The rows and
   columns form a grid; a table's cells must completely cover that grid without overlap.
 
@@ -608,7 +608,7 @@ side in the right column.&lt;/p&gt;
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>, but with no descendant <{table}> elements.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
+    <dd>A <{caption}> element's end tag may be omitted if the <{caption}> element is not immediately followed by a <a>space character</a> or a <a>comment</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
@@ -698,7 +698,7 @@ the cell that corresponds to the values of the two dice.
     <dd>A <{colgroup}> element's [=start tag=] may be omitted if the first thing inside the <{colgroup}>
     element is a <{col}> element, and if the element is not immediately preceded by another
     <{colgroup}> element whose [=end tag=] has been omitted. (It can't be omitted if the element is
-    empty.)</dd>
+    empty). A <{colgroup}> element's <a>end tag</a> may be omitted if the <{colgroup}> element is not immediately followed by a <a>space character</a> or a <a>comment</a></dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd><code>span</code> - Number of columns spanned by the element</dd>
@@ -1371,7 +1371,7 @@ the cell that corresponds to the values of the two dice.
   <hr />
 
   The <{td}> and <{th}> element may have a <dfn element-attr for="tablecells"><code>headers</code></dfn>
-  content attribute specified. The <code>headers</code> attribute, if specified, 
+  content attribute specified. The <code>headers</code> attribute, if specified,
   must contain a string consisting of an <a>unordered set of unique space-separated tokens</a> that are
   <a>case-sensitive</a>, each of which must have the value of an <{global/id}> of a <{th}> element
   taking part in the same <a>table</a> as the <{td}> or <{th}> element (as defined by the <a>table model</a>).

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -537,10 +537,12 @@
     </pre>
   </div>
 
-  An <{rt}> element's <a>end tag</a> may be omitted if the <{rt}> element is immediately followed by an <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
+  An <{rb}> element's <a>end tag</a> may be omitted if the <{rb}> element is immediately followed by an <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
 
-  An <{rp}> element's <a>end tag</a> may be omitted if the <{rp}> element is immediately followed by an
+    An <{rp}> element's <a>end tag</a> may be omitted if the <{rp}> element is immediately followed by an
   <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
+
+  An <{rt}> element's <a>end tag</a> may be omitted if the <{rt}> element is immediately followed by an <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
 
   An <{rtc}> element's <a>end tag</a> may be omitted if the <{rtc}> element is immediately followed by an <{rb}> or <{rtc}> element, or if there is no more content in the parent element.
 

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -537,11 +537,12 @@
     </pre>
   </div>
 
-  An <{rt}> element's [=end tag=] may be omitted if the <{rt}> element is immediately followed by an
-  <{rt}> or <{rp}> element, or if there is no more content in the parent element.
+  An <{rt}> element's <a>end tag</a> may be omitted if the <{rt}> element is immediately followed by an <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
 
-  An <{rp}> element's [=end tag=] may be omitted if the <{rp}> element is immediately followed by an
-  <{rt}> or <{rp}> element, or if there is no more content in the parent element.
+  An <{rp}> element's <a>end tag</a> may be omitted if the <{rp}> element is immediately followed by an
+  <{rb}>, <{rt}>, <{rtc}> or <{rp}> element, or if there is no more content in the parent element.
+
+  An <{rtc}> element's <a>end tag</a> may be omitted if the <{rtc}> element is immediately followed by an <{rb}> or <{rtc}> element, or if there is no more content in the parent element.
 
   An <{optgroup}> element's [=end tag=] may be omitted if the <{optgroup}> element  is immediately
   followed by another <{optgroup}> element, or if  there is no more content in the parent element.


### PR DESCRIPTION
* Updates/adds end tag omission information for the ```<rb>```, ```<rp>```, ```<rt>```, and ```<rtc>``` elements in the [Optional tags](http://w3c.github.io/html/syntax.html#optional-tags) section.
* Updates element definitions for ```<caption>``` and ```<colgroup>``` to match element end tag omission info from the [Optional tags](http://w3c.github.io/html/syntax.html#optional-tags) section.
* Behaviour verified with the W3C validator.

Fixes #922 
