### PR TITLE
Minor update to paragraph definition

### DIFF
--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1276,7 +1276,7 @@
   A <dfn lt="paragraph|paragraphs|implied paragraph|paragraphing|implied|implied paragraphs">paragraph</dfn>
   is typically a run of [=phrasing content=] that forms a block of text with one or more sentences
   that discuss a particular topic, as in typography, but can also be used for more general thematic
-  grouping. For instance, an address is also a paragraph, as is a part of a form, a byline, or a
+  grouping. For instance, an address is also a paragraph, as is a a byline, or a
   stanza in a poem.
 
   <div class="example">

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -49,21 +49,11 @@
 
   <div class="example">
     The following examples are conforming HTML fragments:
+
     <pre highlight="html">
       &lt;p&gt;The little kitten gently seated itself on a piece of
       carpet. Later in his life, this would be referred to as the time the
       cat sat on the mat.&lt;/p&gt;
-    </pre>
-
-    <pre highlight="html">
-      &lt;fieldset&gt;
-        &lt;legend&gt;Personal information&lt;/legend&gt;
-        &lt;p&gt;
-          &lt;label&gt;Name: &lt;input name="n"&gt;&lt;/label&gt;
-          &lt;label&gt;&lt;input name="anon" type="checkbox"&gt; Hide from other users&lt;/label&gt;
-        &lt;/p&gt;
-        &lt;p&gt;&lt;label&gt;Address: &lt;textarea name="a"&gt;&lt;/textarea&gt;&lt;/label&gt;&lt;/p&gt;
-      &lt;/fieldset&gt;
     </pre>
 
     <pre highlight="html">


### PR DESCRIPTION
* Removes suggestion to use p inside form elements
* Removes example that uses p elements to group label and input elements inside a form
* Fixes #558