### PR TITLE
Editorial: remove ascii art in source files - 

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -5,7 +5,7 @@
   This source produces the "attributes" section of the Index:
   https://w3c.github.io/html/fullindex.html#index-attributes
 
-  This documents contains non-normative listings of:
+  This document contains non-normative table listings of:
   - all attributes (excluding event handler content attributes)
   - event handler content attributes
 

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -917,10 +917,8 @@
   </tbody>
 </table>
 
-  <small>
-    An asterisk (*) in a cell indicates that the actual rules are more complicated than indicated in
-    the table above.
-  </small>
+<p class="tablenote"><small>An asterisk (*) in a cell indicates that the actual rules are more
+complicated than indicated in the table above.</small></p>
 
 <hr>
 

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -1,3 +1,16 @@
+<!--
+
+  ATTRIBUTES
+
+  This source produces the "attributes" section of the Index:
+  https://w3c.github.io/html/fullindex.html#index-attributes
+
+  This documents contains non-normative listings of:
+  - all attributes (excluding event handler content attributes)
+  - event handler content attributes
+
+-->
+
 <h3 class="no-num" id="attributes-table">Attributes</h3>
 
 <em>This section is non-normative.</em>

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -1,8 +1,22 @@
+<!--
+
+  ELEMENT CONTENT CATEGORIES
+
+  This source produces the "element content categories" section of the Index:
+  https://w3c.github.io/html/fullindex.html#element-content-categories
+
+  This document contains a non-normative table listing of all element content categories
+  defined in the spec.
+
+
+  NOTE: when updating this also check the category-list <ul>s
+
+-->
+
+
 <h3 class="no-num" id="element-content-categories">Element content categories</h3>
 
 <em>This section is non-normative.</em>
-
-<!-- when updating this also check the category-list <ul>s -->
 
 <table>
   <caption>List of element content categories</caption>

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -29,7 +29,9 @@
   </thead>
   <tbody>
     <tr>
-      <td><a>Metadata content</a></td>
+      <th>
+        <a>Metadata content</a>
+      </th>
       <td>
         <{base}>;
         <{link}>;
@@ -43,450 +45,418 @@
       <td>—</td>
     </tr>
     <tr>
-      <td><a>Flow content</a></td>
+      <th>
+        <a>Flow content</a>
+      </th>
       <td>
         <{a}>;
-      <{abbr}>;
-      <{address}>;
-      <{article}>;
-      <{aside}>;
-      <{audio}>;
-      <{b}>;
-      <{bdi}>;
-      <{bdo}>;
-      <{blockquote}>;
-      <{br}>;
-      <{button}>;
-      <{canvas}>;
-      <{cite}>;
-      <{code}>;
-      <{data}>;
-      <{datalist}>;
-      <{del}>;
-      <{details}>;
-      <{dfn}>;
-      <{dialog}>;
-      <{div}>;
-      <{dl}>;
-      <{em}>;
-      <{embed}>;
-      <{fieldset}>;
-      <{figure}>;
-      <{footer}>;
-      <{form}>;
-      <{h1}>;
-      <{h2}>;
-      <{h3}>;
-      <{h4}>;
-      <{h5}>;
-      <{h6}>;
-      <{header}>;
-      <{hr}>;
-      <{i}>;
-      <{iframe}>;
-      <{img}>;
-      <{input}>;
-      <{ins}>;
-      <{kbd}>;
-      <{label}>;
-      <{main}>;
-      <{map}>;
-      <{mark}>;
-      <{math}>;
-      <{meter}>;
-      <{nav}>;
-      <{noscript}>;
-      <{object}>;
-      <{ol}>;
-      <{output}>;
-      <{p}>;
-      <{pre}>;
-      <{progress}>;
-      <{q}>;
-      <{ruby}>;
-      <{s}>;
-      <{samp}>;
-      <{script}>;
-      <{section}>;
-      <{select}>;
-      <{small}>;
-      <{span}>;
-      <{strong}>;
-      <{sub}>;
-      <{sup}>;
-      <{svg}>;
-      <{table}>;
-      <{template}>;
-      <{textarea}>;
-      <{time}>;
-      <{u}>;
-      <{ul}>;
-      <{var}>;
-      <{video}>;
-      <{wbr}>;
-      <a>Text</a>
-     </td>
+        <{abbr}>;
+        <{address}>;
+        <{article}>;
+        <{aside}>;
+        <{audio}>;
+        <{b}>;
+        <{bdi}>;
+        <{bdo}>;
+        <{blockquote}>;
+        <{br}>;
+        <{button}>;
+        <{canvas}>;
+        <{cite}>;
+        <{code}>;
+        <{data}>;
+        <{datalist}>;
+        <{del}>;
+        <{details}>;
+        <{dfn}>;
+        <{dialog}>;
+        <{div}>;
+        <{dl}>;
+        <{em}>;
+        <{embed}>;
+        <{fieldset}>;
+        <{figure}>;
+        <{footer}>;
+        <{form}>;
+        <{h1}>;
+        <{h2}>;
+        <{h3}>;
+        <{h4}>;
+        <{h5}>;
+        <{h6}>;
+        <{header}>;
+        <{hr}>;
+        <{i}>;
+        <{iframe}>;
+        <{img}>;
+        <{input}>;
+        <{ins}>;
+        <{kbd}>;
+        <{label}>;
+        <{main}>;
+        <{map}>;
+        <{mark}>;
+        <{math}>;
+        <{meter}>;
+        <{nav}>;
+        <{noscript}>;
+        <{object}>;
+        <{ol}>;
+        <{output}>;
+        <{p}>;
+        <{pre}>;
+        <{progress}>;
+        <{q}>;
+        <{ruby}>;
+        <{s}>;
+        <{samp}>;
+        <{script}>;
+        <{section}>;
+        <{select}>;
+        <{small}>;
+        <{span}>;
+        <{strong}>;
+        <{sub}>;
+        <{sup}>;
+        <{svg}>;
+        <{table}>;
+        <{template}>;
+        <{textarea}>;
+        <{time}>;
+        <{u}>;
+        <{ul}>;
+        <{var}>;
+        <{video}>;
+        <{wbr}>;
+        <a>Text</a>
+      </td>
       <td>
         <{area}> (if it is a descendant of a <{map}> element);
         <{link}> (if it is <a>allowed in the body</a>);
-
-    </td>
+      </td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Sectioning content</a>
-      </td>
+      </th>
       <td>
         <{article}>;
-      <{aside}>;
-      <{nav}>;
-      <{section}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{aside}>;
+        <{nav}>;
+        <{section}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Heading content</a>
-      </td>
+      </th>
       <td>
         <{h1}>;
-      <{h2}>;
-      <{h3}>;
-      <{h4}>;
-      <{h5}>;
-      <{h6}>;
-     </td>
-      <td>
-      —
-
-    </td>
+        <{h2}>;
+        <{h3}>;
+        <{h4}>;
+        <{h5}>;
+        <{h6}>;
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td><a>Phrasing content</a></td>
+      <th>
+        <a>Phrasing content</a>
+      </th>
       <td>
         <{a}>;
-      <{abbr}>;
-      <{audio}>;
-      <{b}>;
-      <{bdi}>;
-      <{bdo}>;
-      <{br}>;
-      <{button}>;
-      <{canvas}>;
-      <{cite}>;
-      <{code}>;
-      <{data}>;
-      <{datalist}>;
-      <{del}>;
-      <{dfn}>;
-      <{em}>;
-      <{embed}>;
-      <{i}>;
-      <{iframe}>;
-      <{img}>;
-      <{input}>;
-      <{ins}>;
-      <{kbd}>;
-      <{label}>;
-      <{map}>;
-      <{mark}>;
-      <{math}>;
-      <{meter}>;
-      <{noscript}>;
-      <{object}>;
-      <{output}>;
-      <{progress}>;
-      <{q}>;
-      <{ruby}>;
-      <{s}>;
-      <{samp}>;
-      <{script}>;
-      <{select}>;
-      <{small}>;
-      <{span}>;
-      <{strong}>;
-      <{sub}>;
-      <{sup}>;
-      <{svg}>;
-      <{template}>;
-      <{textarea}>;
-      <{time}>;
-      <{u}>;
-      <{var}>;
-      <{video}>;
-      <{wbr}>;
-      <a>Text</a>
-     </td>
+        <{abbr}>;
+        <{audio}>;
+        <{b}>;
+        <{bdi}>;
+        <{bdo}>;
+        <{br}>;
+        <{button}>;
+        <{canvas}>;
+        <{cite}>;
+        <{code}>;
+        <{data}>;
+        <{datalist}>;
+        <{del}>;
+        <{dfn}>;
+        <{em}>;
+        <{embed}>;
+        <{i}>;
+        <{iframe}>;
+        <{img}>;
+        <{input}>;
+        <{ins}>;
+        <{kbd}>;
+        <{label}>;
+        <{map}>;
+        <{mark}>;
+        <{math}>;
+        <{meter}>;
+        <{noscript}>;
+        <{object}>;
+        <{output}>;
+        <{progress}>;
+        <{q}>;
+        <{ruby}>;
+        <{s}>;
+        <{samp}>;
+        <{script}>;
+        <{select}>;
+        <{small}>;
+        <{span}>;
+        <{strong}>;
+        <{sub}>;
+        <{sup}>;
+        <{svg}>;
+        <{template}>;
+        <{textarea}>;
+        <{time}>;
+        <{u}>;
+        <{var}>;
+        <{video}>;
+        <{wbr}>;
+        <a>Text</a>
+      </td>
       <td>
         <{area}> (if it is a descendant of a  <{map}> element);
         <{link}> (if it is <a>allowed in the body</a>);
-    </td>
+      </td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Embedded content</a>
-      </td>
+      </th>
       <td>
         <{audio}>;
-      <{canvas}>;
-      <{embed}>;
-      <{iframe}>;
-      <{img}>;
-      <{math}>;
-      <{object}>;
-      <{svg}>;
-      <{video}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{canvas}>;
+        <{embed}>;
+        <{iframe}>;
+        <{img}>;
+        <{math}>;
+        <{object}>;
+        <{svg}>;
+        <{video}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td> <a>Interactive content</a>*
-     </td>
+      <th>
+        <a>Interactive content</a>*
+      </th>
       <td>
-      <{button}>;
-      <{details}>;
-      <{embed}>;
-      <{iframe}>;
-      <{label}>;
-      <{select}>;
-      <{textarea}>
-     </td>
+        <{button}>;
+        <{details}>;
+        <{embed}>;
+        <{iframe}>;
+        <{label}>;
+        <{select}>;
+        <{textarea}>
+      </td>
       <td>
         <{a}> (if the <{a/href}> attribute is present);
         <{audio}> (if the <{audio/controls}> attribute is present);
-      <{img}> (if the <{common/usemap}> attribute is present);
-      <{input}> (if the <{input/type}> attribute is <em>not</em> in the <{input/Hidden}> state);
-      <{video}> (if the <{video/controls}> attribute is present)
-
-    </td>
+        <{img}> (if the <{common/usemap}> attribute is present);
+        <{input}> (if the <{input/type}> attribute is <em>not</em> in the <{input/Hidden}> state);
+        <{video}> (if the <{video/controls}> attribute is present)
+      </td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Sectioning roots</a>
-      </td>
+      </th>
       <td>
         <{blockquote}>;
-      <{body}>;
-      <{details}>;
-      <{dialog}>;
-      <{fieldset}>;
-      <{figure}>;
-      <{td}>
-     </td><td>
-      —
-
-    </td>
+        <{body}>;
+        <{details}>;
+        <{dialog}>;
+        <{fieldset}>;
+        <{figure}>;
+        <{td}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Form-associated elements</a>
-      </td>
+      </th>
       <td>
         <{button}>;
-      <{fieldset}>;
-      <{input}>;
-      <{label}>;
-      <{object}>;
-      <{output}>;
-      <{select}>;
-      <{textarea}>;
-      <{img}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{fieldset}>;
+        <{input}>;
+        <{label}>;
+        <{object}>;
+        <{output}>;
+        <{select}>;
+        <{textarea}>;
+        <{img}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Listed elements</a>
-      </td>
+      </th>
       <td>
         <{button}>;
-      <{fieldset}>;
-      <{input}>;
-      <{object}>;
-      <{output}>;
-      <{select}>;
-      <{textarea}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{fieldset}>;
+        <{input}>;
+        <{object}>;
+        <{output}>;
+        <{select}>;
+        <{textarea}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Submittable elements</a>
-      </td>
+      </th>
       <td>
         <{button}>;
