### PR TITLE
Adds note to autofocus attrib definition

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9980,7 +9980,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   without having to manually focus the main control.
 
   <div class="note">
-  When navigating to a fragment of a page, such as https://foo.bar#fragment, the fragment identifier takes precedence and the <{formelements/autofocus}> attribute has no effect.
+  When navigating to a fragment of a page, such as https://tink.uk#main, the fragment identifier takes precedence and the <{formelements/autofocus}> attribute has no effect.
   </div>
 
  <div  class="warning">

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9980,7 +9980,7 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   without having to manually focus the main control.
 
   <div class="note">
-  When navigating to a fragment of a page, such as foo.bar#fragment, the fragment identifier takes precedence and the <{formelements/autofocus}> attribute has no effect.
+  When navigating to a fragment of a page, such as https://foo.bar#fragment, the fragment identifier takes precedence and the <{formelements/autofocus}> attribute has no effect.
   </div>
 
  <div  class="warning">

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3266,7 +3266,7 @@ part of the form.</p>
   user agent must run the <a>value sanitization algorithm</a>.
 
   A <dfn>valid e-mail address</dfn> is defined in [[!RFC6531]].
-  
+
   A user agent should present and consume unicode text in the user interface, and expose it to other applications,
   except when sending to a Mail Transfer Agent that does not support SMTPUTF8 [[RFC6531]].
 
@@ -3275,7 +3275,7 @@ part of the form.</p>
     This allows fully internationalised email addresses such as <samp>我買@屋企.香港</samp>,
     and e-mail addresses with Internationalised Domain Names as defined by [[RFC5890]], such as
     <samp>example@яндекс.рф</samp>.
-    
+
   </div>
 
   A <dfn>valid e-mail address list</dfn> is a <a>set of comma-separated tokens</a>, where
@@ -6443,7 +6443,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     The <dfn element-attr for="input, textarea"><code>autocapitalize</code></dfn>
     content attribute is an <a>enumerated attribute</a>.
     It provides a suggestion to the user agent, to help automatically capitalize text entered by the user in
-    <{input}> and <{textarea}> elements. For example when an onscreen keyboard is provided, 
+    <{input}> and <{textarea}> elements. For example when an onscreen keyboard is provided,
     default word suggestions may be capitalized as described.
 
     If the user agent sets capitalization automatically,
@@ -6452,7 +6452,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     The value must be one of the following:
     <code>sentences</code>, <code>words</code>, <code>characters</code> or <code>none</code>.
     The attribute may be omitted. The <i>missing value default</i>
-    is <code>sentences</code> for <{input}> elements in the <{input/Text}> and <{input/Search}> states and <{textarea}> elements, 
+    is <code>sentences</code> for <{input}> elements in the <{input/Text}> and <{input/Search}> states and <{textarea}> elements,
     and <code>none</code> for <{input}> elements in the <{input/URL}>, <{input/E-mail}>, and <{input/Password}> states.
 
     When an <{input}> or a <{textarea}> element has an <{input/autocapitalize}> attribute,
@@ -8656,23 +8656,23 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     </dd>
   </dl>
 
-  The <{progress}> element <a>represents</a> progress of a task, either as a fraction of the total that has been completed, 
+  The <{progress}> element <a>represents</a> progress of a task, either as a fraction of the total that has been completed,
   or merely that progress is occurring.
-  
+
   <p class="note">
-  The <{progress}> element is the wrong element to for a simple gauge, as opposed to task progress. 
+  The <{progress}> element is the wrong element to for a simple gauge, as opposed to task progress.
   The <{meter}> element is more appropriate for such use cases. It allows arbitrary minimum as well as maximum values.
   </p>
 
   The <dfn element-attr for="progress"><code>value</code></dfn> content attribute specifies how much of the
   task has been completed. When the attribute is present the value must be a <a>valid floating-point number</a>
-  in the range [0,<a for="progress">maximum value</a>]. 
+  in the range [0,<a for="progress">maximum value</a>].
   If the attribute is missing, the element is an <dfn>indeterminate progress bar</dfn>, and should show something is happening
   but that it is not clear how much more work remains to be done before the task is complete, for example
   waiting for a response to a network request. If the attribute is present, the element is a <dfn>determinate progress bar</dfn>.
-  
+
   The <dfn element-attr for="progress"><code>max</code></dfn> content attribute specifies how much work the task requires.
-  When the attribuite is present, the value must be a <a>valid floating-point number</a> greater than zero. 
+  When the attribuite is present, the value must be a <a>valid floating-point number</a> greater than zero.
   The <a>missing value default</a> is 1.0.
 
   The units are arbitrary and not specified.
@@ -8682,14 +8682,14 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   zero</a>. The default value for <{progress/max}> is 1.0.
 
   The <dfn attribute for="HTMLProgressElement"><code>value</code></dfn> IDL attribute provides the amount of the task complete
