### PR TITLE
list textarea under autocapitalize attribute

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -75,7 +75,7 @@
     </tr>
     <tr>
       <th><{input/autocapitalize}></th>
-      <td><{input}></td>
+      <td><{input}>; <{textarea}></td>
       <td>Hint for the capitalization of the inputted text</td>
       <td>"<a attr-value for="input/autocapitalize"><code>sentences</code></a>";
       "<a attr-value for="input/autocapitalize"><code>words</code></a>";


### PR DESCRIPTION
[fix issue 1205](https://github.com/w3c/html/issues/1205) - add `textarea` to `autocapitalize` listing.