### PR TITLE
change descripiton of download attribute

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -24,8 +24,8 @@
       and [[#forms-form-submission]]
     </dd>
     <dd>
-      <code>download</code> - Whether to download the resource instead of navigating to it, and its
-      file name if so
+      <code>download</code> - Indicates to download the linked resource
+      instead of navigating to it. If the attribute has a set value, change the resource's <var>proposed filename</var> to the set value.
     </dd>
     <dd><{a/rel}> — Relationship of this document (or subsection/topic) to the destination resource</dd>
     <dd><{a/rev}> — <a>Reverse link</a> relationship of the destination resource to this document (or subsection/topic)</dd>


### PR DESCRIPTION
[Per issue 1162](https://github.com/w3c/html/issues/1162), second pass at updating the `download` attribute description, as it appears under the [`a` element section](https://w3c.github.io/html/textlevel-semantics.html#the-a-element).

If this needs any more work, please advise and I will make the edits.

Thank you!

