### PR TITLE
Update/add source header comments (continued)

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -4,7 +4,7 @@
 
     Browsers
 
-  This source produces chapter 6:
+  This source produces Chapter 6: Loading Web pages
   https://w3c.github.io/html/browsers.html
 
   It covers Window and WindowProxy objects,

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -7,7 +7,7 @@
   This source produces chapter 3: "Semantics, structure, and APIs of HTML documents"
   https://w3c.github.io/html/dom.html
 
-  It covers
+  It covers:
   - the "Document" object, significantly extending what is defined in the DOM specification
       including attributes of it like document.cookies, document.referrer, document.head, document.forms, etc.
   - The HTMLElement interface

--- a/sections/iana.include
+++ b/sections/iana.include
@@ -4,11 +4,10 @@
 
     IANA
 
-  This source produces Chapter 12: "IANA considerations"
+  This source produces Chapter 12: IANA considerations
   https://w3c.github.io/html/iana.html
 
   It covers:
-
   - text/html
   - multipart/x-mixed-replace
   - applicatoin/xhtml+xml

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -4,7 +4,7 @@
 
     Infrastructure
 
-  This section produces chapter 2: Common Infrastructure
+  This section produces Chapter 2: Common Infrastructure
   https://w3c.github.io/html/infrastructure.html
 
   It covers:

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -15,7 +15,7 @@
   - some privacy considerations
   - an introduction to HTML itself, how to write it, etc.
   - non-normative conformance requirements for content
-  - links to some other specs: charmod, unicode security, and some accessibility specs
+  - links to some other specs: charmod, Unicode security, and some accessibility specs
 
 -->
 

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -1,16 +1,21 @@
 <section>
+
 <!--
 
-This is the source file for Introduction.html
-All the content is "non-normative". It contains
-- a background / potted history of HTML
-- a few design notes
-- a note on HTML and XML syntax
-- information on how the spec is written and how to read it
-- some privacy considerations
-- an introduction to HTML itself, how to write it, etc.
-- non-normative conformance requirements for content
-- links to some other specs: charmod, unicode security, and some accessibility specs
+    Introduction
+
+ This source produces Chapter 1: Introduction
+ https://w3c.github.io/html/introduction.html
+
+  All the content is "non-normative". It covers:
+  - a background / potted history of HTML
+  - a few design notes
+  - a note on HTML and XML syntax
+  - information on how the spec is written and how to read it
+  - some privacy considerations
+  - an introduction to HTML itself, how to write it, etc.
+  - non-normative conformance requirements for content
+  - links to some other specs: charmod, unicode security, and some accessibility specs
 
 -->
 

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -1,13 +1,17 @@
 <section>
+
 <!--
 
-        OBSOLETE
-        
-This section produces Chapter 11: Obsolete Features https://w3c.github.io/html/obsolete.html
+    Obsolete
 
-It covers features which are deprecated and should or must not be used in conforming HTML content,
-  but which user agents need to handle because there is a body of legacty content using them.
-  Examples include
+  This section produces Chapter 11: Obsolete Features
+  https://w3c.github.io/html/obsolete.html
+
+  It covers features which are deprecated and should or must not be used in conforming
+  HTML content, but which user agents need to handle because there is a body of legacy
+  content using them.
+
+  Examples include:
   - appcache
   - applet
   - keygen

--- a/sections/rendering.include
+++ b/sections/rendering.include
@@ -1,7 +1,40 @@
 <section>
+
 <!--
 
-        RENDERING
+    Rendering
+
+  This source produces Chapter 10: Rendering
+  https://w3c.github.io/html/rendering.html
+
+  It covers:
+  - Introduction to Rendering
+  - The CSS user agent style sheet and presentational hints
+  - Non-replacement elements, such as:
+    + Hidden elements
+    + The page
+    + Flow & Phrasing content
+    + Bidirectional text
+    + Quotes
+    + Sections and headings
+    + Lists
+    + Tables
+    + Margin collapsing quirks
+    + Form controls
+    + The hr, fieldset, and legend elements
+  - Replaced elements, such as:
+    + Embedded content, images, and attributes for each
+    + Image maps
+  - Widgets, such as:
+    + the various form controls
+    + details and summary
+    + marquee
+    + meter
+    + progress
+  - Frames and framesets
+  - Interactive media
+  - Print media
+  - Unstyled XML documents
 
 -->
 

