### PR TITLE
tweak example

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1879,17 +1879,17 @@ INFRASTRUCTURE
     Here is an example of a checkbox that is checked and disabled. The <code>checked</code> and
     <code>disabled</code> attributes are the <a>boolean attributes</a>.
 
-    <xmp highlight="html">
-      <label><input type=checkbox checked name=cheese disabled> Cheese</label>
-    </xmp>
+    <pre highlight="html">
+      &lt;label>&lt;input type="checkbox" <mark>checked</mark> name="cheese" <mark>disabled</mark>> Cheese&lt;/label>
+    </pre>
 
     This could be equivalently written as this:
 
-    <xmp highlight="html">
-      <label><input type=checkbox checked=checked name=cheese disabled=disabled> Cheese</label>
-    </xmp>
+    <pre highlight="html">
+      &lt;label>&lt;input type="checkbox" <mark>checked="checked"</mark> name="cheese" <mark>disabled="disabled"</mark>> Cheese&lt;/label>
+    </pre>
 
-    You can also mix styles; the following is still equivalent:
+    You can also mix styles; the following is also equivalent:
 
     <xmp highlight="html">
       <label><input type='checkbox' checked name=cheese disabled=""> Cheese</label>


### PR DESCRIPTION
quote attribute values, `<mark>` the key bits of the example so reverting it to use `<pre>`