-  for a <a>determinate progress bar</a> or 0 for an <a>indeterminate progress bar</a>. 
+  for a <a>determinate progress bar</a> or 0 for an <a>indeterminate progress bar</a>.
   On setting, the given value must be converted to the
   <a lt="best floating-point number">best representation of the number as a floating-point number</a>
   and then the <{progress/value}> content attribute must be set to that string.
 
   The {{HTMLProgressElement/labels}} IDL attribute provides a list of the element's <{label}>s.
-  
-  The <dfn attribute for="HTMLProgressElement"><code>position</code></dfn> IDL attribute 
+
+  The <dfn attribute for="HTMLProgressElement"><code>position</code></dfn> IDL attribute
   gives the fraction of the task completed for a <a>determinate progress bar</a> or -1 for an <a>indeterminate progress bar</a>.
 
   <dl class="domintro">
@@ -8710,7 +8710,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <strong>user agent requirements for showing the progress bar</strong>: When representing a
   <{progress}> element to the user, the user agent should indicate whether it is a determinate or
   indeterminate progress bar. For a <a>determinate progress bar</a> the user agent should indicate the
-  <a for="progress">current value</a> relative to the <a for="progress">maximum value</a>, 
+  <a for="progress">current value</a> relative to the <a for="progress">maximum value</a>,
   e.g. by filling an appropriate fraction of the widget in a contrasting color.
 
 <h5 id="determinate-progress-bar">Determinate progress bars</h5>
@@ -8742,16 +8742,16 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   If the element has a <{progress/max}> attribute, the user agent must parse the attribute's value according to the
   <a>rules for parsing floating-point number values</a>.
-  
-  If this does not result in an error, and if the parsed value is greater than zero, then the 
-  <dfn for="progress">maximum value</dfn> of the progress bar is that value. 
-  
+
+  If this does not result in an error, and if the parsed value is greater than zero, then the
+  <dfn for="progress">maximum value</dfn> of the progress bar is that value.
+
   Otherwise the <a for="progress">maximum value</a> of the progress bar is 1.0.
 
   User agents must parse the <{progress/value}> attribute's value according to the <a>rules for
   parsing floating-point number values</a>. If this results in an error, or if the
   parsed value is less than zero, then the <dfn for="progress">current value</dfn> of the progress bar is zero.
-  
+
   Otherwise, the <a for="progress">current value</a> of the progress bar is the lesser of the parsed value and the
   <a for="progress">maximum value</a> of the progress bar.
 
@@ -8779,7 +8779,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     The <code>finishedWorking()</code> method in this example would be called by some
     other code on the page to update the actual progress bar when the task is complete.
-    
+
     Setting the {{HTMLProgressElement/value}} there changes the element to a <a>determinate progress bar</a>.
 
   </div>
@@ -8787,7 +8787,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   The {{HTMLProgressElement/position}} IDL attribute must return -1.
 
   The {{HTMLProgressElement/value}} IDL attribute, on getting, must return 0.
-  Otherwise, it must return the <a for="progress">current value</a>. 
+  Otherwise, it must return the <a for="progress">current value</a>.
 
   <p class="note">
   Setting the {{HTMLProgressElement/value}} IDL attribute to itself
@@ -9744,11 +9744,11 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
     <li>The element is a <{button}>, <{input}>, <{option}>, <{select}>, or
     <{textarea}> element, and the <code>disabled</code> attribute
     is specified on this element (regardless of its value).</li>
-    
+
     <!-- Note. option/disabled and optgroup/disabled are defined in the relevant element descriptions.
     That is repeated here for clarity -->
-    
-    <li>The element is an <{option}> element that is a child of an 
+
+    <li>The element is an <{option}> element that is a child of an
     <{optgroup}> element that has the <{optgroup/disabled}> attribute specified.</li>
 
     <li>The element is a descendant of a <{fieldset}> element whose <code>disabled</code> attribute is specified, and is <em>not</em> a
@@ -9978,6 +9978,11 @@ out of 233 257 824 bytes available&lt;/meter&gt;&lt;/p&gt;
   author to indicate that a control is to be focused as soon as the page is loaded or as soon as the
   <code>dialog</code> within which it finds itself is shown, allowing the user to just start typing
   without having to manually focus the main control.
+
+  <div class="note">
+  When navigating to a fragment of a page, such as foo.bar#fragment, the fragment identifier takes precedence and the <{formelements/autofocus}> attribute has no effect.
+  </div>
+
  <div  class="warning">
   <p>Use of the <{formelements/autofocus}> attribute can reduce usability and accessibility
   for users. Users of assistive technology can be adversively affected, because its use overrides


### PR DESCRIPTION
* Indicates that a fragment identifier takes precedence over the autofocus attribute
* Fixes #277