### PR TITLE
fix missing slash from #1248

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2718,7 +2718,7 @@
   
   <xmp highlight="html">
     <p>The <u>see</u> is full of fish</p>
-  <xmp>
+  </xmp>
   </div>
   
   In most cases, another element is likely to be more appropriate: for marking stress emphasis,


### PR DESCRIPTION
closing tag is now `</xmp>` instead of `<xmp>`