--- a/sections/semantics-common-idioms.include
+++ b/sections/semantics-common-idioms.include
@@ -2,12 +2,12 @@
 
 <!--
 
-    COMMON IDIOMS
+    Common Idioms
 
   This source produces section 4.13: Common Idioms without Dedicated Elements
   https://w3c.github.io/html/common-idioms-without-dedicated-elements.html
 
-  It covers
+  It covers:
   - Subheadings and taglines
   - "breadcrumb" navigation information
   - Tag Clouds

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -2,7 +2,7 @@
 
 <!--
 
-    DOCUMENT METADATA
+    Document Metadata
 
   This source produces section 4.2: Document Metadata
   https://w3c.github.io/html/document-metadata.html

--- a/sections/semantics-edits.include
+++ b/sections/semantics-edits.include
@@ -1,12 +1,15 @@
 <!--
 
-         Edits
-         
-This source file produces section 4.6: Edits https://w3c.github.io/html/edits.html#edits
+    Edits
 
-It describes the ins and del elements, and how they span different kinds of content.
+  This source file produces section 4.6: Edits
+  https://w3c.github.io/html/edits.html#edits
+
+  It covers:
+  The ins and del elements, and how they span different kinds of content.
 
 -->
+
 <section>
   <h3 id="edits">Edits</h3>
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -1,19 +1,22 @@
 <section>
+
 <!--
-     Embedded content
-     
-This source produces section 4.7: Embedded Content https://w3c.github.io/html/semantics-embedded-content.html
 
-It covers 
+    Embedded content
 
-- media elements:
-  + img, picture, source, and their attributes
-  + video, audio, track, and their attributes
-  + core APIs for playing media files
-- Image maps
-- Embedding SVG and MathML into HTML
+  This source produces section 4.7: Embedded Content
+  https://w3c.github.io/html/semantics-embedded-content.html
+
+  It covers:
+  - media elements:
+    + img, picture, source, and their attributes
+    + video, audio, track, and their attributes
+    + core APIs for playing media files
+  - Image maps
+  - Embedding SVG and MathML into HTML
 
 -->
+
 <h3 id="semantics-embedded-content">Embedded content</h3>
 
 <h4 id="embedded-content-introduction">Introduction</h4>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -16,7 +16,8 @@
   - Categories
   - Form Elements:
     + form, label, input states and types, button, select, datalist,
-        optgroup, option, textarea, output, meter, fieldset, legend, and progress
+        optgroup, option, textarea, output, meter, fieldset, legend,
+        and progress
   - Form control infrastructure
   - Attributes common to form controls
     + including name, dirname, disabled, etc.
@@ -24,6 +25,7 @@
   - Constraints
   - Form submission
   - Resetting a form
+
 -->
 
 <h3 id="sec-forms"><dfn>Forms</dfn></h3>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -1,5 +1,31 @@
 <section>
 
+<!--
+
+    Forms
+
+  This source produces section 4.10: Forms
+  https://w3c.github.io/html/sec-forms.html
+
+  It covers:
+  - Introduction to forms including:
+    + Form's user interface
+    + Server and client side information
+    + Differences between field type, autofill name, and input modality
+    + Date, time, and number formats
+  - Categories
+  - Form Elements:
+    + form, label, input states and types, button, select, datalist,
+      optgroup, option, textarea, output, meter, fieldset, legend, and progress
+  - Form control infrastructure
+  - Attributes common to form controls
+    + including name, dirname, disabled, etc.
+  - APIs for text field selections
+  - Constraints
+  - Form submission
+  - Resetting a form
+-->
+
 <h3 id="sec-forms"><dfn>Forms</dfn></h3>
 
 <h4 id="forms-introduction">Introduction</h4>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -16,7 +16,7 @@
   - Categories
   - Form Elements:
     + form, label, input states and types, button, select, datalist,
-      optgroup, option, textarea, output, meter, fieldset, legend, and progress
+        optgroup, option, textarea, output, meter, fieldset, legend, and progress
   - Form control infrastructure
   - Attributes common to form controls
     + including name, dirname, disabled, etc.
