### PR TITLE
fixes #1234 - adds missing roles to aria roles, states, properties table

### DIFF
--- a/sections/dom.include
+++ b/sections/dom.include
@@ -2156,8 +2156,10 @@
     visual media.
 
     <xmp highlight="html">
-      <p>My suit is <span style="color: green; background: transparent">green</span>. 
-        My eyes are <span style="color: blue;  background: transparent">blue</span>.</p>
+      <p>
+        My suit is <span style="color: green; background: transparent">green</span>.
+        My eyes are <span style="color: blue;  background: transparent">blue</span>.
+      </p>
     </xmp>
   </div>
 
@@ -3071,6 +3073,20 @@
         </td>
       </tr>
       <tr>
+        <td><a attr-value for="aria/role"><code>menu</code></a></td>
+        <td>
+          A type of widget that offers a list of choices to the user.
+        </td>
+        <td>none</td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-activedescendant}>
+            * <{aria/aria-expanded}> (state)
+            * <{aria/aria-orientation}>
+          </ul>
+        </td>
+      </tr>
+      <tr>
         <td><a attr-value for="aria/role"><code>menubar</code></a></td>
         <td>
           A presentation of menu that usually remains visible and is usually presented horizontally.
@@ -3082,6 +3098,59 @@
             * <{aria/aria-activedescendant}>
             * <{aria/aria-expanded}> (state)
             * <{aria/aria-orientation}>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td><a attr-value for="aria/role"><code>menuitem</code></a></td>
+        <td>
+          An option in a group of choices contained by a
+          <a attr-value for="aria/role"><code>menu</code></a>
+          or <a attr-value for="aria/role"><code>menubar</code></a>.
+        </td>
+        <td>none</td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-posinset}>
+            * <{aria/aria-setsize}>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td><a attr-value for="aria/role"><code>menuitemcheckbox</code></a></td>
+        <td>
+          A checkable <a attr-value for="aria/role"><code>menuitem</code></a> that has three
+          possible values: true, false, or mixed.
+        </td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-checked}> (state)
+          </ul>
+        </td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-posinset}>
+            * <{aria/aria-setsize}>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td><a attr-value for="aria/role"><code>menuitemradio</code></a></td>
+        <td>
+          A checkable <a attr-value for="aria/role"><code>menuitem</code></a> in a group of
+          <a attr-value for="aria/role"><code>menuitemradio</code></a> roles, only one of which
+          can be checked at a time.
+        </td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-checked}> (state)
+          </ul>
+        </td>
+        <td>
+          <ul class="brief">
+            * <{aria/aria-posinset}>
+            * <{aria/aria-selected}> (state)
+            * <{aria/aria-setsize}>
           </ul>
         </td>
       </tr>


### PR DESCRIPTION
This commit [fixes #1234](https://github.com/w3c/html/issues/1234) and adds the ARIA roles `menu`, `menuitem`, `menuradio` and `menuitemcheckbox` to the [Allowed ARIA roles, states and properties table](http://w3c.github.io/html/dom.html#allowed-aria-roles-states-and-properties).