### PR TITLE
fixes #1243 - Add refrences to alt with no value

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3039,7 +3039,7 @@
 <h6 id="inline-images">Inline images</h6>
 
   When images are used inline as part of the flow of text in a sentence, provide a word or
-  phrase as a text alternative which makes sense in the context of the sentence it is apart of.
+  phrase as a text alternative which makes sense in the context of the sentence it is a part of.
 
   <div class="example">
     I <img src="images/heart.png" alt="love" width="27" height="24" /> you.

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -2981,7 +2981,7 @@
 
   In many cases, the image is actually just supplementary, and its presence merely reinforces the
   surrounding text. In these cases, the <code>alt</code> attribute must be
-  present but its value must be unset or an empty string.
+  present but its value must be unset or the empty string.
 
   In general, an image falls into this category if removing the image doesn't make the page any
   less useful, but including the image makes it a lot easier for users of visual browsers to

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -2166,7 +2166,7 @@
 
   <dl class="switch">
 
-    <dt>If the <code>src</code> attribute is set and the <code>alt</code> attribute is set to the empty string</dt>
+    <dt>If the <code>src</code> attribute is set and the <code>alt</code> attribute is set to the empty string (e.g. <code>alt=""</code> or <code>alt</code> without a set value)</dt>
 
     <dd>
 
@@ -2890,7 +2890,7 @@
       </figcaption>
     </figure>
   </xmp>
-  
+
   <p class="note">
     The advantage of this method over the previous example is that the text alternative
   is available to all users at all times. It also allows structured mark up to be used in the text
@@ -2981,23 +2981,28 @@
 
   In many cases, the image is actually just supplementary, and its presence merely reinforces the
   surrounding text. In these cases, the <code>alt</code> attribute must be
-  present but its value must be the empty string.
+  present but its value must be unset or an empty string.
 
   In general, an image falls into this category if removing the image doesn't make the page any
   less useful, but including the image makes it a lot easier for users of visual browsers to
   understand the concept.
 
   <div class="example">
-  This example includes a screenshot of part of a text editor with the file described in the instruction, displayed:
+    This example includes a screenshot of part of a text editor with the file described in
+    the instruction, displayed:
 
-  <p>In the text file, add <code>SleepMode=1</code> under <code>[options]</code>, then save and close.</p>
+    <p>
+      In the text file, add <code>SleepMode=1</code> under <code>[options]</code>, then save and close.
+    </p>
 
-  <img src="images/jcf-text.png" alt="">
+    <img src="images/jcf-text.png" alt="">
 
-   <xmp highlight="html">
-   <p>In the text file, add <code>SleepMode=1</code> under <code>[options]</code>, then save and close.</p>
-   <img src="images/text.png" alt="">
-   </xmp>
+    <xmp highlight="html">
+      <p>
+        In the text file, add <code>SleepMode=1</code> under <code>[options]</code>, then save and close.
+      </p>
+      <img src="images/text.png" alt="">
+    </xmp>
   </div>
 
 <h6 id="a-purely-decorative-image-that-doesnt-add-any-information">A purely decorative image that doesn't add any information</h6>
@@ -3005,23 +3010,27 @@
   Purely decorative images are visual enhancements, decorations or embellishments that provide no
   function or information beyond aesthetics to users who can view the images.
 
-  Mark up purely decorative images so they can be ignored by assistive technology by using an empty <code>alt</code>
-  attribute (<code>alt=""</code>). While it is not unacceptable to include decorative images inline,
+  Mark up purely decorative images so they can be ignored by assistive technology by using an
+  <code>alt</code> attribute with no value (e.g. <code>alt=""</code> or <code>alt</code> with
+  no set value). While it is not unacceptable to include decorative images inline,
   it is recommended if they are purely decorative to include the image using CSS.
 
   <div class="example">
-  Here's an example of an image being used as a decorative banner for a person's blog, the image offers no information
-  and so an empty <code>alt</code> attribute is used.
+    Here's an example of an image being used as a decorative banner for a person's blog,
+    the image offers no information and so an <code>alt</code> attribute with no set value
+    is used.
 
-  <img src="images/border.png" alt="" width="400" height="30" />
+    <img src="images/border.png" alt width="400" height="30" />
 
-  <strong>Clara's Blog</strong>
-  Welcome to my blog...
+    <div>
+      <strong>Clara's Blog</strong>
+    </div>
+    Welcome to my blog...
   </div>
 
   <xmp highlight="html">
     <header>
-      <div><img src="border.gif" alt="" width="400" height="30"></div>
+      <div><img src="border.gif" alt width="400" height="30"></div>
       <h1>Clara's Blog</h1>
     </header>
     <p>Welcome to my blog...</p>
@@ -3029,8 +3038,8 @@
 
 <h6 id="inline-images">Inline images</h6>
 
-  When images are used inline as part of the flow of text in a sentence, provide a word or phrase as a text
-  alternative which makes sense in the context of the sentence it is apart of.
+  When images are used inline as part of the flow of text in a sentence, provide a word or
+  phrase as a text alternative which makes sense in the context of the sentence it is apart of.
 
   <div class="example">
     I <img src="images/heart.png" alt="love" width="27" height="24" /> you.
@@ -12097,7 +12106,7 @@ red:89
   [=other applicable specifications=]. [[!MATHML]]
 
   <div class="example">
-    Here is an example of the use of MathML in an HTML document. 
+    Here is an example of the use of MathML in an HTML document.
     Some browsers may not be able to render it correctly.
 
     <strong>The quadratic formula</strong>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3055,14 +3055,14 @@
 
   When a picture has been sliced into smaller image files that are then displayed
   together to form the complete picture again, include a text alternative for one
-  of the images using the <code>alt</code> attribute as per the relevant relevant
+  of the images using the <code>alt</code> attribute as per the relevant
   guidance for the picture as a whole, and then include an empty <code>alt</code>
   attribute on the other images.
 
   <div class="example">
-  In this example, a picture representing a company logo for the <i>PIP Corporation</i>
-  has been split into two pieces, the first containing the letters "PIP" and the second with the word "CO".
-  The text alternatve <i>PIP CO</i> is in the <code>alt</code> attribute of the first image.
+    In this example, a picture representing a company logo for the <i>PIP Corporation</i>
+    has been split into two pieces, the first containing the letters "PIP" and the second with
+    the word "CO". The text alternative <i>PIP CO</i> is in the <code>alt</code> attribute of the first image.
 
   <img src="images/pip.gif" alt="Image containing the text 'PIP'." width="99" height="64" /><img src="images/co.gif" alt="Image containing the text 'CO'." width="103" height="64" />
 


### PR DESCRIPTION
This commit adds prose to reference that an `alt=“”` and `alt` with no set value will both be interpreted as an empty string, per [issue #1243](https://github.com/w3c/html/issues/1243).

Happy to hear any/all feedback.  Thanks!


