### PR TITLE
removal of fileapi monkey patch

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -1,12 +1,25 @@
  <section>
+
  <h2 class="no-num" id="changes">Changes</h2>
 
-  This section summarises substantial <em>substantive</em> changes between Public Working Drafts, as a guide for general review.
+  This section summarises substantial <em>substantive</em> changes between Public Working Drafts,
+  as a guide for general review.
 
-  Full details of all changes since 12 January 2016 are available from the <a href="https://github.com/w3c/html/commits/master">commit log</a> of the <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various editorial and linking fixes.
+  Full details of all changes since 12 January 2016 are available from the
+  <a href="https://github.com/w3c/html/commits/master">commit log</a> of the
+  <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various
+  editorial and linking fixes.
 
-  <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
+<h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
+
   <dl>
+    <dt>
+      <a href="">Remove monkey-patch 2.9.10 for FileAPI</a>
+    </dt>
+    <dd>
+      FileAPI is better defined in <a href="https://w3c.github.io/FileAPI/">FileApi spec</a>.
+      Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
+    </dd>
       <dt><a href="https://github.com/w3c/html/pull/1220">Other Pragma Directives removed.</a></dt>
         <dd>Change to match reality. Fixed <a href="https://github.com/w3c/html/issues/1212">issue 1212</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1204">Caption end tag can be ommitted.</a></dt>
@@ -15,6 +28,7 @@
 
 <h3 id="changes-wd2">Changes between the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a>
 and the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First Public Working Draft</a></h3>
+
   <dl>
     <dt><a href="https://github.com/w3c/html/pull/1186">Add missing <code>link rel</code> definitions.</a></dt>
       <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/987">issue 987</a></dd>
@@ -32,7 +46,7 @@ and the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First 
     <dt><a href="https://github.com/w3c/html/pull/1123">Removing magic alignment for <code>dialog</code> element</a></dt>
         <dd>Removed due to lack of implementation. Fixed <a href="https://github.com/w3c/html/issues/1108">issue 1108</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/tbd">nonce now uses</a> the <a href="#cryptographicnonce">[[<span>CryptographicNonce</span>]]</a></dt>
-        <dd><a href="https://github.com/w3c/html/issues/1121">Hide `nonce` content attribute</a></dd>  
+        <dd><a href="https://github.com/w3c/html/issues/1121">Hide `nonce` content attribute</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1152">Removed section on <code>anchor-points</code></a></dt>
             <dd>Substantive change. Fixed <a href="https://github.com/w3c/html/issues/1104">issue 1104</a></dd>
     <dt><a href="https://github.com/w3c/html/pull/1167">Added <code>disableRemotePlayback</code> to the <code>HTMLMediaElement</code> interface</a></dt>
@@ -58,4 +72,4 @@ and the <a href="https://www.w3.org/TR/2017/WD-html53-20171214/">HTML 5.3 First 
       <dd>Fixed <a href="https://github.com/w3c/html/issues/208">Issue 208</a></dd>
   </dl>
 
-  </section>
+</section>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1,19 +1,21 @@
 <section>
+
 <!--
 
-         INFRASTRUCTURE
+    INFRASTRUCTURE
 
-This section produces chapter 2: Common Infrastructure https://w3c.github.io/html/infrastructure.html
+  This section produces chapter 2: Common Infrastructure
+  https://w3c.github.io/html/infrastructure.html
 
-It covers
-- Terminology
-- How Conformance Requirements are described
-- Case sensitivity and comparing strings
-- Common "micro" syntaxes
-- URLs and Fetching resources, including referrer and nonce attributes
-- Reflection of attributes
-- DOM collections
-- De/serialising to pass structured objects
+  It covers:
+  - Terminology
+  - How Conformance Requirements are described
+  - Case sensitivity and comparing strings
+  - Common "micro" syntaxes
+  - URLs and Fetching resources, including referrer and nonce attributes
+  - Reflection of attributes
+  - DOM collections
+  - De/serialising to pass structured objects
 
 -->
 
@@ -5365,76 +5367,5 @@ o.myself = o;</pre>
   the appropriate preparations beforehand. As of this time, we know of no such APIs on the platform;
   usually it is simpler to perform the serialization ahead of time, as a synchronous consequence of
   author code.</p>
