### PR TITLE
Add bdo example

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2974,7 +2974,7 @@
   </div>
 
   <div class="example">
-      If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages
+      If character encoding isn't <a href="https://w3c.github.io/html/infrastructure.html#encoding-terminology">appropriately defined</a>, the characters of <abbr>RTL</abbr> languages
       may appear in reverse order. For example:
 
       <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
@@ -2982,6 +2982,8 @@
       <xmp highlight="html">
         <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
       </xmp>
+
+      In this example, Hebrew characters have been reversed from their normal right to left order.
   </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2962,13 +2962,22 @@
   </p>
 
   <div class="example">
-      If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages
-      may appear in reverse order. Example:
+      This example shows how the <{bdo}> element can be used to alter directionality formatting:
+
+      <bdi><bdo dir="rtl">English is a left-to-right language.</bdo></bdi>
+
+      This effect is achieved by applying the <code>rtl</code> attribute to the <{bdo}> element:
 
       <xmp highlight="html">
-        <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
+        <bdi><bdo dir="rtl">English is a left-to-right language.</bdo></bdi>
       </xmp>
+  </div>
 
+  <div class="example">
+      If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages
+      may appear in reverse order. For example:
+
+      <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
   </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2964,13 +2964,13 @@
   <div class="example">
       This example shows how the <{bdo}> element can be used to alter directionality formatting:
 
-      <bdi><bdo dir="rtl">English is a left-to-right language.</bdo></bdi>
-
-      This effect is achieved by applying the <code>rtl</code> attribute to the <{bdo}> element:
-
       <xmp highlight="html">
         <bdi><bdo dir="rtl">English is a left-to-right language.</bdo></bdi>
       </xmp>
+
+      <bdi><bdo dir="rtl">English is a left-to-right language.</bdo></bdi>
+
+      This effect is achieved by applying the <code>rtl</code> attribute to the <{bdo}> element.
   </div>
 
   <div class="example">
@@ -2978,6 +2978,10 @@
       may appear in reverse order. For example:
 
       <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
+
+      <xmp highlight="html">
+        <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
+      </xmp>
   </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2957,11 +2957,15 @@
   value <a attr-value for="global/dir"><code>ltr</code></a> to specify a left-to-right override and with the value <a attr-value for="global/dir"><code>rtl</code></a> to
   specify a right-to-left override. The <a attr-value for="global/dir"><code>auto</code></a> value must not be specified.
 
-
   <p class="note">
     This element <a href="#bidireq">has rendering requirements involving the bidirectional algorithm</a>.
   </p>
 
+  <div class="example">
+      <xmp highlight="html">
+        <p>If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages may appear in reverse order. Example: <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>.</p>
+      </xmp>
+  </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>
 

--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2962,9 +2962,13 @@
   </p>
 
   <div class="example">
+      If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages
+      may appear in reverse order. Example:
+
       <xmp highlight="html">
-        <p>If character encoding isn't appropriately defined, the characters of <abbr>RTL</abbr> languages may appear in reverse order. Example: <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>.</p>
+        <bdi><bdo dir="ltr">עֶזרָה</bdo></bdi>
       </xmp>
+
   </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>


### PR DESCRIPTION
This PR addresses the issue outlined in https://github.com/w3c/html/issues/1254.

It adds an example of the `<bdo>` element. If the example feels too meta, I'm happy to revise.