-      <{input}>;
-      <{object}>;
-      <{select}>;
-      <{textarea}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{input}>;
+        <{object}>;
+        <{select}>;
+        <{textarea}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Resettable elements</a>
-      </td>
+      </th>
       <td>
         <{input}>;
-      <{output}>;
-      <{select}>;
-      <{textarea}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{output}>;
+        <{select}>;
+        <{textarea}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Labelable elements</a>
-      </td>
+      </th>
       <td>
         <{button}>;
-      <{input}>;
-      <{meter}>;
-      <{output}>;
-      <{progress}>;
-      <{select}>;
-      <{textarea}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{input}>;
+        <{meter}>;
+        <{output}>;
+        <{progress}>;
+        <{select}>;
+        <{textarea}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Reassociateable elements</a>
-      </td>
+      </th>
       <td>
         <{button}>;
-      <{fieldset}>;
-      <{input}>;
-      <{label}>;
-      <{object}>;
-      <{output}>;
-      <{select}>;
-      <{textarea}>
-     </td>
-      <td>
-      —
-
-    </td>
+        <{fieldset}>;
+        <{input}>;
+        <{label}>;
+        <{object}>;
+        <{output}>;
+        <{select}>;
+        <{textarea}>
+      </td>
+      <td>—</td>
     </tr>
     <tr>
-      <td>
+      <th>
         <a>Palpable content</a>
-      </td>
+      </th>
       <td>
         <{a}>;
