### PR TITLE
Latin references - not Limburgish

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1408,7 +1408,7 @@
          <a><code>sandbox</code></a> <a>directives</a>
       * The <a>EnsureCSPDoesNotBlockStringCompilation</a> abstract algorithm
       * The <a>Is base allowed for Document?</a> algorithm
-      * The <a for="/">Should element be blocked <i lang="li">a priori</i> by Content Security Policy?</a> algorithm
+      * The <a for="/">Should element be blocked <i lang="la">a priori</i> by Content Security Policy?</a> algorithm
 
   :: The following terms are defined in <cite>Content Security Policy: Document Features</code> <!-- [[!CSPDOCUMENT]] when published -->
 

--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -420,7 +420,7 @@
     [=fallback content=].
   * No Java Language runtime [=plugin=] is available.
   * A Java runtime [=plugin=] is available but it is disabled.
-  * The <a for="/">Should element be blocked <i lang="li">a priori</i> by Content Security Policy?</a>
+  * The <a for="/">Should element be blocked <i lang="la">a priori</i> by Content Security Policy?</a>
     algorithm returns "Blocked" when executed on the element. [[!CSP3]]
 
   Otherwise, the user agent should instantiate a Java Language runtime [=plugin=], and should

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4717,7 +4717,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <a>browsing context</a>, or if the element's <a>node document</a> is not <a>fully
     active</a>, or if the element is still in the <a>stack of open elements</a> of an
     <a>HTML parser</a> or <a>XML parser</a>, or if the element is not <a>being rendered</a>, or if the
-    <a for="/">Should element be blocked <i lang="li">a priori</i> by Content Security Policy?</a> algorithm
+    <a for="/">Should element be blocked <i lang="la">a priori</i> by Content Security Policy?</a> algorithm
      returns "Blocked" when executed on the element, then jump to the step below labeled fallback. [[!CSP3]].
 
     </li>


### PR DESCRIPTION
The phrase "a priori" is Latin - https://en.wikipedia.org/wiki/A_priori_and_a_posteriori

The ISO 639 code for Latin is `la` - https://www.loc.gov/standards/iso639-2/php/code_list.php

`li` is Limburgish

"Quidquid latine dictum sit, altum videtur!"