### PR TITLE
Shwetank issue1104 remove anchor point

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,6 +13,8 @@
       <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/890">issue 890</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1123">Removing magic alignment for <code>dialog</code> element</a></dt>
         <dd>Removed due to lack of implementation. Fixed <a href="https://github.com/w3c/html/issues/1108">issue 1108</a></dd>
+    <dt><a href="https://github.com/w3c/html/pull/1152">Removed section on <code>anchor-points</code></a></dt>
+            <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/1104">issue 1104</a></dd>
   </dl>
 
   <h3 id="changes-wd1">Changes between the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a> and

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -768,12 +768,6 @@
   </ol>
 
   <p class="note">
-    The trivial example of an element that does not have a rendered box is one whose
-  'display' property computes to ''anchor-point/none''. However, there are many other cases; e.g., table columns do
-  not have boxes (their properties merely affect other boxes).
-  </p>
-
-  <p class="note">
     If an element to which another element is anchored changes rendering, the anchored
   element will be repositioned accordingly. (In other words, the requirements above are live,
   they are not just calculated once per anchored element.)

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -795,35 +795,3 @@
   The <dfn attribute for="HTMLDialogElement"><code>open</code></dfn> IDL attribute must
   <a>reflect</a> the <code>open</code> content attribute.
 
-
-
-<h5 id="anchor-points">Anchor points</h5>
-
-  <p class="critical">This section will eventually be moved to a CSS specification; it is specified
-  here only on an interim basis until an editor can be found to own this.</p>
-
-<pre class="propdef">
-Name: anchor-point
-Value: [ none | &lt;position&gt; ]
-Initial: none
-Applies To: all elements
-Inherited: no
-Percentages: refer to width or height of box; see prose
-Computed Value: The <a>specified value</a>, but with any lengths replaced by their corresponding absolute length
-Media: visual
-Animatable: no
-Canonical Order: per grammar
-</pre>
-
-  The 'anchor-point' property specifies a point to which dialog boxes are to be aligned.
-
-  If the value is a <dfn value for="anchor-point">&lt;position&gt;</dfn>, the anchor point is the point given by the value, which
-  must be interpreted relative to the element's first rendered box's <a>margin box</a>. Percentages must be
-  calculated relative to the element's first rendered box's <a>margin box</a> (specifically, its width for
-  the horizontal position and its height for the vertical position). [[!CSS-VALUES]] [[!CSS-2015]]
-
-  If the value is the keyword <dfn value for="anchor-point">none</dfn>, then no explicit anchor point is defined. The user agent
-  will pick an anchor point automatically if necessary (as described in the definition of the
-  <code>open()</code> method above).
-
-</section>


### PR DESCRIPTION
Removed portion related to anchor-point as referred to in [issue 1104](https://github.com/w3c/html/issues/1104)

Pinging @chaals for review. 