### PR TITLE
fix for issue 1171, in-page link typo

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -121,7 +121,7 @@
   <dfn>Tags</dfn> are used to delimit the start and end of elements in the markup. [=Raw text=],
   [=escapable raw text=], and [=normal elements=] have a [=start tag=] to indicate where they begin,
   and an [=end tag=] to indicate where they end. The start and end tags of certain
-  [=normal elements=] can be [=omitted=], as described below in the section on [[#optional tags]].
+  [=normal elements=] can be [=omitted=], as described below in the section on [=optional tags=].
   Those that cannot be omitted must not be omitted. [=Void elements=] only have a start tag; end
   tags must not be specified for [=void elements=]. [=Foreign elements=] must either have a start
   tag and an end tag, or a start tag that is marked as self-closing, in which case they must not


### PR DESCRIPTION
revise `[[#optional tags]]` to `[=optional tags=]` for in page linking.