@@ -5712,7 +5712,7 @@ input { height: 75px; width: 49px; background: #D5CCBB; color: black; }
       <form action="products.cgi" method="post" enctype="multipart/form-data">
         <table>
           <tr>
-            <th>Product ID</th> <th>Product name</th> <th>Price</th> <th>Action</th> 
+            <th>Product ID</th> <th>Product name</th> <th>Price</th> <th>Action</th>
           </tr>
           <tr>
             <td> <input readonly="readonly" name="1.pid" value="H412"> </td>
@@ -7704,7 +7704,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
                 <optgroup label="8.01 Physics I: Classical Mechanics">
                   <option value="8.01.1">Lecture 01: Powers of Ten</option>
                   <option value="8.01.2">Lecture 02: 1D Kinematics</option>
-                  <option value="8.01.3">Lecture 03: Vectors</option> 
+                  <option value="8.01.3">Lecture 03: Vectors</option>
                 </optgroup>
 
                 <optgroup label="8.02 Electricity and Magnestism">

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -8,8 +8,8 @@
   https://w3c.github.io/html/grouping-content.html
 
   It covers:
-  - p, address, hr, pre, blockquote, ol, ul, li,
-    dl, dt, dd, figure, figcaption, main, and div elements
+  The p, address, hr, pre, blockquote, ol, ul, li,
+  dl, dt, dd, figure, figcaption, main, and div elements
 
 -->
 

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1,5 +1,18 @@
 <section>
 
+<!--
+
+    Grouping Content
+
+  This source produces section 4.4: Grouping Content
+  https://w3c.github.io/html/grouping-content.html
+
+  It covers:
+  - p, address, hr, pre, blockquote, ol, ul, li,
+    dl, dt, dd, figure, figcaption, main, and div elements
+
+-->
+
 <h3 id="grouping-content">Grouping content</h3>
 
 <h4 id="the-p-element">The <dfn element><code>p</code></dfn> element</h4>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -2,10 +2,10 @@
 
 <!--
 
-    Interactive Elements
+    Interactive elements
 
-  This source produces section 4.7: Embedded Content
-  https://w3c.github.io/html/semantics-embedded-content.html
+  This source produces section 4.11: Interactive elements
+  http://w3c.github.io/html/interactive-elements.html
 
   It covers
 
@@ -125,7 +125,7 @@
   <div class="example">
     The following example shows the <{details}> element being used to hide technical
     details in a progress report.
-    
+
     <section class="progress window">
       <strong>Copying "Really Achieving Your Childhood Dreams"</strong>
       <details>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -5,16 +5,14 @@
     Interactive elements
 
   This source produces section 4.11: Interactive elements
-  http://w3c.github.io/html/interactive-elements.html
+  https://w3c.github.io/html/interactive-elements.html
 
-  It covers
-
-  - media elements:
-    + img, picture, source, and their attributes
-    + video, audio, track, and their attributes
-    + core APIs for playing media files
-  - Image maps
-  - Embedding SVG and MathML into HTML
+  It covers:
+  - Details and summary elements
+  - Commands
+    + facets of commands
+    + defining commands with a, button, input, option, and accesskeys
+  - Dialog element
 
 -->
 

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -1,5 +1,23 @@
 <section>
 
+<!--
+
+    Interactive Elements
+
+  This source produces section 4.7: Embedded Content
+  https://w3c.github.io/html/semantics-embedded-content.html
+
+  It covers
+
+  - media elements:
+    + img, picture, source, and their attributes
+    + video, audio, track, and their attributes
+    + core APIs for playing media files
+  - Image maps
+  - Embedding SVG and MathML into HTML
+
+-->
+
 <h3 id="interactive-elements">Interactive elements</h3>
 
 <h4 id="the-details-element">The <dfn element><code>details</code></dfn> element</h4>

--- a/sections/semantics-root.include
+++ b/sections/semantics-root.include
@@ -1,5 +1,20 @@
 <section>
 
+<!--
+
+    Semantics: Root
+
+  This source produces section 4.1: The document Element
+  https://w3c.github.io/html/semantics.html#the-root-element
+
+  It covers:
+  - HTML element
+  - The manifest attribute, and its pending removal
+  - Note about keeping HTML attributes at a minimum to allow proper
+    character encoding within 1024 bytes
+
+-->
+
 <h3 id="the-root-element">The document element</h3>
 
 <h4 id="the-html-element">The <dfn element><code>html</code></dfn> element</h4>

--- a/sections/semantics-root.include
+++ b/sections/semantics-root.include
@@ -10,8 +10,7 @@
   It covers:
   - HTML element
   - The manifest attribute, and its pending removal
-  - Note about keeping HTML attributes at a minimum to allow proper
-    character encoding within 1024 bytes
+  - Note about keeping HTML attributes at a minimum to allow proper char encoding within 1024 bytes
 
 -->
 

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -1,5 +1,21 @@
 <section>
 
+<!--
+
+    Scripting
+
+  This source produces section 4.12: Scripting
+  https://w3c.github.io/html/semantics-scripting.html
+
+  It covers:
+  - Introduction to scripts and the following elements
+  - script
+  - noscript
+  - template
+  - canvas
+
+-->
+
 <h3 id="semantics-scripting">Scripting</h3>
 
   Scripts allow authors to add interactivity to their documents.

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -2,20 +2,22 @@
 
 <!--
 
-  SECTIONS
+    Sections
 
-  This source produces section 4.3 Sections:
+  This source produces section 4.3: Sections
   https://w3c.github.io/html/sections.html
 
-It covers
-- elements used to create the sectioning root, content sections within the document outline, and headings:
-    body, article, section, nav, aside, h1-h6, header, footer
-- headings and sections and creating an outline
-- summary of usage for the above mentioned elements
+  It covers
+  - elements used to create the sectioning root, content sections within the document outline,
+    and headings:
+      body, article, section, nav, aside, h1-h6, header, footer
+  - headings and sections and creating an outline
+  - summary of usage for the above mentioned elements
 
 -->
 
 <h3 id="sections">Sections</h3>
+
 <h4 id="the-body-element">The <dfn element><code>body</code></dfn> element</h4>
 
   <dl class="element">

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -7,7 +7,7 @@
   This source produces section 4.3: Sections
   https://w3c.github.io/html/sections.html
 
-  It covers
+  It covers:
   - elements used to create the sectioning root, content sections within the document outline,
     and headings:
       body, article, section, nav, aside, h1-h6, header, footer

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1,19 +1,20 @@
 <section>
+
 <!--
 
-          TABULAR DATA
-          
-This source produces section 4.9 Tabular Data  https://w3c.github.io/html/tabular-data.html
+    Tabular Data
 
-It covers 
-- elements used to make tables:
-    table, caption, colgroup, col, tbody, thead, tfoot, tr, td, th
-- attributes for tables:
-    headers, rowspan, colspan, scope, ...
-- the processing model for forming and laying out a table
+  This source produces section 4.9: Tabular Data
+  https://w3c.github.io/html/tabular-data.html
+
+  It covers:
+  - elements used to make tables:
+      table, caption, colgroup, col, tbody, thead, tfoot, tr, td, th
+  - attributes for tables:
+      headers, rowspan, colspan, scope, ...
+  - the processing model for forming and laying out a table
 
 -->
-
 
 <h3 id="tabular-data">Tabular data</h3>
 

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -8,9 +8,8 @@
   https://w3c.github.io/html/textlevel-semantics.html
 
   It covers:
-  - a, em, strong, small, s, cite, q, dfn, abbr, ruby, rb, rt,
-    rtc, rp, data, time, code, var, samp, kbd, sub, sup, i, b,
-    u, mark, bdi, bdo, span, br, and wbr elements
+  - a, em, strong, small, s, cite, q, dfn, abbr, ruby, rb, rt, rtc, rp, data, time, code,
+      var, samp, kbd, sub, sup, i, b, u, mark, bdi, bdo, span, br, and wbr elements
   - Usage summary table
 
 -->
@@ -2508,7 +2507,7 @@
 
     <xmp highlight="html">
       <p>The coordinate of the <var>i</var>th point is (<var>x<sub><var>i</var></sub></var>, <var>y<sub><var>i</var></sub></var>).
-      For example, the 10th point has coordinate (<var>x<sub>10</sub></var>, <var>y<sub>10</sub></var>).</p>    
+      For example, the 10th point has coordinate (<var>x<sub>10</sub></var>, <var>y<sub>10</sub></var>).</p>
     </xmp>
   </div>
 

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -1,5 +1,20 @@
 <section>
 
+<!--
+
+    Text-level semantics
+
+  This source produces section 4.5: Text-level semantics
+  https://w3c.github.io/html/textlevel-semantics.html
+
+  It covers:
+  - a, em, strong, small, s, cite, q, dfn, abbr, ruby, rb, rt,
+    rtc, rp, data, time, code, var, samp, kbd, sub, sup, i, b,
+    u, mark, bdi, bdo, span, br, and wbr elements
+  - Usage summary table
+
+-->
+
 <h3 id="textlevel-semantics">Text-level semantics</h3>
 
 <h4 id="the-a-element">The <dfn element><code>a</code></dfn> element</h4>

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -2,7 +2,7 @@
 
 <!--
 
-    SEMANTICS
+    Semantics
 
   This source produces Chapter 4: The elements of HTML
   https://w3c.github.io/html/semantics.html

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -1,12 +1,20 @@
 <section>
+
 <!--
- ██████  ████████ ██     ██    ███    ██    ██ ████████ ████  ██████   ██████
-██    ██ ██       ███   ███   ██ ██   ███   ██    ██     ██  ██    ██ ██    ██
-██       ██       ████ ████  ██   ██  ████  ██    ██     ██  ██       ██
- ██████  ██████   ██ ███ ██ ██     ██ ██ ██ ██    ██     ██  ██        ██████
-      ██ ██       ██     ██ █████████ ██  ████    ██     ██  ██             ██
-██    ██ ██       ██     ██ ██     ██ ██   ███    ██     ██  ██    ██ ██    ██
- ██████  ████████ ██     ██ ██     ██ ██    ██    ██    ████  ██████   ██████
+
+    SEMANTICS
+
+  This source produces Chapter 4: The elements of HTML
+  https://w3c.github.io/html/semantics.html
+
+  This file collects the partial include files for sections 4.1 to the 4.13s
+
+  This file contains the content for 4.14 and the 4.15s, which covers:
+  - Disabled elements
+  - Matching HTML elements using selectors
+  - Case-sensitivity
+  - Pseudo-classes
+
 -->
 
 <h2 id="semantics">The elements of HTML</h2>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -1,7 +1,32 @@
 <section>
+
 <!--
 
-   HTML SYNTAX - Parsing...
+    Syntax
+
+  This source produces Chapter 8: The HTML syntax
+  https://w3c.github.io/html/syntax.html
+
+  It covers:
+  - Writing HTML documents
+    + DOCTYPE
+    + Elements
+    + Text
+    + Character references
+    + CDATA sections
+    + Comments
+  - Parsing HTML documents
+    + Overview of parsing model
+    + Input byte stream
+    + Parse state
+    + Tokenization
+    + Tree construction
+    + The end: steps for UA after parsing ends
+    + Coercing an HTML DOM into an infoset
+    + Intro to error handling
+  - Serializing HTML fragments
+  - Parsing HTML fragments
+  - Named character references
 
 -->
 

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -2,7 +2,7 @@
 
 <!--
 
-  Web Application APIs
+    Web Application APIs
 
   This source produces Chapter 7: Web application APIs
   https://w3c.github.io/html/webappapis.html

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1,16 +1,22 @@
 <section>
+
 <!--
 
-APIs for Web APplications. This is a bit of a grab-bag
-* Scripting
-* Events and Event Loops
-* Utilities: WindoworGlobalScope mixin, atob/bota for Base64, 
-* Inserting markup: document.write and friends
-* TImers
-* alert(). confirm(), prompt(), print()
-* navigator object and its methods
-* ImageBitmap
-* animation frames - requestAnimationFrame() etc
+  Web Application APIs
+
+  This source produces Chapter 7: Web application APIs
+  https://w3c.github.io/html/webappapis.html
+
+  It covers:
+  - Scripting
+  - Events and Event Loops
+  - Utilities: WindoworGlobalScope mixin, atob/bota for Base64,
+  - Inserting markup: document.write and friends
+  - Timers
+  - User prompts: alert(), confirm(), prompt(), print()
+  - The Navigator object and its methods
+  - ImageBitmap
+  - Animation frames - requestAnimationFrame() etc
 
 -->
 
@@ -4438,4 +4444,3 @@ APIs for Web APplications. This is a bit of a grab-bag
      thrown, <a>report the exception</a>. [[!WEBIDL]]
 
 </section>
-


### PR DESCRIPTION
Continuing to work through [issue #1201](https://github.com/w3c/html/issues/1201)

This commit adds new source header comments for the following files:
- root
- Semantics
- Interactive elements
- Rendering
- Web Application APIs (revised)

This commit touches other previously edited source files to continue to normalize the way we format these source headers.
- browsers
- dom
- iana
- Infrastructure
- introduction
- obsolete
- common idioms
- document metadata
- edits
- embedded content
- sections
- tabular data
