### PR TITLE
Add references to custom elements

### DIFF
--- a/images/content-venn.svg
+++ b/images/content-venn.svg
@@ -107,6 +107,7 @@
      <li><code>var</code></li>
      <li><code>video</code></li>
      <li><code>wbr</code></li>
+     <li>autonomous custom elements</li>
      <li><span>Text*</span></li>
     </ul>
     <p>* Under certain circumstances (see prose).</p>
@@ -252,6 +253,7 @@
      <li><code>var</code></li>
      <li><code>video</code></li>
      <li><code>wbr</code></li>
+     <li>autonomous custom elements</li>
      <li><span title="text content">Text</span>*</li>
     </ul>
     <p>* Under certain circumstances; see prose.</p>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -815,8 +815,10 @@
     * [[#interactive-content|Interactive content]]
   </ul>
 
-  <p class="note">Some elements also fall into other categories, which are defined in other parts of
-  this specification.</p>
+  <p class="note">
+    Some elements also fall into other categories, which are defined in other parts of
+    this specification.
+  </p>
 
   These categories are related as follows:
 
@@ -965,6 +967,7 @@
     <li><{var}>
     <li><{video}>
     <li><{wbr}>
+    <li><a>autonomous custom elements</a>
     <li>[=text=]
   </ul>
 
@@ -1062,6 +1065,7 @@
     <li><{var}>
     <li><{video}>
     <li><{wbr}>
+    <li><a>autonomous custom elements</a>
     <li>[=text=]
   </ul>
 
@@ -1227,6 +1231,7 @@
     <li><{ul}> (if the element's children include at least one <{li}> element)
     <li><{var}>
     <li><{video}>
+    <li><a>autonomous custom elements</a>
     <li>[=text=] that is not [=inter-element white space=]
   </ul>
 

--- a/sections/element-content-categories.include
+++ b/sections/element-content-categories.include
@@ -128,6 +128,7 @@
         <{var}>;
         <{video}>;
         <{wbr}>;
+        <a>autonomous custom elements</a>;
         <a>Text</a>
       </td>
       <td>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -1546,6 +1546,23 @@
        <td><a>globals</a></td>
        <td>{{HTMLElement}}</td>
       </tr>
+
+      <tr>
+       <th><a>autonomous custom elements</a></th>
+       <td>Author-defined elements</td>
+       <td>
+          <a>flow</a>;
+          <a>phrasing</a>;
+          <a>palpable</a>
+        </td>
+       <td>
+          <a>flow</a>;
+          <a>phrasing</a>
+       </td>
+       <td><a>transparent</a></td>
+       <td><a>globals</a>; any, as decided by the element's author</td>
+       <td>Supplied by the element's author. Inherits from {{HTMLElement}}</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
This PR addresses the bullet points of [issue 1276](https://github.com/w3c/html/issues/1276), and one of the checkboxes for [issue 1229](https://github.com/w3c/html/issues/1229)
 
* Added references to diagram for custom elements
* Added to flow content
* Added to phrasing content
* Added to palpable content
* Added to elements index
* Added to the element content categories index
* The note about `p` element tag omission and autonomous custom elements is already (still) in the spec. So no changes here, unless I misunderstood what was necessary to add?

