### PR TITLE
Remove redundant note

### DIFF
--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -810,12 +810,6 @@
   they are not just calculated once per anchored element.)
   </p>
 
-  <p class="note">
-    The '<a>absolute-anchored</a>'
-  keyword is not a keyword that can be specified in CSS; the 'position' property can only compute to
-  this value if the <{dialog}> element is positioned via the APIs described above.
-  </p>
-
   User agents in visual interactive media should allow the user to pan the <a>viewport</a> to access all
   parts of a <{dialog}> element's <a>border box</a>, even if the element is larger than the
   <a>viewport</a> and the <a>viewport</a> would otherwise not have a scroll mechanism (e.g., because the viewport's


### PR DESCRIPTION
see #1108, #1215

It looks like this note is redundant since we removed the unimplemented "magic alignment" for dialogs.