### PR TITLE
Remove onshow

### DIFF
--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -1318,12 +1318,6 @@ complicated than indicated in the table above.</small></p>
         <td><a>Event handler content attribute</a></td>
       </tr>
       <tr>
-        <th><code>onshow</code></th>
-        <td><a>HTML elements</a></td>
-        <td><a event for="global"><code>show</code></a> event handler</td>
-        <td><a>Event handler content attribute</a></td>
-      </tr>
-      <tr>
         <th><code>onstalled</code></th>
         <td><a>HTML elements</a></td>
         <td><a event for="media"><code>stalled</code></a> event handler</td>

--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -2047,7 +2047,7 @@
   1. If this {{Document}} object's <a>active sandboxing flag set</a> has its
       <a>sandboxed <code>document.domain</code> browsing context flag</a> set, then throw a
       "{{SecurityError}}" {{DOMException}}.
-  1. Let <var>effectiveDomain</var> be this <code>Document</code>'s <a>origin</a>'s 
+  1. Let <var>effectiveDomain</var> be this {{Document}}'s [=concept/origin=]'s 
       <a>effective domain</a>.
   1. If <var>effectiveDomain</var> is null, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If the given value <span data-x="is a registrable domain suffix of or is equal to">is not

--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -3983,7 +3983,7 @@
   5. Set the {{Document}}'s <a>referrer policy</a> to the result of
      parsing the <a><code>Referrer-Policy</code></a> header</a> of the <a>response</a>
      used to generate the document. [[!REFERRERPOLICY]]
-  6. Execute the <a>Initialize a <code>Document</code>'s CSP list</a> algorithm on the {{Document}}
+  6. Execute the <a>Initialize a Document's CSP list</a> algorithm on the {{Document}}
       object and the resource used to generate the document. [[CSP3]]
   7. Set [=the document's referrer=] to the
       <em>address of the resource from which Request-URIs are obtained</em> as determined when the

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -142,7 +142,7 @@
   (a [=referrer policy=]), initially the empty string, which represents the default
   [=referrer policy=] used by [=fetches=] initiated by the {{Document}}.
 
-  The {{Document}} has a <dfn for="document">CSP list</dfn>, which is a <a>CSP list</a>
+  The {{Document}} has a <dfn for="document">CSP list</dfn>, which is a <a for="/">CSP list</a>
   containing all of the [=Content Security Policy=] objects active for the document. The
   list is empty unless otherwise specified.</p>
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1599,7 +1599,6 @@
     * {{GlobalEventHandlers/onseeked}}
     * {{GlobalEventHandlers/onseeking}}
     * {{GlobalEventHandlers/onselect}}
-    * {{GlobalEventHandlers/onshow}}
     * {{GlobalEventHandlers/onstalled}}
     * {{GlobalEventHandlers/onsubmit}}
     * {{GlobalEventHandlers/onsuspend}}

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -1872,7 +1872,6 @@
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onseeked</code></dfn> <td> <code>seeked</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onseeking</code></dfn> <td> <code>seeking</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onselect</code></dfn> <td> <code>select</code>
-    <tr><td><dfn attribute for="GlobalEventHandlers"><code>onshow</code></dfn> <td> <code>show</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onstalled</code></dfn> <td> <code>stalled</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onsubmit</code></dfn> <td> <code>submit</code>
     <tr><td><dfn attribute for="GlobalEventHandlers"><code>onsuspend</code></dfn> <td> <code>suspend</code>
@@ -2019,7 +2018,6 @@
       attribute EventHandler onseeked;
       attribute EventHandler onseeking;
       attribute EventHandler onselect;
-      attribute EventHandler onshow;
       attribute EventHandler onstalled;
       attribute EventHandler onsubmit;
       attribute EventHandler onsuspend;

--- a/sections/webappapis.include
+++ b/sections/webappapis.include
@@ -116,7 +116,7 @@
   :: A <a>URL record</a> that represents the location of the resource with which the
       <a>environment</a> is associated.
       <p class="note">In the case of an <a>environment settings object</a>, this URL might be
-      distinct from the <a>environment settings object</a>'s <a>responsible document</a>'s <a>URL</a>, due to mechanisms such as
+      distinct from the <a>environment settings object</a>'s <a>responsible document</a>'s <a for="/">URL</a>, due to mechanisms such as
       <code>history.pushState()</code>.</p>
 
   : A <a>target browsing context</a>
@@ -330,7 +330,7 @@
   asynchronously complete with either null (on failure) or a new <a>classic script</a>
   (on success).
 
-  1. Let <var>request</var> be a new <a>request</a> whose <a>url</a> is <var>url</var>, 
+  1. Let <var>request</var> be a new <a>request</a> whose <a for="/">url</a> is <var>url</var>, 
       <a>client</a> is <var>fetch client settings object</var>, <a>destination</a> is <var>destination</var>,
        <a>mode</a> is "<code>same-origin</code>", <a>credentials mode</a> is "<code>same-origin</code>",
        <a>parser metadata</a> is "<code>not parser-inserted</code>", and whose
@@ -432,7 +432,7 @@
   4. Create an entry in <var>module map</var> with key <var>url</var> and value
       "<code>fetching</code>".
   5. Let <var>request</var> be a new <a>request</a> whose
-      <a>url</a> is <var>url</var>, <a>destination</a> is <var>destination</var>, <a>mode</a> is "<code>cors</code>", 
+      <a for="/">url</a> is <var>url</var>, <a>destination</a> is <var>destination</var>, <a>mode</a> is "<code>cors</code>", 
       <a>referrer</a> is <var>referrer</var>, and <a>client</a> is <var>fetch client settings
       object</var>. <a>Set up the module script request</a> given <var>request</var> and
       <var>options</var>.


### PR DESCRIPTION
(I think I'm right about this...)

The `onshow` event handler was part of `contextmenu` - which was never implemented.

See:

* https://github.com/w3c/html/issues/589
* https://github.com/whatwg/html/issues/2860

Re #1215