-      <{abbr}>;
-      <{address}>;
-      <{article}>;
-      <{aside}>;
-      <{b}>;
-      <{bdi}>;
-      <{bdo}>;
-      <{blockquote}>;
-      <{button}>;
-      <{canvas}>;
-      <{cite}>;
-      <{code}>;
-      <{data}>;
-      <{details}>;
-      <{dfn}>;
-      <{div}>;
-      <{em}>;
-      <{embed}>;
-      <{fieldset}>;
-      <{figure}>;
-      <{footer}>;
-      <{form}>;
-      <{h1}>;
-      <{h2}>;
-      <{h3}>;
-      <{h4}>;
-      <{h5}>;
-      <{h6}>;
-      <{header}>;
-      <{i}>;
-      <{iframe}>;
-      <{img}>;
-      <{ins}>;
-      <{kbd}>;
-      <{label}>;
-      <{main}>;
-      <{map}>;
-      <{mark}>;
-      <{math}>;
-      <{meter}>;
-      <{nav}>;
-      <{object}>;
-      <{output}>;
-      <{p}>;
-      <{pre}>;
-      <{progress}>;
-      <{q}>;
-      <{ruby}>;
-      <{s}>;
-      <{samp}>;
-      <{section}>;
-      <{select}>;
-      <{small}>;
-      <{span}>;
-      <{strong}>;
-      <{sub}>;
-      <{sup}>;
-      <{svg}>;
-      <{table}>;
-      <{textarea}>;
-      <{time}>;
-      <{u}>;
-      <{var}>;
-      <{video}>
-     </td>
-      <td>
-        <{audio}> (if the <{audio/controls}> attribute is present);
-      <{dl}> (if the element's children include at least one name-value group);
-      <{input}> (if the <{input/type}> attribute is <em>not</em> in the <{input/Hidden}> state);
-      <{ol}> (if the element's children include at least one <{li}> element);
-      <{ul}> (if the element's children include at least one <{li}> element);
-      <a>Text</a> that is not <a>inter-element white space</a>
-
-    </td>
-    </tr>
-    <tr>
-      <td>
-        <a>Script-supporting elements</a>
+        <{abbr}>;
+        <{address}>;
+        <{article}>;
+        <{aside}>;
+        <{b}>;
+        <{bdi}>;
+        <{bdo}>;
+        <{blockquote}>;
+        <{button}>;
+        <{canvas}>;
+        <{cite}>;
+        <{code}>;
+        <{data}>;
+        <{details}>;
+        <{dfn}>;
+        <{div}>;
+        <{em}>;
+        <{embed}>;
+        <{fieldset}>;
+        <{figure}>;
+        <{footer}>;
+        <{form}>;
+        <{h1}>;
+        <{h2}>;
+        <{h3}>;
+        <{h4}>;
+        <{h5}>;
+        <{h6}>;
+        <{header}>;
+        <{i}>;
+        <{iframe}>;
+        <{img}>;
+        <{ins}>;
+        <{kbd}>;
+        <{label}>;
+        <{main}>;
+        <{map}>;
+        <{mark}>;
+        <{math}>;
+        <{meter}>;
+        <{nav}>;
+        <{object}>;
+        <{output}>;
+        <{p}>;
+        <{pre}>;
+        <{progress}>;
+        <{q}>;
+        <{ruby}>;
+        <{s}>;
+        <{samp}>;
+        <{section}>;
+        <{select}>;
+        <{small}>;
+        <{span}>;
+        <{strong}>;
+        <{sub}>;
+        <{sup}>;
+        <{svg}>;
+        <{table}>;
+        <{textarea}>;
+        <{time}>;
+        <{u}>;
+        <{var}>;
+        <{video}>
       </td>
       <td>
-        <{script}>;
-      <{template}>
-     </td>
+        <{audio}> (if the <{audio/controls}> attribute is present);
+        <{dl}> (if the element's children include at least one name-value group);
+        <{input}> (if the <{input/type}> attribute is <em>not</em> in the <{input/Hidden}> state);
+        <{ol}> (if the element's children include at least one <{li}> element);
+        <{ul}> (if the element's children include at least one <{li}> element);
+        <a>Text</a> that is not <a>inter-element white space</a>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        <a>Script-supporting elements</a>
+      </th>
       <td>
-      —
-
-  </td>
+        <{script}>;
+        <{template}>
+      </td>
+      <td>—</td>
     </tr>
   </tbody>
 </table>
 
-<p class="tablenote">
-  <small>* The <{global/tabindex}> attribute can also make any element into
-    <a>interactive content</a>.</small>
-</p>
+<p class="tablenote"><small>* The <{global/tabindex}> attribute can also make any element into
+<a>interactive content</a>.</small></p>

--- a/sections/element-interfaces.include
+++ b/sections/element-interfaces.include
@@ -3,454 +3,458 @@
   <em>This section is non-normative.</em>
 
   <table>
-   <caption>List of interfaces for elements</caption>
-   <thead>
-    <tr>
-     <th> Element(s)
-     </th><th> Interface(s)
-   </th></tr></thead><tbody>
-    <tr>
-     <td> <{a}>
-     </td><td> {{HTMLAnchorElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{abbr}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{address}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{area}>
-     </td><td> {{HTMLAreaElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{article}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{aside}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{audio}>
-     </td><td> {{HTMLAudioElement}} : {{HTMLMediaElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{b}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{base}>
-     </td><td> {{HTMLBaseElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{bdi}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{bdo}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{blockquote}>
-     </td><td> {{HTMLQuoteElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{body}>
-     </td><td> {{HTMLBodyElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{br}>
-     </td><td> {{HTMLBRElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{button}>
-     </td><td> {{HTMLButtonElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{canvas}>
-     </td><td> {{HTMLCanvasElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{caption}>
-     </td><td> {{HTMLTableCaptionElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{cite}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{code}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{col}>
-     </td><td> {{HTMLTableColElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{colgroup}>
-     </td><td> {{HTMLTableColElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{data}>
-     </td><td> {{HTMLDataElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{datalist}>
-     </td><td> {{HTMLDataListElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{dd}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{del}>
-     </td><td> {{HTMLModElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{details}>
-     </td><td> {{HTMLDetailsElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{dfn}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{dialog}>
-     </td><td> {{HTMLDialogElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{div}>
-     </td><td> {{HTMLDivElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{dl}>
-     </td><td> {{HTMLDListElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{dt}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{em}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{embed}>
-     </td><td> {{HTMLEmbedElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{fieldset}>
-     </td><td> {{HTMLFieldSetElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{figcaption}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{figure}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{footer}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{form}>
-     </td><td> {{HTMLFormElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h1}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h2}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h3}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h4}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h5}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{h6}>
-     </td><td> {{HTMLHeadingElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{head}>
-     </td><td> {{HTMLHeadElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{header}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{hr}>
-     </td><td> {{HTMLHRElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{html}>
-     </td><td> {{HTMLHtmlElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{i}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{iframe}>
-     </td><td> {{HTMLIFrameElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{img}>
-     </td><td> {{HTMLImageElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{input}>
-     </td><td> {{HTMLInputElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{ins}>
-     </td><td> {{HTMLModElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{kbd}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{label}>
-     </td><td> {{HTMLLabelElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{legend}>
-     </td><td> {{HTMLLegendElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{li}>
-     </td><td> {{HTMLLIElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{link}>
-     </td><td> {{HTMLLinkElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{main}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{map}>
-     </td><td> {{HTMLMapElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{mark}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{meta}>
-     </td><td> {{HTMLMetaElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{meter}>
-     </td><td> {{HTMLMeterElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{nav}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{noscript}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{object}>
-     </td><td> {{HTMLObjectElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{ol}>
-     </td><td> {{HTMLOListElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{optgroup}>
-     </td><td> {{HTMLOptGroupElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{option}>
-     </td><td> {{HTMLOptionElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{output}>
-     </td><td> {{HTMLOutputElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{p}>
-     </td><td> {{HTMLParagraphElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{param}>
-     </td><td> {{HTMLParamElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{picture}>
-     </td><td> {{HTMLPictureElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{pre}>
-     </td><td> {{HTMLPreElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{progress}>
-     </td><td> {{HTMLProgressElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{q}>
-     </td><td> {{HTMLQuoteElement}} : {{HTMLElement}}
-
-        </td></tr><tr>
-     <td> <{rb}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{rp}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{rt}>
-     </td><td> {{HTMLElement}}
-
-          </td></tr><tr>
-      <td> <{rtc}>
-      </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{ruby}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{s}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{samp}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{script}>
-     </td><td> {{HTMLScriptElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{section}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{select}>
-     </td><td> {{HTMLSelectElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{small}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{source}>
-     </td><td> {{HTMLSourceElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{span}>
-     </td><td> {{HTMLSpanElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{strong}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{style}>
-     </td><td> {{HTMLStyleElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{sub}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{summary}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{sup}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{table}>
-     </td><td> {{HTMLTableElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{tbody}>
-     </td><td> {{HTMLTableSectionElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{td}>
-     </td><td> {{HTMLTableDataCellElement}} : {{HTMLTableCellElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{template}>
-     </td><td> {{HTMLTemplateElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{textarea}>
-     </td><td> {{HTMLTextAreaElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{tfoot}>
-     </td><td> {{HTMLTableSectionElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{th}>
-     </td><td> {{HTMLTableHeaderCellElement}} : {{HTMLTableCellElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{thead}>
-     </td><td> {{HTMLTableSectionElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{time}>
-     </td><td> {{HTMLTimeElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{title}>
-     </td><td> {{HTMLTitleElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{tr}>
-     </td><td> {{HTMLTableRowElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{track}>
-     </td><td> {{HTMLTrackElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{u}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{ul}>
-     </td><td> {{HTMLUListElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{var}>
-     </td><td> {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{video}>
-     </td><td> {{HTMLVideoElement}} : {{HTMLMediaElement}} : {{HTMLElement}}
-
-    </td></tr><tr>
-     <td> <{wbr}>
-     </td><td> {{HTMLElement}}
-
-  </td></tr></tbody></table>
+    <caption>List of interfaces for elements</caption>
+    <thead>
+      <tr>
+        <th>Element(s)</th>
+        <th>Interface(s)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><{a}></td>
+        <td>{{HTMLAnchorElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{abbr}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{address}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{area}></td>
+        <td>{{HTMLAreaElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{article}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{aside}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{audio}></td>
+        <td>{{HTMLAudioElement}} : {{HTMLMediaElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{b}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{base}></td>
+        <td>{{HTMLBaseElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{bdi}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{bdo}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{blockquote}></td>
+        <td>{{HTMLQuoteElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{body}></td>
+        <td>{{HTMLBodyElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{br}></td>
+        <td>{{HTMLBRElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{button}></td>
+        <td>{{HTMLButtonElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{canvas}></td>
+        <td>{{HTMLCanvasElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{caption}></td>
+        <td>{{HTMLTableCaptionElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{cite}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{code}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{col}></td>
+        <td>{{HTMLTableColElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{colgroup}></td>
+        <td>{{HTMLTableColElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{data}></td>
+        <td>{{HTMLDataElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{datalist}></td>
+        <td>{{HTMLDataListElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{dd}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{del}></td>
+        <td>{{HTMLModElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{details}></td>
+        <td>{{HTMLDetailsElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{dfn}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{dialog}></td>
+        <td>{{HTMLDialogElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{div}></td>
+        <td>{{HTMLDivElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{dl}></td>
+        <td>{{HTMLDListElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{dt}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{em}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{embed}></td>
+        <td>{{HTMLEmbedElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{fieldset}></td>
+        <td>{{HTMLFieldSetElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{figcaption}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{figure}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{footer}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{form}></td>
+        <td>{{HTMLFormElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h1}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h2}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h3}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h4}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h5}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{h6}></td>
+        <td>{{HTMLHeadingElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{head}></td>
+        <td>{{HTMLHeadElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{header}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{hr}></td>
+        <td>{{HTMLHRElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{html}></td>
+        <td>{{HTMLHtmlElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{i}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{iframe}></td>
+        <td>{{HTMLIFrameElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{img}></td>
+        <td>{{HTMLImageElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{input}></td>
+        <td>{{HTMLInputElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{ins}></td>
+        <td>{{HTMLModElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{kbd}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{label}></td>
+        <td>{{HTMLLabelElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{legend}></td>
+        <td>{{HTMLLegendElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{li}></td>
+        <td>{{HTMLLIElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{link}></td>
+        <td>{{HTMLLinkElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{main}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{map}></td>
+        <td>{{HTMLMapElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{mark}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{meta}></td>
+        <td>{{HTMLMetaElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{meter}></td>
+        <td>{{HTMLMeterElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{nav}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{noscript}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{object}></td>
+        <td>{{HTMLObjectElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{ol}></td>
+        <td>{{HTMLOListElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{optgroup}></td>
+        <td>{{HTMLOptGroupElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{option}></td>
+        <td>{{HTMLOptionElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{output}></td>
+        <td>{{HTMLOutputElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{p}></td>
+        <td>{{HTMLParagraphElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{param}></td>
+        <td>{{HTMLParamElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{picture}></td>
+        <td>{{HTMLPictureElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{pre}></td>
+        <td>{{HTMLPreElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{progress}></td>
+        <td>{{HTMLProgressElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{q}></td>
+        <td>{{HTMLQuoteElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{rb}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{rp}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{rt}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{rtc}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{ruby}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{s}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{samp}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{script}></td>
+        <td>{{HTMLScriptElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{section}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{select}></td>
+        <td>{{HTMLSelectElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{small}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{source}></td>
+        <td>{{HTMLSourceElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{span}></td>
+        <td>{{HTMLSpanElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{strong}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{style}></td>
+        <td>{{HTMLStyleElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{sub}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{summary}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{sup}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{table}></td>
+        <td>{{HTMLTableElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{tbody}></td>
+        <td>{{HTMLTableSectionElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{td}></td>
+        <td>{{HTMLTableDataCellElement}} : {{HTMLTableCellElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{template}></td>
+        <td>{{HTMLTemplateElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{textarea}></td>
+        <td>{{HTMLTextAreaElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{tfoot}></td>
+        <td>{{HTMLTableSectionElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{th}></td>
+        <td>{{HTMLTableHeaderCellElement}} : {{HTMLTableCellElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{thead}></td>
+        <td>{{HTMLTableSectionElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{time}></td>
+        <td>{{HTMLTimeElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{title}></td>
+        <td>{{HTMLTitleElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{tr}></td>
+        <td>{{HTMLTableRowElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{track}></td>
+        <td>{{HTMLTrackElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{u}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{ul}></td>
+        <td>{{HTMLUListElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{var}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{video}></td>
+        <td>{{HTMLVideoElement}} : {{HTMLMediaElement}} : {{HTMLElement}}</td>
+      </tr>
+      <tr>
+        <td><{wbr}></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+
+  </tbody>
+</table>

--- a/sections/element-interfaces.include
+++ b/sections/element-interfaces.include
@@ -1,3 +1,16 @@
+<!--
+
+  ELEMENT INTERFACES
+
+  This source produces the "element interfaces" section of the Index:
+  https://w3c.github.io/html/fullindex.html#element-interfaces
+
+  This document contains a non-normative table listing of all element interfaces
+  defined in the spec.
+
+-->
+
+
 <h3 class="no-num" id="element-interfaces">Element Interfaces</h3>
 
   <em>This section is non-normative.</em>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -1,3 +1,14 @@
+<!--
+
+  ELEMENTS
+
+  This source produces the "elements" section of the Index:
+  https://w3c.github.io/html/fullindex.html#index-elements
+
+  This documents contains a non-normative listing of all elements defined in the spec
+
+-->
+
 <h3 class="no-num" id="index-elements">Elements</h3>
 
   <em>This section is non-normative.</em>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -5,7 +5,7 @@
   This source produces the "elements" section of the Index:
   https://w3c.github.io/html/fullindex.html#index-elements
 
-  This documents contains a non-normative listing of all elements defined in the spec
+  This document contains a non-normative table listing of all elements defined in the spec
 
 -->
 

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -28,7 +28,6 @@
     </thead>
 
     <tbody>
-
       <tr>
        <th><{a}></th>
        <td>Hyperlink</td>
@@ -41,23 +40,23 @@
            <{links/href}>;
            <{links/target}>;
            <{links/download}>;
-  	 <{links/ping}>;
+           <{links/ping}>;
            <{links/rel}>;
            <{links/hreflang}>;
            <{links/type}>;
            <{link/referrerpolicy}></td>
-       <td>{{HTMLAnchorElement}}</td>
+        <td>{{HTMLAnchorElement}}</td>
       </tr>
 
       <tr>
-       <th><{abbr}></th>
-       <td>Abbreviation</td>
-       <td><a>flow</a>;
+        <th><{abbr}></th>
+        <td>Abbreviation</td>
+        <td><a>flow</a>;
            <a>phrasing</a></td>
-       <td><a>phrasing</a></td>
-       <td><a>phrasing</a></td>
-       <td><a>globals</a></td>
-       <td>{{HTMLElement}}</td>
+        <td><a>phrasing</a></td>
+        <td><a>phrasing</a></td>
+        <td><a>globals</a></td>
+        <td>{{HTMLElement}}</td>
       </tr>
 
       <tr>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -14,1537 +14,1543 @@
   <em>This section is non-normative.</em>
 
   <table>
-   <caption>List of elements</caption>
-   <thead>
-    <tr>
-     <th> Element
-     </th><th> Description
-     </th><th> Categories
-     </th><th> Parents†
-     </th><th> Children
-     </th><th> Attributes
-     </th><th> Interface
-   </th></tr></thead><tbody>
-
-    <tr>
-     <th><{a}></th>
-     <td>Hyperlink</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>*;
-         <a>interactive</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>transparent</a>*</td>
-     <td><a>globals</a>;
-         <{links/href}>;
-         <{links/target}>;
-         <{links/download}>;
-	 <{links/ping}>;
-         <{links/rel}>;
-         <{links/hreflang}>;
-         <{links/type}>;
-         <{link/referrerpolicy}></td>
-     <td>{{HTMLAnchorElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{abbr}></th>
-     <td>Abbreviation</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{address}></th>
-     <td>Contact information</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{area}></th>
-     <td>Hyperlink or dead area on an image map</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{area/alt}>;
-         <{area/coords}>;
-         <{area/shape}>;
-         <{links/href}>;
-         <{links/target}>;
-         <{links/download}>;
-	 <{links/ping}>;
-         <{links/rel}>;
-         <{links/hreflang}>;
-         <{links/type}>;
-         <{link/referrerpolicy}></td>
-     <td>{{HTMLAreaElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{article}></th>
-     <td>Self-contained syndicatable or reusable composition</td>
-     <td><a>flow</a>;
-         <a>sectioning</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{aside}></th>
-     <td>Sidebar for tangentially related content</td>
-     <td><a>flow</a>;
-         <a>sectioning</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{audio}></th>
-     <td>Audio player</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a></td>
-     <td><a>phrasing</a></td>
-     <td><{source}>*;
-         <a>transparent</a>*</td>
-     <td><a>globals</a>;
-         <{media/src}>;
-         <{media/crossorigin}>;
-         <{media/disableRemotePlayback}>;
-         <{media/preload}>;
-         <{media/autoplay}>;
-         <{media/loop}>;
-         <{media/muted}>;
-         <{audio/controls}></td>
-     <td>{{HTMLAudioElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{b}></th>
-     <td>Keywords</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{base}></th>
-     <td>Base URL and default target <a>browsing context</a> for <a>hyperlinks</a> and <a>forms</a></td>
-     <td><a lt="metadata content">metadata</a></td>
-     <td><{head}>;
-         <{template}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{base/href}>;
-         <{base/target}></td>
-     <td>{{HTMLBaseElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{bdi}></th>
-     <td>Text directionality isolation</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{bdo}></th>
-     <td>Text directionality formatting</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{blockquote}></th>
-     <td>A section quoted from another source</td>
-     <td><a>flow</a>;
-         <a>sectioning root</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a>;
-         <{blockquote/cite}></td>
-     <td>{{HTMLQuoteElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{body}></th>
-     <td>Document body</td>
-     <td><a>sectioning root</a></td>
-     <td><{html}></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a>;
-         {{WindowEventHandlers/onafterprint}};
-         {{WindowEventHandlers/onbeforeprint}};
-         {{WindowEventHandlers/onbeforeunload}};
-         {{WindowEventHandlers/onhashchange}};
-         {{WindowEventHandlers/onlanguagechange}};
-         {{WindowEventHandlers/onmessage}};
-         {{WindowEventHandlers/onoffline}};
-         {{WindowEventHandlers/ononline}};
-         {{WindowEventHandlers/onpagehide}};
-         {{WindowEventHandlers/onpageshow}};
-         {{WindowEventHandlers/onpopstate}};
-         {{WindowEventHandlers/onstorage}};
-         {{WindowEventHandlers/onunload}}</code>
-     </td>
-     <td>{{HTMLBodyElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{br}></th>
-     <td>Line break, e.g., in poem or postal address</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td>empty</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLBRElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{button}></th>
-     <td>Button control</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>interactive</a>;
-         <a lt="listed element">listed</a>;
-         <a>labelable</a>;
-         <a>submittable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td><a>globals</a>;
-         <{button/autofocus}>;
-         <{button/disabled}>;
-         <{button/form}>;
-         <{button/formaction}>;
-         <{button/formenctype}>;
-         <{button/formmethod}>;
-         <{button/formnovalidate}>;
-         <{button/formtarget}>;
-         <{button/name}>;
-         <{button/type}>;
-         <{button/value}></td>
-     <td>{{HTMLButtonElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{canvas}></th>
-     <td>Scriptable bitmap canvas</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>transparent</a></td>
-     <td><a>globals</a>;
-         <{canvas/width}>;
-         <{canvas/height}></td>
-     <td>{{HTMLCanvasElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{caption}></th>
-     <td>Table caption</td>
-     <td>none</td>
-     <td><{table}>;
-         <{template}></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTableCaptionElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{cite}></th>
-     <td>Title of a work</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{code}></th>
-     <td>Computer code</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{col}></th>
-     <td>Table column</td>
-     <td>none</td>
-     <td><{colgroup}>;
-         <{template}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{col/span}></td>
-     <td>{{HTMLTableColElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{colgroup}></th>
-     <td>Group of columns in a table</td>
-     <td>none</td>
-     <td><{table}>;
-         <{template}></td>
-     <td><{col}>*;
-         <{template}>*</td>
-     <td><a>globals</a>;
-         <{colgroup/span}></td>
-     <td>{{HTMLTableColElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{data}></th>
-     <td>Machine-readable equivalent</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a>;
-         <{data/value}></td>
-     <td>{{HTMLDataElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{datalist}></th>
-     <td>Container for options for combo box control </td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>;
-         <{option}></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLDataListElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{dd}></th>
-     <td>Content for corresponding <{dt}> element(s)</td>
-     <td>none</td>
-     <td><{dl}>;
-         <{template}></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{del}></th>
-     <td>A removal from the document</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>*</td>
-     <td><a>phrasing</a></td>
-     <td><a>transparent</a></td>
-     <td><a>globals</a>;
-         <{edits/cite}>;
-         <{edits/datetime}></td>
-     <td>{{HTMLModElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{details}></th>
-     <td>Disclosure control for hiding details</td>
-     <td><a>flow</a>;
-         <a>sectioning root</a>;
-         <a>interactive</a></td>
-     <td><a>flow</a></td>
-     <td><{summary}>*;
-         <a>flow</a></td>
-     <td><a>globals</a>;
-         <{details/open}></td>
-     <td>{{HTMLDetailsElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{dfn}></th>
-     <td>Defining instance</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{dialog}></th>
-     <td>Dialog box or window</td>
-     <td><a>flow</a>;
-         <a>sectioning root</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a>;
-         <{dialog/open}></td>
-     <td>{{HTMLDialogElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{div}></th>
-     <td>Generic flow container</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLDivElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{dl}></th>
-     <td>Association list consisting of zero or more name-value groups</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><{dt}>*;
-         <{dd}>*;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLDListElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{dt}></th>
-     <td>Legend for corresponding <{dd}> element(s)</td>
-     <td>none</td>
-     <td><{dl}>;
-         <{template}></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{em}></th>
-     <td>Stress emphasis</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{embed}></th>
-     <td><a>Plugin</a></td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a></td>
-     <td><a>phrasing</a></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{embed/src}>;
-         <{embed/type}>;
-         <{media/width}>;
-         <{media/height}>;
-         any*</td>
-     <td>{{HTMLEmbedElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{fieldset}></th>
-     <td>Group of form controls</td>
-     <td><a>flow</a>;
-         <a>sectioning root</a>;
-         <a lt="listed element">listed</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>flow</a></td>
-     <td><{legend}>*;
-         <a>flow</a></td>
-     <td><a>globals</a>;
-         <{fieldset/disabled}>;
-         <{fieldset/form}>;
-         <{fieldset/name}></td>
-     <td>{{HTMLFieldSetElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{figcaption}></th>
-     <td>Caption for <{figure}></td>
-     <td>none</td>
-     <td><{figure}>;
-         <{template}></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{figure}></th>
-     <td>Figure with optional caption</td>
-     <td><a>flow</a>;
-         <a>sectioning root</a></td>
-     <td><a>flow</a></td>
-     <td><{figcaption}>*;
-         <a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{footer}></th>
-     <td>Footer for a page or section</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{form}></th>
-     <td>User-submittable form</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a>;
-         <{form/accept-charset}>;
-         <{form/action}>;
-         <{form/autocomplete}>;
-         <{form/enctype}>;
-         <{form/method}>;
-         <{form/name}>;
-         <{form/novalidate}>;
-         <{form/target}></td>
-     <td>{{HTMLFormElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{h1}>, <{h2}>, <{h3}>, <{h4}>, <{h5}>, <{h6}></th>
-     <td>Section heading</td>
-     <td><a>flow</a>;
-         <a>headings</a></td>
-     <td>
-         <a>flow</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLHeadingElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{head}></th>
-     <td>Container for document metadata</td>
-     <td>none</td>
-     <td><{html}></td>
-     <td><a lt="metadata content">metadata</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLHeadElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{header}></th>
-     <td>Introductory or navigational aids for a page or section</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{hr}></th>
-     <td>Thematic break</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td>empty</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLHRElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{html}></th>
-     <td>Root element</td>
-     <td>none</td>
-     <td>none*</td>
-     <td><{head}>*;
-         <{body}>*</td>
-     <td><a>globals</a>;
-     <{html/manifest}></td>
-     <td>{{HTMLHtmlElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{i}></th>
-     <td>Alternate voice</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{iframe}></th>
-     <td><a>Nested browsing context</a></td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a></td>
-     <td><a>phrasing</a></td>
-     <td>text*</td>
-     <td><a>globals</a>;
-         <{iframe/src}>;
-         <{iframe/srcdoc}>;
-         <{iframe/name}>;
-         <{iframe/sandbox}>;
-         <{iframe/allowfullscreen}>;
-         <{media/width}>;
-         <{media/height}>;
-         <{iframe/referrerpolicy}></td>
-     <td>{{HTMLIFrameElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{img}></th>
-     <td>Image</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a>*;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{img/alt}>;
-         <{img/src}>;
-         <{img/srcset}>;
-         <{img/crossorigin}>;
-         <{common/usemap}>;
-         <{img/ismap}>;
-         <{img/longdesc}>;
-         <{media/width}>;
-         <{media/height}>;
-         <{img/referrerpolicy}></td>
-     <td>{{HTMLImageElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{input}></th>
-     <td>Form control</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>interactive</a>*;
-         <a lt="listed element">listed</a>;
-         <a>labelable</a>;
-         <a>submittable</a>;
-         <a>resettable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{input/accept}>;
-         <{input/alt}>;
-         <{input/autocapitalize}>;
-         <{input/autocomplete}>;
-         <{input/autofocus}>;
-         <{input/checked}>;
-         <{input/dirname}>;
-         <{input/disabled}>;
-         <{input/form}>;
-         <{input/formaction}>;
-         <{input/formenctype}>;
-         <{input/formmethod}>;
-         <{input/formnovalidate}>;
-         <{input/formtarget}>;
-         <{input/height}>;
-         <{input/list}>;
-         <{input/max}>;
-         <{input/maxlength}>;
-         <{input/min}>;
-         <{input/minlength}>;
-         <{input/multiple}>;
-         <{input/name}>;
-         <{input/pattern}>;
-         <{input/placeholder}>;
-         <{input/readonly}>;
-         <{input/required}>;
-         <{input/size}>;
-         <{input/src}>;
-         <{input/step}>;
-         <{input/type}>;
-         <{input/value}>;
-         <{input/width}></td>
-     <td>{{HTMLInputElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{ins}></th>
-     <td>An addition to the document</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>*</td>
-     <td><a>phrasing</a></td>
-     <td><a>transparent</a></td>
-     <td><a>globals</a>;
-         <{edits/cite}>;
-         <{edits/datetime}></td>
-     <td>{{HTMLModElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{kbd}></th>
-     <td>User input</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{label}></th>
-     <td>Caption for a form control</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>interactive</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td><a>globals</a>;
-         <{label/for}></td>
-     <td>{{HTMLLabelElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{legend}></th>
-     <td>Caption for <{fieldset}></td>
-     <td>none</td>
-     <td><{fieldset}>;
-         <{template}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLLegendElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{li}></th>
-     <td>List item</td>
-     <td>none</td>
-     <td><{ol}>;
-         <{ul}>;
-         <{template}></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a>;
-         <{li/value}>*</td>
-     <td>{{HTMLLIElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{link}></th>
-     <td>Link metadata</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>*;
-         <a>phrasing</a>*</td>
-     <td><{head}>;
-         <{template}>;
-         <{noscript}>*;
-         <a>phrasing</a>*</td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{link/href}>;
-         <{link/crossorigin}>;
-         <{link/integrity}>;
-         <{link/rel}>;
-         <{link/media}>;
-         <{link/referrerpolicy}>;
-         <{link/nonce}>;
-         <{link/hreflang}>;
-         <{link/type}>;
-         <{link/sizes}></td>
-     <td>{{HTMLLinkElement}}</td>
-    </tr>
-
-  <tr>
-    <th><{main}></th>
-    <td>Main content of a document
-    </td><td><a>flow</a>
-    </td><td><a>flow</a>
-    </td><td><a>flow</a>*
-    </td><td><a>globals</a>
-    </td><td>{{HTMLElement}}
-  </td></tr>
-
-    <tr>
-     <th><{map}></th>
-     <td><a>Image map</a></td>
-     <td><a>flow</a>;
-         <a>phrasing</a>*</td>
-     <td><a>phrasing</a></td>
-     <td><a>transparent</a>;
-         <{area}>*</td>
-     <td><a>globals</a>;
-         <{map/name}></td>
-     <td>{{HTMLMapElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{mark}></th>
-     <td>Highlight</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{meta}></th>
-     <td>Text metadata</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>*;
-         <a>phrasing</a>*</td>
-     <td><{head}>;
-         <{template}>;
-         <{noscript}>*;
-         <a>phrasing</a>*</td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{meta/name}>;
-         <{meta/http-equiv}>;
-         <{meta/content}>;
-         <{meta/charset}></td>
-     <td>{{HTMLMetaElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{meter}></th>
-     <td>Gauge</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>labelable</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td><a>globals</a>;
-         <{meter/value}>;
-         <{meter/min}>;
-         <{meter/max}>;
-         <{meter/low}>;
-         <{meter/high}>;
-         <{meter/optimum}></td>
-     <td>{{HTMLMeterElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{nav}></th>
-     <td>Section with navigational links</td>
-     <td><a>flow</a>;
-         <a>sectioning</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{noscript}></th>
-     <td>Fallback content for script</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>;
-         <a>phrasing</a></td>
-     <td><{head}>*;
-         <{template}>*;
-         <a>phrasing</a>*</td>
-     <td>varies*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{object}></th>
-     <td>Image, <a>nested browsing context</a>, or <a>plugin</a></td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a>*;
-         <a lt="listed element">listed</a>;
-         <a>submittable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><{param}>*;
-         <a>transparent</a></td>
-     <td><a>globals</a>;
-         <{object/data}>;
-         <{object/type}>;
-         <{object/typemustmatch}>;
-         <{object/name}>;
-         <{object/form}>;
-         <{media/width}>;
-         <{media/height}></td>
-     <td>{{HTMLObjectElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{ol}></th>
-     <td>Ordered list</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><{li}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a>;
-         <{ol/reversed}>;
-         <{ol/start}>;
-         <{ol/type}></td>
-     <td>{{HTMLOListElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{optgroup}></th>
-     <td>Group of options in a list box</td>
-     <td>none</td>
-     <td><{select}>;
-         <{template}></td>
-     <td><{option}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a>;
-         <{optgroup/disabled}>;
-         <{optgroup/label}></td>
-     <td>{{HTMLOptGroupElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{option}></th>
-     <td>Option in a list box or combo box control</td>
-     <td>none</td>
-     <td><{select}>;
-         <{datalist}>;
-         <{optgroup}>;
-         <{template}></td>
-     <td><a>text</a>*</td>
-     <td><a>globals</a>;
-         <{option/disabled}>;
-         <{option/label}>;
-         <{option/selected}>;
-         <{option/value}></td>
-     <td>{{HTMLOptionElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{output}></th>
-     <td>Calculated output value</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a lt="listed element">listed</a>;
-         <a>labelable</a>;
-         <a>resettable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a>;
-         <{output/for}>;
-         <{output/form}>;
-         <{output/name}></td>
-     <td>{{HTMLOutputElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{p}></th>
-     <td>Paragraph</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLParagraphElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{param}></th>
-     <td>Parameter for <{object}></td>
-     <td>none</td>
-     <td><{object}>;
-         <{template}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{param/name}>;
-         <{param/value}></td>
-     <td>{{HTMLParamElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{picture}></th>
-     <td>Image</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a></td>
-     <td><a>phrasing</a></td>
-     <td><{source}>*; one <{img}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLPictureElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{pre}></th>
-     <td>Block of preformatted text</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLPreElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{progress}></th>
-     <td>Progress bar</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>labelable</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>*</td>
-     <td><a>globals</a>;
-         <{progress/value}>;
-         <{progress/max}></td>
-     <td>{{HTMLProgressElement}}</td>
-    </tr>
-
-    <tr>
-     <th><{q}></th>
-     <td>Quotation</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a>;
-         <{q/cite}></td>
-     <td>{{HTMLQuoteElement}}</td>
-    </tr>
+    <caption>List of elements</caption>
+    <thead>
         <tr>
-     <th><{rb}></th>
-     <td>Ruby base</td>
-     <td>none</td>
-     <td><{ruby}>;
+         <th>Element</th>
+         <th>Description</th>
+         <th>Categories</th>
+         <th>Parents†</th>
+         <th>Children</th>
+         <th>Attributes</th>
+         <th>Interface</th>
+        </tr>
+    </thead>
+
+    <tbody>
+
+      <tr>
+       <th><{a}></th>
+       <td>Hyperlink</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>*;
+           <a>interactive</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>transparent</a>*</td>
+       <td><a>globals</a>;
+           <{links/href}>;
+           <{links/target}>;
+           <{links/download}>;
+  	 <{links/ping}>;
+           <{links/rel}>;
+           <{links/hreflang}>;
+           <{links/type}>;
+           <{link/referrerpolicy}></td>
+       <td>{{HTMLAnchorElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{abbr}></th>
+       <td>Abbreviation</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{address}></th>
+       <td>Contact information</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{area}></th>
+       <td>Hyperlink or dead area on an image map</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{area/alt}>;
+           <{area/coords}>;
+           <{area/shape}>;
+           <{links/href}>;
+           <{links/target}>;
+           <{links/download}>;
+  	 <{links/ping}>;
+           <{links/rel}>;
+           <{links/hreflang}>;
+           <{links/type}>;
+           <{link/referrerpolicy}></td>
+       <td>{{HTMLAreaElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{article}></th>
+       <td>Self-contained syndicatable or reusable composition</td>
+       <td><a>flow</a>;
+           <a>sectioning</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{aside}></th>
+       <td>Sidebar for tangentially related content</td>
+       <td><a>flow</a>;
+           <a>sectioning</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{audio}></th>
+       <td>Audio player</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a></td>
+       <td><a>phrasing</a></td>
+       <td><{source}>*;
+           <a>transparent</a>*</td>
+       <td><a>globals</a>;
+           <{media/src}>;
+           <{media/crossorigin}>;
+           <{media/disableRemotePlayback}>;
+           <{media/preload}>;
+           <{media/autoplay}>;
+           <{media/loop}>;
+           <{media/muted}>;
+           <{audio/controls}></td>
+       <td>{{HTMLAudioElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{b}></th>
+       <td>Keywords</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{base}></th>
+       <td>Base URL and default target <a>browsing context</a> for <a>hyperlinks</a> and <a>forms</a></td>
+       <td><a lt="metadata content">metadata</a></td>
+       <td><{head}>;
+           <{template}></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{base/href}>;
+           <{base/target}></td>
+       <td>{{HTMLBaseElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{bdi}></th>
+       <td>Text directionality isolation</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{bdo}></th>
+       <td>Text directionality formatting</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{blockquote}></th>
+       <td>A section quoted from another source</td>
+       <td><a>flow</a>;
+           <a>sectioning root</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a>;
+           <{blockquote/cite}></td>
+       <td>{{HTMLQuoteElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{body}></th>
+       <td>Document body</td>
+       <td><a>sectioning root</a></td>
+       <td><{html}></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a>;
+           {{WindowEventHandlers/onafterprint}};
+           {{WindowEventHandlers/onbeforeprint}};
+           {{WindowEventHandlers/onbeforeunload}};
+           {{WindowEventHandlers/onhashchange}};
+           {{WindowEventHandlers/onlanguagechange}};
+           {{WindowEventHandlers/onmessage}};
+           {{WindowEventHandlers/onoffline}};
+           {{WindowEventHandlers/ononline}};
+           {{WindowEventHandlers/onpagehide}};
+           {{WindowEventHandlers/onpageshow}};
+           {{WindowEventHandlers/onpopstate}};
+           {{WindowEventHandlers/onstorage}};
+           {{WindowEventHandlers/onunload}}</code>
+       </td>
+       <td>{{HTMLBodyElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{br}></th>
+       <td>Line break, e.g., in poem or postal address</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td>empty</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLBRElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{button}></th>
+       <td>Button control</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>interactive</a>;
+           <a lt="listed element">listed</a>;
+           <a>labelable</a>;
+           <a>submittable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td><a>globals</a>;
+           <{button/autofocus}>;
+           <{button/disabled}>;
+           <{button/form}>;
+           <{button/formaction}>;
+           <{button/formenctype}>;
+           <{button/formmethod}>;
+           <{button/formnovalidate}>;
+           <{button/formtarget}>;
+           <{button/name}>;
+           <{button/type}>;
+           <{button/value}></td>
+       <td>{{HTMLButtonElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{canvas}></th>
+       <td>Scriptable bitmap canvas</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>transparent</a></td>
+       <td><a>globals</a>;
+           <{canvas/width}>;
+           <{canvas/height}></td>
+       <td>{{HTMLCanvasElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{caption}></th>
+       <td>Table caption</td>
+       <td>none</td>
+       <td><{table}>;
+           <{template}></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTableCaptionElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{cite}></th>
+       <td>Title of a work</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{code}></th>
+       <td>Computer code</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{col}></th>
+       <td>Table column</td>
+       <td>none</td>
+       <td><{colgroup}>;
+           <{template}></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{col/span}></td>
+       <td>{{HTMLTableColElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{colgroup}></th>
+       <td>Group of columns in a table</td>
+       <td>none</td>
+       <td><{table}>;
+           <{template}></td>
+       <td><{col}>*;
+           <{template}>*</td>
+       <td><a>globals</a>;
+           <{colgroup/span}></td>
+       <td>{{HTMLTableColElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{data}></th>
+       <td>Machine-readable equivalent</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a>;
+           <{data/value}></td>
+       <td>{{HTMLDataElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{datalist}></th>
+       <td>Container for options for combo box control </td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>;
+           <{option}></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLDataListElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{dd}></th>
+       <td>Content for corresponding <{dt}> element(s)</td>
+       <td>none</td>
+       <td><{dl}>;
+           <{template}></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{del}></th>
+       <td>A removal from the document</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>*</td>
+       <td><a>phrasing</a></td>
+       <td><a>transparent</a></td>
+       <td><a>globals</a>;
+           <{edits/cite}>;
+           <{edits/datetime}></td>
+       <td>{{HTMLModElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{details}></th>
+       <td>Disclosure control for hiding details</td>
+       <td><a>flow</a>;
+           <a>sectioning root</a>;
+           <a>interactive</a></td>
+       <td><a>flow</a></td>
+       <td><{summary}>*;
+           <a>flow</a></td>
+       <td><a>globals</a>;
+           <{details/open}></td>
+       <td>{{HTMLDetailsElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{dfn}></th>
+       <td>Defining instance</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{dialog}></th>
+       <td>Dialog box or window</td>
+       <td><a>flow</a>;
+           <a>sectioning root</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a>;
+           <{dialog/open}></td>
+       <td>{{HTMLDialogElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{div}></th>
+       <td>Generic flow container</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLDivElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{dl}></th>
+       <td>Association list consisting of zero or more name-value groups</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><{dt}>*;
+           <{dd}>*;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLDListElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{dt}></th>
+       <td>Legend for corresponding <{dd}> element(s)</td>
+       <td>none</td>
+       <td><{dl}>;
+           <{template}></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{em}></th>
+       <td>Stress emphasis</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{embed}></th>
+       <td><a>Plugin</a></td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a></td>
+       <td><a>phrasing</a></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{embed/src}>;
+           <{embed/type}>;
+           <{media/width}>;
+           <{media/height}>;
+           any*</td>
+       <td>{{HTMLEmbedElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{fieldset}></th>
+       <td>Group of form controls</td>
+       <td><a>flow</a>;
+           <a>sectioning root</a>;
+           <a lt="listed element">listed</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>flow</a></td>
+       <td><{legend}>*;
+           <a>flow</a></td>
+       <td><a>globals</a>;
+           <{fieldset/disabled}>;
+           <{fieldset/form}>;
+           <{fieldset/name}></td>
+       <td>{{HTMLFieldSetElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{figcaption}></th>
+       <td>Caption for <{figure}></td>
+       <td>none</td>
+       <td><{figure}>;
+           <{template}></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{figure}></th>
+       <td>Figure with optional caption</td>
+       <td><a>flow</a>;
+           <a>sectioning root</a></td>
+       <td><a>flow</a></td>
+       <td><{figcaption}>*;
+           <a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{footer}></th>
+       <td>Footer for a page or section</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{form}></th>
+       <td>User-submittable form</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a>;
+           <{form/accept-charset}>;
+           <{form/action}>;
+           <{form/autocomplete}>;
+           <{form/enctype}>;
+           <{form/method}>;
+           <{form/name}>;
+           <{form/novalidate}>;
+           <{form/target}></td>
+       <td>{{HTMLFormElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{h1}>, <{h2}>, <{h3}>, <{h4}>, <{h5}>, <{h6}></th>
+       <td>Section heading</td>
+       <td><a>flow</a>;
+           <a>headings</a></td>
+       <td>
+           <a>flow</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLHeadingElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{head}></th>
+       <td>Container for document metadata</td>
+       <td>none</td>
+       <td><{html}></td>
+       <td><a lt="metadata content">metadata</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLHeadElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{header}></th>
+       <td>Introductory or navigational aids for a page or section</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{hr}></th>
+       <td>Thematic break</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td>empty</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLHRElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{html}></th>
+       <td>Root element</td>
+       <td>none</td>
+       <td>none*</td>
+       <td><{head}>*;
+           <{body}>*</td>
+       <td><a>globals</a>;
+       <{html/manifest}></td>
+       <td>{{HTMLHtmlElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{i}></th>
+       <td>Alternate voice</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{iframe}></th>
+       <td><a>Nested browsing context</a></td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a></td>
+       <td><a>phrasing</a></td>
+       <td>text*</td>
+       <td><a>globals</a>;
+           <{iframe/src}>;
+           <{iframe/srcdoc}>;
+           <{iframe/name}>;
+           <{iframe/sandbox}>;
+           <{iframe/allowfullscreen}>;
+           <{media/width}>;
+           <{media/height}>;
+           <{iframe/referrerpolicy}></td>
+       <td>{{HTMLIFrameElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{img}></th>
+       <td>Image</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a>*;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{img/alt}>;
+           <{img/src}>;
+           <{img/srcset}>;
+           <{img/crossorigin}>;
+           <{common/usemap}>;
+           <{img/ismap}>;
+           <{img/longdesc}>;
+           <{media/width}>;
+           <{media/height}>;
+           <{img/referrerpolicy}></td>
+       <td>{{HTMLImageElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{input}></th>
+       <td>Form control</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>interactive</a>*;
+           <a lt="listed element">listed</a>;
+           <a>labelable</a>;
+           <a>submittable</a>;
+           <a>resettable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{input/accept}>;
+           <{input/alt}>;
+           <{input/autocapitalize}>;
+           <{input/autocomplete}>;
+           <{input/autofocus}>;
+           <{input/checked}>;
+           <{input/dirname}>;
+           <{input/disabled}>;
+           <{input/form}>;
+           <{input/formaction}>;
+           <{input/formenctype}>;
+           <{input/formmethod}>;
+           <{input/formnovalidate}>;
+           <{input/formtarget}>;
+           <{input/height}>;
+           <{input/list}>;
+           <{input/max}>;
+           <{input/maxlength}>;
+           <{input/min}>;
+           <{input/minlength}>;
+           <{input/multiple}>;
+           <{input/name}>;
+           <{input/pattern}>;
+           <{input/placeholder}>;
+           <{input/readonly}>;
+           <{input/required}>;
+           <{input/size}>;
+           <{input/src}>;
+           <{input/step}>;
+           <{input/type}>;
+           <{input/value}>;
+           <{input/width}></td>
+       <td>{{HTMLInputElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{ins}></th>
+       <td>An addition to the document</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>*</td>
+       <td><a>phrasing</a></td>
+       <td><a>transparent</a></td>
+       <td><a>globals</a>;
+           <{edits/cite}>;
+           <{edits/datetime}></td>
+       <td>{{HTMLModElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{kbd}></th>
+       <td>User input</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{label}></th>
+       <td>Caption for a form control</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>interactive</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td><a>globals</a>;
+           <{label/for}></td>
+       <td>{{HTMLLabelElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{legend}></th>
+       <td>Caption for <{fieldset}></td>
+       <td>none</td>
+       <td><{fieldset}>;
+           <{template}></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLLegendElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{li}></th>
+       <td>List item</td>
+       <td>none</td>
+       <td><{ol}>;
+           <{ul}>;
+           <{template}></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a>;
+           <{li/value}>*</td>
+       <td>{{HTMLLIElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{link}></th>
+       <td>Link metadata</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>*;
+           <a>phrasing</a>*</td>
+       <td><{head}>;
+           <{template}>;
+           <{noscript}>*;
+           <a>phrasing</a>*</td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{link/href}>;
+           <{link/crossorigin}>;
+           <{link/integrity}>;
+           <{link/rel}>;
+           <{link/media}>;
+           <{link/referrerpolicy}>;
+           <{link/nonce}>;
+           <{link/hreflang}>;
+           <{link/type}>;
+           <{link/sizes}></td>
+       <td>{{HTMLLinkElement}}</td>
+      </tr>
+
+      <tr>
+        <th><{main}></th>
+        <td>Main content of a document</td>
+        <td><a>flow</a></td>
+        <td><a>flow</a></td>
+        <td><a>flow</a>*</td>
+        <td><a>globals</a></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{map}></th>
+       <td><a>Image map</a></td>
+       <td><a>flow</a>;
+           <a>phrasing</a>*</td>
+       <td><a>phrasing</a></td>
+       <td><a>transparent</a>;
+           <{area}>*</td>
+       <td><a>globals</a>;
+           <{map/name}></td>
+       <td>{{HTMLMapElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{mark}></th>
+       <td>Highlight</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{meta}></th>
+       <td>Text metadata</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>*;
+           <a>phrasing</a>*</td>
+       <td><{head}>;
+           <{template}>;
+           <{noscript}>*;
+           <a>phrasing</a>*</td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{meta/name}>;
+           <{meta/http-equiv}>;
+           <{meta/content}>;
+           <{meta/charset}></td>
+       <td>{{HTMLMetaElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{meter}></th>
+       <td>Gauge</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>labelable</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td><a>globals</a>;
+           <{meter/value}>;
+           <{meter/min}>;
+           <{meter/max}>;
+           <{meter/low}>;
+           <{meter/high}>;
+           <{meter/optimum}></td>
+       <td>{{HTMLMeterElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{nav}></th>
+       <td>Section with navigational links</td>
+       <td><a>flow</a>;
+           <a>sectioning</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{noscript}></th>
+       <td>Fallback content for script</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>;
+           <a>phrasing</a></td>
+       <td><{head}>*;
+           <{template}>*;
+           <a>phrasing</a>*</td>
+       <td>varies*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{object}></th>
+       <td>Image, <a>nested browsing context</a>, or <a>plugin</a></td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a>*;
+           <a lt="listed element">listed</a>;
+           <a>submittable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><{param}>*;
+           <a>transparent</a></td>
+       <td><a>globals</a>;
+           <{object/data}>;
+           <{object/type}>;
+           <{object/typemustmatch}>;
+           <{object/name}>;
+           <{object/form}>;
+           <{media/width}>;
+           <{media/height}></td>
+       <td>{{HTMLObjectElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{ol}></th>
+       <td>Ordered list</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><{li}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a>;
+           <{ol/reversed}>;
+           <{ol/start}>;
+           <{ol/type}></td>
+       <td>{{HTMLOListElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{optgroup}></th>
+       <td>Group of options in a list box</td>
+       <td>none</td>
+       <td><{select}>;
+           <{template}></td>
+       <td><{option}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a>;
+           <{optgroup/disabled}>;
+           <{optgroup/label}></td>
+       <td>{{HTMLOptGroupElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{option}></th>
+       <td>Option in a list box or combo box control</td>
+       <td>none</td>
+       <td><{select}>;
+           <{datalist}>;
+           <{optgroup}>;
+           <{template}></td>
+       <td><a>text</a>*</td>
+       <td><a>globals</a>;
+           <{option/disabled}>;
+           <{option/label}>;
+           <{option/selected}>;
+           <{option/value}></td>
+       <td>{{HTMLOptionElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{output}></th>
+       <td>Calculated output value</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a lt="listed element">listed</a>;
+           <a>labelable</a>;
+           <a>resettable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a>;
+           <{output/for}>;
+           <{output/form}>;
+           <{output/name}></td>
+       <td>{{HTMLOutputElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{p}></th>
+       <td>Paragraph</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLParagraphElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{param}></th>
+       <td>Parameter for <{object}></td>
+       <td>none</td>
+       <td><{object}>;
+           <{template}></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{param/name}>;
+           <{param/value}></td>
+       <td>{{HTMLParamElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{picture}></th>
+       <td>Image</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a></td>
+       <td><a>phrasing</a></td>
+       <td><{source}>*; one <{img}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLPictureElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{pre}></th>
+       <td>Block of preformatted text</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLPreElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{progress}></th>
+       <td>Progress bar</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>labelable</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>*</td>
+       <td><a>globals</a>;
+           <{progress/value}>;
+           <{progress/max}></td>
+       <td>{{HTMLProgressElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{q}></th>
+       <td>Quotation</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a>;
+           <{q/cite}></td>
+       <td>{{HTMLQuoteElement}}</td>
+      </tr>
+
+      <tr>
+        <th><{rb}></th>
+        <td>Ruby base</td>
+        <td>none</td>
+        <td><{ruby}>;
          <{template}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-    <tr>
-     <th><{rp}></th>
-     <td>Parenthesis for ruby annotation text</td>
-     <td>none</td>
-     <td><{ruby}>;
-         <{rtc}>;
-         <{template}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+        <td><a>phrasing</a></td>
+        <td><a>globals</a></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{rt}></th>
-     <td>Ruby annotation text</td>
-     <td>none</td>
-     <td><{ruby}>;
-         <{rtc}>;
-         <{template}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+        <th><{rp}></th>
+        <td>Parenthesis for ruby annotation text</td>
+        <td>none</td>
+        <td><{ruby}>;
+           <{rtc}>;
+           <{template}></td>
+        <td><a>phrasing</a></td>
+        <td><a>globals</a></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
 
-     <tr>
-     <th><{rtc}></th>
-     <td>Ruby annotation text container</td>
-     <td>none</td>
-     <td><{ruby}>;
-         <{template}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
-    <tr>
-     <th><{ruby}></th>
-     <td>Ruby annotation(s)</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a>;
-         <{rp}>;
-         <{rt}>;
-         <{rb}>;
-         <{rtc}>*
-         </td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{rt}></th>
+       <td>Ruby annotation text</td>
+       <td>none</td>
+       <td><{ruby}>;
+           <{rtc}>;
+           <{template}></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{s}></th>
-     <td>Inaccurate text</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+        <th><{rtc}></th>
+        <td>Ruby annotation text container</td>
+        <td>none</td>
+        <td><{ruby}>;
+           <{template}></td>
+        <td><a>phrasing</a></td>
+        <td><a>globals</a></td>
+        <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{samp}></th>
-     <td>Computer output</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{ruby}></th>
+       <td>Ruby annotation(s)</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a>;
+           <{rp}>;
+           <{rt}>;
+           <{rb}>;
+           <{rtc}>*
+           </td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{script}></th>
-     <td>Embedded script</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>;
-         <a>phrasing</a>;
-         <a>script-supporting elements</a></td>
-     <td><{head}>;
-         <a>phrasing</a>;
-         <a>script-supporting elements</a></td>
-     <td>script, data, or script documentation*</td>
-     <td><a>globals</a>;
-         <{script/src}>;
-         <{script/type}>;
-         <{script/charset}>;
-         <{script/async}>;
-         <{script/defer}>;
-         <{script/crossorigin}>
-         <{script/integrity}></td>
-     <td>{{HTMLScriptElement}}</td>
-    </tr>
+      <tr>
+       <th><{s}></th>
+       <td>Inaccurate text</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{section}></th>
-     <td>Generic document or application section</td>
-     <td><a>flow</a>;
-         <a>sectioning</a></td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{samp}></th>
+       <td>Computer output</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{select}></th>
-     <td>List box control</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>interactive</a>;
-         <a lt="listed element">listed</a>;
-         <a>labelable</a>;
-         <a>submittable</a>;
-         <a>resettable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><{option}>;
-         <{optgroup}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a>;
-         <{select/autocomplete}>;
-         <{select/autofocus}>;
-         <{select/disabled}>;
-         <{select/form}>;
-         <{select/multiple}>;
-         <{select/name}>;
-         <{select/required}>;
-         <{select/size}></td>
-     <td>{{HTMLSelectElement}}</td>
-    </tr>
+      <tr>
+       <th><{script}></th>
+       <td>Embedded script</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>;
+           <a>phrasing</a>;
+           <a>script-supporting elements</a></td>
+       <td><{head}>;
+           <a>phrasing</a>;
+           <a>script-supporting elements</a></td>
+       <td>script, data, or script documentation*</td>
+       <td><a>globals</a>;
+           <{script/src}>;
+           <{script/type}>;
+           <{script/charset}>;
+           <{script/async}>;
+           <{script/defer}>;
+           <{script/crossorigin}>
+           <{script/integrity}></td>
+       <td>{{HTMLScriptElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{small}></th>
-     <td>Side comment</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{section}></th>
+       <td>Generic document or application section</td>
+       <td><a>flow</a>;
+           <a>sectioning</a></td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{source}></th>
-     <td>Media source for <{video}> or <{audio}> or as image source for <{picture}></td>
-     <td>none</td>
-     <td><{video}>;
-         <{audio}>;
-         <{template}>;
-         <{picture}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{source/src}>;
-         <{source/type}>;
-         <{source/srcset}>;
-         <{source/sizes}>;
-         <{source/media}></td>
-     <td>{{HTMLSourceElement}}</td>
-    </tr>
+      <tr>
+       <th><{select}></th>
+       <td>List box control</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>interactive</a>;
+           <a lt="listed element">listed</a>;
+           <a>labelable</a>;
+           <a>submittable</a>;
+           <a>resettable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><{option}>;
+           <{optgroup}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a>;
+           <{select/autocomplete}>;
+           <{select/autofocus}>;
+           <{select/disabled}>;
+           <{select/form}>;
+           <{select/multiple}>;
+           <{select/name}>;
+           <{select/required}>;
+           <{select/size}></td>
+       <td>{{HTMLSelectElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{span}></th>
-     <td>Generic phrasing container</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLSpanElement}}</td>
-    </tr>
+      <tr>
+       <th><{small}></th>
+       <td>Side comment</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{strong}></th>
-     <td>Importance</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{source}></th>
+       <td>Media source for <{video}> or <{audio}> or as image source for <{picture}></td>
+       <td>none</td>
+       <td><{video}>;
+           <{audio}>;
+           <{template}>;
+           <{picture}></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{source/src}>;
+           <{source/type}>;
+           <{source/srcset}>;
+           <{source/sizes}>;
+           <{source/media}></td>
+       <td>{{HTMLSourceElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{style}></th>
-     <td>Embedded styling information</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>*</td>
-     <td><{head}>;
-         <{noscript}>*;
-         <a>flow</a>*</td>
-     <td>varies*</td>
-     <td><a>globals</a>;
-         <{style/media}>;
-         <{style/nonce}>;
-         <{style/type}></td>
-     <td>{{HTMLStyleElement}}</td>
-    </tr>
+      <tr>
+       <th><{span}></th>
+       <td>Generic phrasing container</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLSpanElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{sub}></th>
-     <td>Subscript</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{strong}></th>
+       <td>Importance</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{summary}></th>
-     <td>Caption for <{details}></td>
-     <td>none</td>
-     <td><{details}></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{style}></th>
+       <td>Embedded styling information</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>*</td>
+       <td><{head}>;
+           <{noscript}>*;
+           <a>flow</a>*</td>
+       <td>varies*</td>
+       <td><a>globals</a>;
+           <{style/media}>;
+           <{style/nonce}>;
+           <{style/type}></td>
+       <td>{{HTMLStyleElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{sup}></th>
-     <td>Superscript</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{sub}></th>
+       <td>Subscript</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{table}></th>
-     <td>Table</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><{caption}>*;
-         <{colgroup}>*;
-         <{thead}>*;
-         <{tbody}>*;
-         <{tfoot}>*;
-         <{tr}>*;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a>;
-         <{table/border}></td>
-     <td>{{HTMLTableElement}}</td>
-    </tr>
+      <tr>
+       <th><{summary}></th>
+       <td>Caption for <{details}></td>
+       <td>none</td>
+       <td><{details}></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{tbody}></th>
-     <td>Group of rows in a table</td>
-     <td>none</td>
-     <td><{table}>;
-         <{template}></td>
-     <td><{tr}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTableSectionElement}}</td>
-    </tr>
+      <tr>
+       <th><{sup}></th>
+       <td>Superscript</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{td}></th>
-     <td>Table cell</td>
-     <td><a>sectioning root</a></td>
-     <td><{tr}>;
-         <{template}></td>
-     <td><a>flow</a></td>
-     <td><a>globals</a>;
-         <{tablecells/colspan}>;
-         <{tablecells/rowspan}>;
-         <{tablecells/headers}></td>
-     <td>{{HTMLTableDataCellElement}}</td>
-    </tr>
+      <tr>
+       <th><{table}></th>
+       <td>Table</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><{caption}>*;
+           <{colgroup}>*;
+           <{thead}>*;
+           <{tbody}>*;
+           <{tfoot}>*;
+           <{tr}>*;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a>;
+           <{table/border}></td>
+       <td>{{HTMLTableElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{template}></th>
-     <td>Template</td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>flow</a>;
-         <a>phrasing</a>;
-         <a>script-supporting elements</a></td>
-     <td><a lt="metadata content">metadata</a>;
-         <a>phrasing</a>;
-         <a>script-supporting elements</a>;
-         <{colgroup}>*</td>
-     <td>it's complicated*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTemplateElement}}</td>
-    </tr>
+      <tr>
+       <th><{tbody}></th>
+       <td>Group of rows in a table</td>
+       <td>none</td>
+       <td><{table}>;
+           <{template}></td>
+       <td><{tr}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTableSectionElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{textarea}></th>
-     <td>Multiline text field</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>interactive</a>;
-         <a lt="listed element">listed</a>;
-         <a>labelable</a>;
-         <a>submittable</a>;
-         <a>resettable</a>;
-         <a>reassociateable</a>;
-         <a>form-associated</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>text</a></td>
-     <td><a>globals</a>;
-         <{textarea/autocapitalize}>;
-         <{textarea/autofocus}>;
-         <{textarea/cols}>;
-         <{textarea/dirname}>;
-         <{textarea/disabled}>;
-         <{textarea/form}>;
-         <{textarea/maxlength}>;
-         <{textarea/minlength}>;
-         <{textarea/name}>;
-         <{textarea/placeholder}>;
-         <{textarea/readonly}>;
-         <{textarea/required}>;
-         <{textarea/rows}>;
-         <{textarea/wrap}></td>
-     <td>{{HTMLTextAreaElement}}</td>
-    </tr>
+      <tr>
+       <th><{td}></th>
+       <td>Table cell</td>
+       <td><a>sectioning root</a></td>
+       <td><{tr}>;
+           <{template}></td>
+       <td><a>flow</a></td>
+       <td><a>globals</a>;
+           <{tablecells/colspan}>;
+           <{tablecells/rowspan}>;
+           <{tablecells/headers}></td>
+       <td>{{HTMLTableDataCellElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{tfoot}></th>
-     <td>Group of footer rows in a table</td>
-     <td>none</td>
-     <td><{table}>;
-         <{template}></td>
-     <td><{tr}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTableSectionElement}}</td>
-    </tr>
+      <tr>
+       <th><{template}></th>
+       <td>Template</td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>flow</a>;
+           <a>phrasing</a>;
+           <a>script-supporting elements</a></td>
+       <td><a lt="metadata content">metadata</a>;
+           <a>phrasing</a>;
+           <a>script-supporting elements</a>;
+           <{colgroup}>*</td>
+       <td>it's complicated*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTemplateElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{th}></th>
-     <td>Table header cell</td>
-     <td><a>interactive</a>*</td>
-     <td><{tr}>;
-         <{template}></td>
-     <td><a>flow</a>*</td>
-     <td><a>globals</a>;
-         <{tablecells/colspan}>;
-         <{tablecells/rowspan}>;
-         <{tablecells/headers}>;
-         <{th/scope}>;
-         <{th/abbr}></td>
-     <td>{{HTMLTableHeaderCellElement}}</td>
-    </tr>
+      <tr>
+       <th><{textarea}></th>
+       <td>Multiline text field</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>interactive</a>;
+           <a lt="listed element">listed</a>;
+           <a>labelable</a>;
+           <a>submittable</a>;
+           <a>resettable</a>;
+           <a>reassociateable</a>;
+           <a>form-associated</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>text</a></td>
+       <td><a>globals</a>;
+           <{textarea/autocapitalize}>;
+           <{textarea/autofocus}>;
+           <{textarea/cols}>;
+           <{textarea/dirname}>;
+           <{textarea/disabled}>;
+           <{textarea/form}>;
+           <{textarea/maxlength}>;
+           <{textarea/minlength}>;
+           <{textarea/name}>;
+           <{textarea/placeholder}>;
+           <{textarea/readonly}>;
+           <{textarea/required}>;
+           <{textarea/rows}>;
+           <{textarea/wrap}></td>
+       <td>{{HTMLTextAreaElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{thead}></th>
-     <td>Group of heading rows in a table</td>
-     <td>none</td>
-     <td><{table}>;
-         <{template}></td>
-     <td><{tr}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTableSectionElement}}</td>
-    </tr>
+      <tr>
+       <th><{tfoot}></th>
+       <td>Group of footer rows in a table</td>
+       <td>none</td>
+       <td><{table}>;
+           <{template}></td>
+       <td><{tr}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTableSectionElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{time}></th>
-     <td>Machine-readable equivalent of date- or time-related data</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a>;
-         <{time/datetime}></td>
-     <td>{{HTMLTimeElement}}</td>
-    </tr>
+      <tr>
+       <th><{th}></th>
+       <td>Table header cell</td>
+       <td><a>interactive</a>*</td>
+       <td><{tr}>;
+           <{template}></td>
+       <td><a>flow</a>*</td>
+       <td><a>globals</a>;
+           <{tablecells/colspan}>;
+           <{tablecells/rowspan}>;
+           <{tablecells/headers}>;
+           <{th/scope}>;
+           <{th/abbr}></td>
+       <td>{{HTMLTableHeaderCellElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{title}></th>
-     <td>Document title</td>
-     <td><a lt="metadata content">metadata</a></td>
-     <td><{head}>;
-         <{template}></td>
-     <td><a>text</a>*</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTitleElement}}</td>
-    </tr>
+      <tr>
+       <th><{thead}></th>
+       <td>Group of heading rows in a table</td>
+       <td>none</td>
+       <td><{table}>;
+           <{template}></td>
+       <td><{tr}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTableSectionElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{tr}></th>
-     <td>Table row</td>
-     <td>none</td>
-     <td><{table}>;
-         <{thead}>;
-         <{tbody}>;
-         <{tfoot}>;
-         <{template}></td>
-     <td><{th}>*;
-         <{td}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLTableRowElement}}</td>
-    </tr>
+      <tr>
+       <th><{time}></th>
+       <td>Machine-readable equivalent of date- or time-related data</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a>;
+           <{time/datetime}></td>
+       <td>{{HTMLTimeElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{track}></th>
-     <td>Timed text track</td>
-     <td>none</td>
-     <td><{audio}>;
-         <{video}>;
-         <{template}></td>
-     <td>empty</td>
-     <td><a>globals</a>;
-         <{track/default}>;
-         <{track/kind}>;
-         <{track/label}>;
-         <{track/src}>;
-         <{track/srclang}></td>
-     <td>{{HTMLTrackElement}}</td>
-    </tr>
+      <tr>
+       <th><{title}></th>
+       <td>Document title</td>
+       <td><a lt="metadata content">metadata</a></td>
+       <td><{head}>;
+           <{template}></td>
+       <td><a>text</a>*</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTitleElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{u}></th>
-     <td>Keywords</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{tr}></th>
+       <td>Table row</td>
+       <td>none</td>
+       <td><{table}>;
+           <{thead}>;
+           <{tbody}>;
+           <{tfoot}>;
+           <{template}></td>
+       <td><{th}>*;
+           <{td}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLTableRowElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{ul}></th>
-     <td>List</td>
-     <td><a>flow</a></td>
-     <td><a>flow</a></td>
-     <td><{li}>;
-         <a>script-supporting elements</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLUListElement}}</td>
-    </tr>
+      <tr>
+       <th><{track}></th>
+       <td>Timed text track</td>
+       <td>none</td>
+       <td><{audio}>;
+           <{video}>;
+           <{template}></td>
+       <td>empty</td>
+       <td><a>globals</a>;
+           <{track/default}>;
+           <{track/kind}>;
+           <{track/label}>;
+           <{track/src}>;
+           <{track/srclang}></td>
+       <td>{{HTMLTrackElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{var}></th>
-     <td>Variable</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{u}></th>
+       <td>Keywords</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{video}></th>
-     <td>Video player</td>
-     <td><a>flow</a>;
-         <a>phrasing</a>;
-         <a>embedded</a>;
-         <a>interactive</a></td>
-     <td><a>phrasing</a></td>
-     <td><{source}>*;
-         <a>transparent</a>*</td>
-     <td><a>globals</a>;
-         <{media/src}>;
-         <{media/crossorigin}>;
-         <{media/disableRemotePlayback}>;
-         <{video/poster}>;
-         <{media/preload}>;
-         <{media/autoplay}>;
-         <{media/loop}>;
-         <{media/muted}>;
-         <{video/controls}>;
-         <{media/width}>;
-         <{media/height}></td>
-     <td>{{HTMLVideoElement}}</td>
-    </tr>
+      <tr>
+       <th><{ul}></th>
+       <td>List</td>
+       <td><a>flow</a></td>
+       <td><a>flow</a></td>
+       <td><{li}>;
+           <a>script-supporting elements</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLUListElement}}</td>
+      </tr>
 
-    <tr>
-     <th><{wbr}></th>
-     <td>Line breaking opportunity</td>
-     <td><a>flow</a>;
-         <a>phrasing</a></td>
-     <td><a>phrasing</a></td>
-     <td>empty</td>
-     <td><a>globals</a></td>
-     <td>{{HTMLElement}}</td>
-    </tr>
+      <tr>
+       <th><{var}></th>
+       <td>Variable</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
 
-  </tbody></table>
+      <tr>
+       <th><{video}></th>
+       <td>Video player</td>
+       <td><a>flow</a>;
+           <a>phrasing</a>;
+           <a>embedded</a>;
+           <a>interactive</a></td>
+       <td><a>phrasing</a></td>
+       <td><{source}>*;
+           <a>transparent</a>*</td>
+       <td><a>globals</a>;
+           <{media/src}>;
+           <{media/crossorigin}>;
+           <{media/disableRemotePlayback}>;
+           <{video/poster}>;
+           <{media/preload}>;
+           <{media/autoplay}>;
+           <{media/loop}>;
+           <{media/muted}>;
+           <{video/controls}>;
+           <{media/width}>;
+           <{media/height}></td>
+       <td>{{HTMLVideoElement}}</td>
+      </tr>
+
+      <tr>
+       <th><{wbr}></th>
+       <td>Line breaking opportunity</td>
+       <td><a>flow</a>;
+           <a>phrasing</a></td>
+       <td><a>phrasing</a></td>
+       <td>empty</td>
+       <td><a>globals</a></td>
+       <td>{{HTMLElement}}</td>
+      </tr>
+    </tbody>
+  </table>
 
   <p class="tablenote"><small>An asterisk (*) in a cell indicates that the actual rules are more
   complicated than indicated in the table above.</small></p>

--- a/sections/events.include
+++ b/sections/events.include
@@ -26,61 +26,61 @@
     </thead>
     <tbody>
       <tr> <!-- abort -->
-        <td><dfn event for="global"><code>abort</code></dfn></td>
+        <th><dfn event for="global"><code>abort</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the download was aborted by the user</td>
       </tr>
       <tr> <!-- DOMContentLoaded -->
-        <td><dfn event for="global"><code>DOMContentLoaded</code></dfn></td>
+        <th><dfn event for="global"><code>DOMContentLoaded</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Document}}</td>
         <td>Fired at the {{Document}} once the parser has finished</td>
       </tr>
       <tr> <!-- afterprint -->
-        <td><dfn event for="global"><code>afterprint</code></dfn></td>
+        <th><dfn event for="global"><code>afterprint</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} after printing</td>
       </tr>
       <tr> <!-- afterscriptexecute -->
-        <td><dfn event for="global"><code>afterscriptexecute</code></dfn></td>
+        <th><dfn event for="global"><code>afterscriptexecute</code></dfn></th>
         <td>{{Event}}</td>
         <td><{script}> elements</td>
         <td>Fired at <{script}> elements after the script runs (just before the corresponding <a event for="global"><code>load</code></a> event)</td>
       </tr>
       <tr> <!-- beforeprint -->
-        <td><dfn event for="global"><code>beforeprint</code></dfn></td>
+        <th><dfn event for="global"><code>beforeprint</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} before printing</td>
       </tr>
       <tr> <!-- beforescriptexecute -->
-        <td><dfn event for="global"><code>beforescriptexecute</code></dfn></td>
+        <th><dfn event for="global"><code>beforescriptexecute</code></dfn></th>
         <td>{{Event}}</td>
         <td><{script}> elements</td>
         <td>Fired at <{script}> elements just before the script runs; canceling the event cancels the running of the script</td>
       </tr>
       <tr> <!-- beforeunload -->
-        <td><dfn event for="global"><code>beforeunload</code></dfn></td>
+        <th><dfn event for="global"><code>beforeunload</code></dfn></th>
         <td>{{BeforeUnloadEvent}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the page is about to be unloaded, in case the page would like to show a warning prompt</td>
       </tr>
       <tr> <!-- blur -->
-        <td><dfn event for="global"><code>blur</code></dfn></td>
+        <th><dfn event for="global"><code>blur</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}, elements</td>
         <td>Fired at nodes losing focus</td>
       </tr>
       <tr> <!-- cancel -->
-        <td><dfn event for="global"><code>cancel</code></dfn></td>
+        <th><dfn event for="global"><code>cancel</code></dfn></th>
         <td>{{Event}}</td>
         <td><{dialog}> elements</td>
         <td>Fired at <{dialog}> elements when they are canceled by the user (e.g., by pressing the Escape key)</td>
       </tr>
       <tr> <!-- change -->
-        <td><dfn event for="global"><code>change</code></dfn></td>
+        <th><dfn event for="global"><code>change</code></dfn></th>
         <td>{{Event}}</td>
         <td>Form controls</td>
         <td>Fired at controls when the user commits a value change (see also the <a event for="global"><code>input</code></a> event)</td>
@@ -92,19 +92,19 @@
         <td>Normally a mouse event; also synthetically fired at an element before its <a>activation behavior</a> is run, when an element is activated from a non-pointer input device (e.g., a keyboard)</td>
       </tr>
       <tr> <!-- close -->
-        <td><dfn event for="global"><code>close</code></dfn></td>
+        <th><dfn event for="global"><code>close</code></dfn></th>
         <td>{{Event}}</td>
         <td><{dialog}> elements, <code>WebSocket</code></td>
         <td>Fired at <a><code>dialog</code></a> elements when they are closed, and at <code>WebSocket</code> elements when the connection is terminated</td>
       </tr>
       <tr> <!-- copy -->
-        <td><dfn event for="global"><code>copy</code></dfn></td>
+        <th><dfn event for="global"><code>copy</code></dfn></th>
         <td>{{Event}}</td>
         <td>Elements</td>
         <td>Fired at elements when the user copies data to the clipboard</td>
       </tr>
       <tr> <!-- cut -->
-        <td><dfn event for="global"><code>cut</code></dfn></td>
+        <th><dfn event for="global"><code>cut</code></dfn></th>
         <td>{{Event}}</td>
         <td>Elements</td>
         <td>
@@ -113,109 +113,109 @@
         </td>
       </tr>
       <tr> <!-- error -->
-        <td><dfn event for="global"><code>error</code></dfn></td>
+        <th><dfn event for="global"><code>error</code></dfn></th>
         <td>{{Event}}</td>
         <td>Global scope objects, {{Worker}} objects, elements, networking-related objects</td>
         <td>Fired when unexpected errors occur (e.g., networking errors, script errors, decoding errors)</td>
       </tr>
       <tr> <!-- focus -->
-        <td><dfn event for="global"><code>focus</code></dfn></td>
+        <th><dfn event for="global"><code>focus</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}, elements</td>
         <td>Fired at nodes gaining focus</td>
       </tr>
       <tr> <!-- focusin -->
-        <td><dfn event for="global"><code>focusin</code></dfn></td>
+        <th><dfn event for="global"><code>focusin</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}, elements</td>
         <td>Fired at nodes gaining focus</td>
       </tr>
       <tr> <!-- focusout -->
-        <td><dfn event for="global"><code>focusout</code></dfn></td>
+        <th><dfn event for="global"><code>focusout</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}, elements</td>
         <td>Fired at nodes losing focus</td>
       </tr>
       <tr> <!-- hashchange -->
-        <td><dfn event for="global"><code>hashchange</code></dfn></td>
+        <th><dfn event for="global"><code>hashchange</code></dfn></th>
         <td>{{HashChangeEvent}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the <a for="url">fragment</a> part of the document's [=Document/URL=] changes</td>
       </tr>
       <tr> <!-- input -->
-        <td><dfn event for="global"><code>input</code></dfn></td>
+        <th><dfn event for="global"><code>input</code></dfn></th>
         <td>{{Event}}</td>
         <td>Form controls</td>
         <td>Fired at controls when the user changes the value (see also the <a event for="global"><code>change</code></a> event)</td>
       </tr>
       <tr> <!-- invalid -->
-        <td><dfn event for="global"><code>invalid</code></dfn></td>
+        <th><dfn event for="global"><code>invalid</code></dfn></th>
         <td>{{Event}}</td>
         <td>Form controls</td>
         <td>Fired at controls during form validation if they do not satisfy their constraints</td>
       </tr>
       <tr> <!-- languagechange -->
-        <td><dfn event for="global"><code>languagechange</code></dfn></td>
+        <th><dfn event for="global"><code>languagechange</code></dfn></th>
         <td>{{Event}}</td>
         <td>Global scope objects</td>
         <td>Fired at the global scope object when the user's preferred languages change</td>
       </tr>
       <tr> <!-- load -->
-        <td><dfn event for="global"><code>load</code></dfn></td>
+        <th><dfn event for="global"><code>load</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}, elements</td>
         <td>Fired at the {{Window}} when the document has finished loading; fired at an element containing a resource (e.g., <{img}>, <{embed}>) when its resource has finished loading</td>
       </tr>
       <tr> <!-- loadend -->
-        <td><dfn event for="global"><code>loadend</code></dfn></td>
+        <th><dfn event for="global"><code>loadend</code></dfn></th>
         <td>{{Event}} or {{ProgressEvent}}</td>
         <td><{img}> elements</td>
         <td>Fired at <{img}> elements after a successful load (see also <a href="#media-elements-event-summary">media element events</a>)</td>
       </tr>
       <tr> <!-- loadstart -->
-        <td><dfn event for="global"><code>loadstart</code></dfn></td>
+        <th><dfn event for="global"><code>loadstart</code></dfn></th>
         <td>{{ProgressEvent}}</td>
         <td><{img}> elements</td>
         <td>Fired at <{img}> elements when a load begins (see also <a href="#media-elements-event-summary">media element events</a>)</td>
       </tr>
       <tr> <!-- message -->
-        <td><dfn event for="global"><code>message</code></dfn></td>
+        <th><dfn event for="global"><code>message</code></dfn></th>
         <td><code>MessageEvent</code></td>
         <td>{{Window}}, <code>EventSource</code>, <code>WebSocket</code>, <code>MessagePort</code>, <code>BroadcastChannel</code>, <code>DedicatedWorkerGlobalScope</code>, {{Worker}}</td>
         <td>Fired at an object when it receives a message</td>
       </tr>
       <tr> <!-- offline -->
-        <td><dfn event for="global"><code>offline</code></dfn></td>
+        <th><dfn event for="global"><code>offline</code></dfn></th>
         <td>{{Event}}</td>
         <td>Global scope objects</td>
         <td>Fired at the global scope object when the network connections fails</td>
       </tr>
       <tr> <!-- online -->
-        <td><dfn event for="global"><code>online</code></dfn></td>
+        <th><dfn event for="global"><code>online</code></dfn></th>
         <td>{{Event}}</td>
         <td>Global scope objects</td>
         <td>Fired at the global scope object when the network connections returns</td>
       </tr>
       <tr> <!-- open -->
-        <td><dfn event for="global"><code>open</code></dfn></td>
+        <th><dfn event for="global"><code>open</code></dfn></th>
         <td>{{Event}}</td>
         <td><code>EventSource</code>, <code>WebSocket</code></td>
         <td>Fired at networking-related objects when a connection is established</td>
       </tr>
       <tr> <!-- pagehide -->
-        <td><dfn event for="global"><code>pagehide</code></dfn></td>
+        <th><dfn event for="global"><code>pagehide</code></dfn></th>
         <td>{{PageTransitionEvent}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the page's entry in the <a>session history</a> stops being the <a>current entry</a></td>
       </tr>
       <tr> <!-- pageshow -->
-        <td><dfn event for="global"><code>pageshow</code></dfn></td>
+        <th><dfn event for="global"><code>pageshow</code></dfn></th>
         <td>{{PageTransitionEvent}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the page's entry in the <a>session history</a> becomes the <a>current entry</a></td>
       </tr>
       <tr> <!-- paste -->
-        <td><dfn event for="global"><code>paste</code></dfn></td>
+        <th><dfn event for="global"><code>paste</code></dfn></th>
         <td>{{Event}}</td>
         <td>Elements</td>
         <td>
@@ -224,55 +224,55 @@
         </td>
       </tr>
       <tr> <!-- popstate -->
-        <td><dfn event for="global"><code>popstate</code></dfn></td>
+        <th><dfn event for="global"><code>popstate</code></dfn></th>
         <td>{{PopStateEvent}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} when the user navigates the <a>session history</a></td>
       </tr>
       <tr> <!-- progress -->
-        <td><dfn event for="global"><code>progress</code></dfn></td>
+        <th><dfn event for="global"><code>progress</code></dfn></th>
         <td>{{ProgressEvent}}</td>
         <td><{img}> elements</td>
         <td>Fired at <{img}> elements during a <a>CORS-same-origin</a> image load (see also <a href="#media-elements-event-summary">media element events</a>)</td>
       </tr>
       <tr> <!-- readystatechange -->
-        <td><dfn event for="global">{{global/readystatechange}}</dfn></td>
+        <th><dfn event for="global">{{global/readystatechange}}</dfn></th>
         <td>{{Event}}</td>
         <td>{{Document}}</td>
         <td>Fired at the {{Document}} when it finishes parsing and again when all its subresources have finished loading</td>
       </tr>
       <tr> <!-- reset -->
-        <td><dfn event for="global"><code>reset</code></dfn></td>
+        <th><dfn event for="global"><code>reset</code></dfn></th>
         <td>{{Event}}</td>
         <td><{form}> elements</td>
         <td>Fired at a <{form}> element when it is <a>reset</a></td>
       </tr>
       <tr> <!-- select -->
-        <td><dfn event for="global"><code>select</code></dfn></td>
+        <th><dfn event for="global"><code>select</code></dfn></th>
         <td>{{Event}}</td>
         <td>Form controls</td>
         <td>Fired at form controls when their text selection is adjusted (whether by an API or by the user)</td>
       </tr>
       <tr> <!-- storage -->
-        <td><dfn event for="global"><code>storage</code></dfn></td>
+        <th><dfn event for="global"><code>storage</code></dfn></th>
         <td><code>StorageEvent</code></td>
         <td>{{Window}}</td>
         <td>Fired at {{Window}} event when the corresponding <code>localStorage</code> or <code>sessionStorage</code> storage areas change</td>
       </tr>
       <tr> <!-- submit -->
-        <td><dfn event for="global"><code>submit</code></dfn></td>
+        <th><dfn event for="global"><code>submit</code></dfn></th>
         <td>{{Event}}</td>
         <td><{form}> elements</td>
         <td>Fired at a <{form}> element when it is <a>submitted</a></td>
       </tr>
       <tr> <!-- toggle -->
-        <td><dfn event for="global"><code>toggle</code></dfn></td>
+        <th><dfn event for="global"><code>toggle</code></dfn></th>
         <td>{{Event}}</td>
         <td><{details}> element</td>
         <td>Fired at <{details}> elements when they open or close</td>
       </tr>
       <tr> <!-- unload -->
-        <td><dfn event for="global"><code>unload</code></dfn></td>
+        <th><dfn event for="global"><code>unload</code></dfn></th>
         <td>{{Event}}</td>
         <td>{{Window}}</td>
         <td>Fired at the {{Window}} object when the page is going away</td>
@@ -280,4 +280,4 @@
     </tbody>
   </table>
 
-  See also <a href="#media-elements-event-summary">media element events</a> and <a>drag-and-drop events</a>.
+  <p class="tablenote"><small>See also <a href="#media-elements-event-summary">media element events</a> and <a>drag-and-drop events</a>.</small></p>

--- a/sections/events.include
+++ b/sections/events.include
@@ -1,4 +1,16 @@
-<h3 class="no-num" id="events-table">Events</h3> 
+<!--
+
+  EVENTS
+
+  This source produces the "events" section of the Index:
+  https://w3c.github.io/html/fullindex.html#events-table
+
+  This document contains a non-normative table listing of all events defined in the spec.
+
+-->
+
+
+<h3 class="no-num" id="events-table">Events</h3>
 
   <em>This section is non-normative.</em>
 

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1,5 +1,20 @@
 <section>
 
+<!--
+
+  SECTIONS
+
+  This source produces section 4.3 Sections:
+  https://w3c.github.io/html/sections.html
+
+It covers
+- elements used to create the sectioning root, content sections within the document outline, and headings:
+    body, article, section, nav, aside, h1-h6, header, footer
+- headings and sections and creating an outline
+- summary of usage for the above mentioned elements
+
+-->
+
 <h3 id="sections">Sections</h3>
 <h4 id="the-body-element">The <dfn element><code>body</code></dfn> element</h4>
 


### PR DESCRIPTION
More cleanup of source files pertaining to [issue 1201](https://github.com/w3c/html/issues/1201).

Adds updated source header notes for the following:

- attributes.include
- element-content-categories.include
- element-interfaces.include
- elements.include
- events.include
- semantics-sections.include

These updates also includes table formatting and creating better source consistency across the Spec Index files that were updated.

Will add more sections to this PR as time permits.