### PR TITLE
editorial updates for cite attribute

### DIFF
--- a/sections/semantics-edits.include
+++ b/sections/semantics-edits.include
@@ -27,17 +27,21 @@
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
+    <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>cite</code> - Link to the source of the quotation or more information about the edit </dd>
-    <dd><code>datetime</code> - Date and (optionally) time of the change </dd>
+    <dd><a>Global attributes</a>.</dd>
+    <dd>
+      <code>cite</code> - Link to the source of the edit to provide additional information.
+    </dd>
+    <dd><code>datetime</code> - Date and (optionally) time of the change.</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd><a>Global aria-* attributes</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses the {{HTMLModElement}} interface.</dd>
   </dl>
@@ -122,17 +126,23 @@
     <dt><a>Content model</a>:</dt>
     <dd><a>Transparent</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
-    <dd>Neither tag is omissible</dd>
+    <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
-    <dd><a>Global attributes</a></dd>
-    <dd><code>cite</code> - Link to the source of the quotation or more information about the edit </dd>
-    <dd><code>datetime</code> - Date and (optionally) time of the change </dd>
+    <dd><a>Global attributes</a>.</dd>
+    <dd>
+      <code>cite</code> - Link to the source of the edit to provide additional information.
+    </dd>
+    <dd>
+      <code>datetime</code> - Date and (optionally) time of the edit.
+    </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd><a>Global aria-* attributes</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses the {{HTMLModElement}} interface.</dd>
   </dl>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -700,20 +700,21 @@
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
     <dd>
-      <code>cite</code> - Link to the source of the quotation or more information about the edit
+      <code>cite</code> - Link to the source of the quotation.
     </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
-    <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd><a>Global aria-* attributes</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLQuoteElement}}.</dd>
   </dl>
 
-  The <{q}> element <a>represents</a> some <a>phrasing content</a> quoted from another
-  source.
+  The <{q}> element <a>represents</a> some <a>phrasing content</a> quoted from another source.
 
   Quotation punctuation (such as quotation marks) that is quoting the contents of the element must
   not appear immediately before, after, or inside <{q}> elements; they will be inserted
@@ -805,9 +806,10 @@
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
 
-   The <{dfn}> element <a>represents</a> the defining instance of a term. The <a>term-description group</a>
-   , <{p}>, <{li}> or <{section}> element that is the nearest ancestor of the <{dfn}> element
-   must also contain the definition(s) for the <a>term</a> given by the <{dfn}> element.
+  The <{dfn}> element <a>represents</a> the defining instance of a term. The
+  <a>term-description group</a>, <{p}>, <{li}> or <{section}> element that is the nearest
+  ancestor of the <{dfn}> element must also contain the definition(s) for the <a>term</a>
+  given by the <{dfn}> element.
 
   <dfn lt="defines the term|defining term|term">Defining term</dfn>: If the <{dfn}> element has a
   <dfn element-attr for="dfn"><code>title</code></dfn>


### PR DESCRIPTION
[Fixes #1240](https://github.com/w3c/html/issues/1240)

Editorial updates to the cite attribute as outlined in the introductory information pertaining to the `del`, `ins` and `q` elements.

Additional updates:

consistently add periods to the end of `dd`s in the `del`, `ins`, and `q` sections.

Fix a typo in the prose of `q` where there was an extra space before a comma.