### PR TITLE
Allow headings within label elements

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -1055,8 +1055,9 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>phrasing content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Phrasing content</a>, but with no descendant <a>labelable elements</a> unless it is the element's
-      <a>labeled control</a>, and no descendant <{label}> elements.</dd>
+    <dd><a>Phrasing content</a> and headings (<{h1}>-<{h6}> elements), but with no descendant
+      <a>labelable elements</a> unless it is the element's <a>labeled control</a>, and no descendant
+      <{label}> elements.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>


### PR DESCRIPTION
Update the spec to permit headings as part of the `<label>` element’s content model.

In #724 the spec was changed to allow headings as permitted children of legends, but this same change was not also extended to labels. This meant that including a heading as part of a legend is valid, but including a heading as part of a label is not.

This led to an inconsistent experience when building interfaces where the label for a form field or fieldset is also the heading for the page – with a fieldset, the heading could be nested inside the legend, but with a single field the label instead needed to be nested inside the heading. Unifying the behaviour of the two elements so that both permit headings reduces the complexity for the developer.

Fixes #1270.