-
-  <h4 id="monkey-patch-for-blob-and-filelist-objects">Monkey patch for <code>Blob</code> and <code>FileList</code> objects</h4>
-
-  <p class="&#x0058;&#x0058;&#x0058;">This monkey patch will be moved in due course. See
-  <a href="https://github.com/w3c/FileAPI/issues/32">w3c/FileAPI issue 32</a>.</p>
-
-  <code>Blob</code> objects are <a>serializable objects</a>. The <code>Blob</code>
-  interface must be annotated with the <code data-x="Serializable">[Serializable]</code>
-  <a>extended attribute</a>. Their <a>serialization steps</a>, given <var>value</var>
-  and <var>serialized</var>, are:
-
-  1. Set <var>serialized</var>.\[[SnapshotState]] to <var>value</var>'s <a>snapshot state</a>.
-
-  2. Set <var>serialized</var>.\[[ByteSequence]] to <var>value</var>'s underlying byte sequence.
-
-  Their <a>deserialization steps</a>, given <var>serialized</var> and <var>value</var>, are:
-
-  1. Set <var>value</var>'s <a>snapshot state</a> to
-     <var>serialized</var>.\[[SnapshotState]].
-
-  2. Set <var>value</var>'s underlying byte sequence to
-     <var>serialized</var>.\[[ByteSequence]].
-
-  <hr>
-
-  <code>File</code> objects are <a>serializable objects</a>. The <code>File</code>
-  interface must be annotated with the <code>[Serializable]</code>
-  <a>extended attribute</a>. Their <a>serialization steps</a>, given <var>value</var>
-  and <var>serialized</var>, are:
-
-  1. Set <var>serialized</var>.\[[SnapshotState]] to <var>value</var>'s <a>snapshot state</a>.
-
-  2. Set <var>serialized</var>.\[[ByteSequence]] to <var>value</var>'s underlying byte sequence.
-
-  3. Set <var>serialized</var>.\[[Name]] to the value of <var>value</var>'s
-     <code>name</code> attribute.
-
-  4. Set <var>serialized</var>.\[[LastModified]] to the value of <var>value</var>'s
-     <code>lastModified</code> attribute.
-
-  Their <a>deserialization steps</a>, given <var>serialized</var> and <var>value</var>, are:
-
-  1. Set <var>value</var>'s <a>snapshot state</a> to
-     <var>serialized</var>.\[[SnapshotState]].
-
-  2. Set <var>value</var>'s underlying byte sequence to
-     <var>serialized</var>.\[[ByteSequence]].
-
-  3. Initialize the value of <var>value</var>'s <code>name</code>
-     attribute to <var>serialized</var>.\[[Name]].
-
-  4. Initialize the value of <var>value</var>'s <code>lastModified</code> attribute to
-     <var>serialized</var>.\[[LastModified]].
-
-  <hr>
-
-  <code>FileList</code> objects are <a>serializable objects</a>. The <code>FileList</code>
-  interface must be annotated with the <code>[Serializable]</code>
-  <a>extended attribute</a>. Their <a>serialization steps</a>, given <var>value</var>
-  and <var>serialized</var>, are:
-
-  1. Set <var>serialized</var>.\[[Files]] to an empty <a for="ecma">List</a>.
-
-  2. For each <var>file</var> in <var>value</var>, <a>append</a>
-     the <a>sub-serialization</a> of <var>file</var> to
-     <var>serialized</var>.\[[Files]].
-
-  Their <a>deserialization steps</a>, given <var>serialized</var> and <var>value</var>, are:
-
-  1. <a>For each</a> <var>file</var> of <var>serialized</var>.\[[Files]],
-     add the <a>sub-deserialization</a> of <var>file</var> to <var>value</var>.
 
 </section>


### PR DESCRIPTION
[fix #1217](https://github.com/w3c/html/issues/1217)

The primary purpose of this commit is to remove the fileAPI monkey patch.

Additionally, the infrastructure source header is revised to resemble other source header content.

changes.include is updated to reference the substantial change of removing the monkey patch.