### PR TITLE
Clarify option/optgroup can be disabled

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -11,6 +11,7 @@
   Arron Eicholz,
   Dan Connolly,
   Dave Raggett, 
+  "Devarshipant", <!-- github -->
   Erika Navara Doyle,
   Ian Hickson,
   Ian Jacobs,

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9752,7 +9752,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
 <h5 id="enabling-and-disabling-form-controls-the-disabled-attribute">Enabling and disabling form controls: the <code>disabled</code> attribute</h5>
 
-  The <dfn element-attr for="disabledformelements,input,button,select,textarea"><code>disabled</code></dfn> content attribute is a
+  The <dfn element-attr for="disabledformelements,input,button,option, optgroup,select,textarea"><code>disabled</code></dfn> content attribute is a
   <a>boolean attribute</a>.
 
   A form control is disabled if any of the following
@@ -9760,7 +9760,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <ol>
 
-    <li>The element is a <{button}>, <{input}>, <{select}>, or
+    <li>The element is a <{button}>, <{input}>, <option>, <{optgroup}>, <{select}>, or
     <{textarea}> element, and the <code>disabled</code> attribute
     is specified on this element (regardless of its value).</li>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9764,6 +9764,9 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <{textarea}> element, and the <code>disabled</code> attribute
     is specified on this element (regardless of its value).</li>
     
+    <!-- Note. option/disabled and optgroup/disabled are defined in the relevant element descriptions.
+    That is repeated here for clarity -->
+    
     <li>The element is an <{option}> element that is a child of an 
     <{optgroup}> element that has the <{optgroup/disabled}> attribute specified.</li>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9760,9 +9760,12 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
   <ol>
 
-    <li>The element is a <{button}>, <{input}>, <option>, <{optgroup}>, <{select}>, or
+    <li>The element is a <{button}>, <{input}>, <{option}>, <{select}>, or
     <{textarea}> element, and the <code>disabled</code> attribute
     is specified on this element (regardless of its value).</li>
+    
+    <li>The element is an <{option}> element that is a child of an 
+    <{optgroup}> element that has the <{optgroup/disabled}> attribute specified.</li>
 
     <li>The element is a descendant of a <{fieldset}> element whose <code>disabled</code> attribute is specified, and is <em>not</em> a
     descendant of that <{fieldset}> element's first <{legend}> element child, if

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9752,7 +9752,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
 
 <h5 id="enabling-and-disabling-form-controls-the-disabled-attribute">Enabling and disabling form controls: the <code>disabled</code> attribute</h5>
 
-  The <dfn element-attr for="disabledformelements,input,button,option, optgroup,select,textarea"><code>disabled</code></dfn> content attribute is a
+  The <dfn element-attr for="disabledformelements,input,button,select,textarea"><code>disabled</code></dfn> content attribute is a
   <a>boolean attribute</a>.
 
   A form control is disabled if any of the following


### PR DESCRIPTION
Fix #1138

`option` and `optgroup` can be disabled. A [manual test](http://chaals.github.io/testcases/optgroup-disabled-manual.html)  works in Edge, Firefox, Opera (blink)