### PR TITLE
fixes #1258 - provide picture example

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -235,21 +235,20 @@
           was an English <a href="/wiki/Music_hall">music hall</a> singer, ...
       </xmp>
 
-      The user agent can choose any of the given resources depending on
-      the user's screen's pixel density, zoom level, and possibly other factors such as the user's network conditions.
+      The user agent can choose any of the given resources depending on the user's screen's pixel
+      density, zoom level, and possibly other factors such as the user's network conditions.
 
-      For backwards compatibility with older user agents that
-      don't yet understand the <{img/srcset}> attribute,
-      one of the URLs is specified in the <{img}> element's <code>src</code> attribute.
-      This will result in something useful (though perhaps lower-resolution than the user would like)
-      being displayed even in older user agents.
-      For new user agents, the <code>src</code> attribute participates in the resource selection,
-      as if it was specified in <{img/srcset}> with a <code>1x</code> descriptor.
+      To provide backwards compatibility with older user agents that don't understand the
+      <{img/srcset}> attribute, one of the URLs is specified in the <{img}> element's
+      <code>src</code> attribute. This will result in something useful (though perhaps at a
+      lower-resolution than the user might expect) being displayed even in older user agents.
+      For user agents that understand <{img/srcset}>, the <code>src</code> attribute participates
+      in the resource selection, as if it had been specified by <{img/srcset}> with a
+      <code>1x</code> descriptor.
 
-      The image's rendered size is given in the
-      <code>width</code> and <code>height</code> attributes,
-      which allows the user agent to allocate space for the image before it is downloaded.
-
+      The image's rendered size is given in the <code>width</code> and <code>height</code>
+      attributes, which allows the user agent to allocate space for the image before it is
+      downloaded.
     </div>
 
     </dd>
@@ -375,14 +374,14 @@
       A banner that takes half the <a>viewport</a> is provided in two versions,
       one for wide screens and one for narrow screens.
 
-    <xmp highlight="html">
-      <h1>
-        <picture>
-          <source media="(max-width: 500px)" srcset="banner-phone.jpeg, banner-phone-HD.jpeg 2x">
-          <img src="banner.jpeg" srcset="banner-HD.jpeg 2x" alt="The Breakfast Combo">
-        </picture>
-      </h1>
-    </xmp>
+      <xmp highlight="html">
+        <h1>
+          <picture>
+            <source media="(max-width: 500px)" srcset="banner-phone.jpeg, banner-phone-HD.jpeg 2x">
+            <img src="banner.jpeg" srcset="banner-HD.jpeg 2x" alt="The Breakfast Combo">
+          </picture>
+        </h1>
+      </xmp>
 
     </div>
 
@@ -461,6 +460,25 @@
   <{img}> element to allow authors to declaratively control or give hints to the user agent about
   which image resource to use, based on the screen pixel density, <a>viewport</a> size, image
   format, and other factors. It <a>represents</a> its children.
+
+  <div class="example">
+    The following example utilizes <a for="image">art direction</a> to provide the appropriate
+    image at a particular <a>viewport</a> for small and large screens.
+
+      <xmp highlight="html">
+        <h3>
+          <picture>
+            <source media="(max-width: 500px)" srcset="photo-small-screen.jpg">
+            <img src="photo-large-screen.jpg"" alt>
+          </picture>
+          Dogs & Cats, Living Together
+        </h3>
+      </xmp>
+
+    For other <{picture}> element examples, see the examples in
+    <a href="embedded-content-introduction">Embedded content introduction</a>, or the
+    <a href="an-image-in-a-picture-element">An image in a <code>picture</code> element</a> example.
+  </div>
 
   <p class="note">
     The <{picture}> element is somewhat different from the similar-looking
@@ -3568,9 +3586,12 @@
   <a href="#alt-text">Requirements for providing text to act as an alternative for images</a> for more information on how to provide
   useful <code>alt</code> text for images.
 
-  <p class="note"><a for="image">Art directed</a> images that rely on <code>picture</code> need to depict
-  the same content (irrespective of size, pixel density, or any other discriminating factor). Therefore the appropriate
-  text alternative for an image will always be the same irrespective of which source file ends up being chosen by the browser.</p>
+  <p class="note">
+    <a for="image">Art directed</a> images that rely on <code>picture</code> need to depict
+    the same content (irrespective of size, pixel density, or any other discriminating
+    factor). Therefore the appropriate text alternative for an image will always be the
+    same irrespective of which source file ends up being chosen by the browser.
+  </p>
 
   <div class="example">
     <xmp highlight="html">


### PR DESCRIPTION
[Fixes #1258](https://github.com/w3c/html/issues/1258)

Creates a new `picture` code example and prose for the `picture` element.  Provide in-page links to the other sections of this document that also provide `picture` element usage examples.

Minor wording revisions for prose from source lines 238 - 247.