### PR TITLE
Allow multiple meta name="description"

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -1,4 +1,4 @@
-<p>This document is proposed to the Working Group as a First Public Working Draft for HTML 5.3,
+<p>This document is proposed to the Working Group as a Public Working Draft for HTML 5.3,
 reflecting the "leading edge" of what is interoperably deployed as HTML.</p>
 
 <p>Review is particularly requested on significant changes made to the specification,
@@ -12,4 +12,10 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 <ul>
  <li>The <{autocapitalize}> attribute</li>
  <li><{registerContentHandler()}>, <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
+</ul>
+
+<p>The following changes from HTML 5.2 are considered "at risk"may be reverted if they cause compatibility problems:</p>
+
+<ul>
+ <li>Allowing multiple <{meta}> elements with <code>name="description"</code></li>
 </ul>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -924,9 +924,7 @@
 
   : <dfn><code>description</code></dfn>
   :: The value must be a free-form string that describes the page. The value must be appropriate for
-      use in a directory of pages, e.g., in a search engine. There must not be more than one
-      <{meta}> element with its <code>name</code> attribute set to the value
-      <code>description</code> per document.
+      use in a directory of pages, e.g., in a search engine or list of bookmarks.
 
   : <dfn><code>generator</code></dfn>
   :: The value must be a free-form string that identifies one of the software packages used to


### PR DESCRIPTION
Fix #553

There is nothing obvious that this breaks, but it is marked "at risk" in
case it does...