### PR TITLE
note to expand context for empty alt vs no alt

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3630,12 +3630,12 @@
 
   <div class="note">
     Setting an <{image}> element's <code>alt</code> attribute to the empty string will convey
-    to assistive technologies, such as screen readers, that the image in question has no relative
-    or informative value to the section of the document in which it is found. Being that it serves
-    no informative purpose, a screen reader may choose to completely ignore the presence of the
-    image, in favor of not announcing a graphic which has no alternative text to describe it.
-    In the context of a decorative image, this poses no detriment to the end user, as fully
-    understanding the document is not reliant on parsing the image.
+    to assistive technologies, such as screen readers, that the image in question provides no
+    substantial informative value, and should be considered decorative to the section of the 
+    document in which it is found. Being that it serves no informative purpose, a screen reader 
+    may choose to completely ignore the presence of the image. In the context of a decorative 
+    image, not being announced poses no detriment to the end user's ability to fully 
+    grasp the information of the document.
 
     However, in instances where an image is vital to understanding the contents of a document,
     an image with an omitted <code>alt</code> attribute is preferable to an <code>alt</code>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3630,7 +3630,7 @@
   <div class="note">
     Setting an <{image}> element's <{img/alt}> attribute to the empty string means the image in
     question provides no essential information. Assistive technology, such as screen readers,
-    will completely ignore the presence of such an image, as ignoring it will not stop the user
+    will typically ignore the presence of such an image, as ignoring it will not stop the user
     from understanding the document, and saves the user time.
 
     In the following example, the <{img/alt}> is set to the empty string, so it will be silently
@@ -3650,7 +3650,7 @@
     should be aware that an image without an <{img/alt}> attribute is preferable to an
     <{img/alt}> attribute set to the empty string.
 
-    Taking the previous example and omitting the <code>alt</code> attribute, as such:
+    Taking the previous example and omitting the <code>alt</code> attribute, as follows:
 
     <xmp highlight="html" class="example">
       <img src="bar-graph.png">

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3624,81 +3624,57 @@
   <{figure}> and <{figcaption}> elements to provide the image's caption.
 
   As a last resort, implementors
-  <a href="https://www.w3.org/TR/ATAG20/#gl_b23">must omit the alt attribute altogether</a>. [[!ATAG20]]
+  <a href="https://www.w3.org/TR/ATAG20/#gl_b23">must omit the alt attribute altogether</a>.
+  [[!ATAG20]]
 
   <div class="note">
-    Setting an <{image}> element's <{img/alt}>
-    attribute to the empty string means the image in question provides no
-    essential information. Assistive technology such as screen readers
-    may choose to completely ignore the presence of such images,
-    since it does not stop the user understanding the document and saves time.
+    Setting an <{image}> element's <{img/alt}> attribute to the empty string means the image in
+    question provides no essential information. Assistive technology, such as screen readers,
+    will completely ignore the presence of such an image, as ignoring it will not stop the user
+    from understanding the document, and saves the user time.
 
-    Where an image is vital to understanding the contents of a document,
-    an image without an <{img/alt}> attribute is preferable to an <{img/alt}>
-    attribute set to the empty string.
-
-    If an image has no alternative text, screen readers will generally announce there is an image,
-    allowing the user to try to learn what the image conveys, e.g. from its filename,
-    asking a friend to look at it,
-    running Optical Character Recognition to see if it contains text,
-    submitting it to an image search to get more information, etc.
-
-    (None of these approaches is as good as having a correct text alternative).
-
-    Similarly, if an image has an <{img/alt}> attribute that is the empty string,
-    content management software and accessibility checking software will generally assume this is because it does not need an alternative text,
-    and therefore not flag the image in question as a potential problem, meaning it is less likely to be repaired.
+    In the following example, the <{img/alt}> is set to the empty string, so it will be silently
+    ignored by screen readers.
 
     <xmp highlight="html" class="example">
-      <figure>
-        <img src="bar-graph.png">
-        <figcaption>
-          <p>
-            Figure 1: the bar graph indicates that in the last four years, profits have been on the rise.
-          </p>
-        </figcaption>
-      </figure>
+      <img src="bar-graph.png" alt="">
     </xmp>
 
-    In the above example, the <{figcaption}> provides context to all users about the image.
-    While the image has no alternative text to describe it, the presence of the image should
-    be announced, and users with low or no vision may understand what it could display,
-    based on the caption provided.
+    Unless the image is truly decorative, implementors setting an image's <code>alt</code>
+    attribute to the empty string is not recommended. An empty string will indicate to content
+    management software and accessibility checking software that the image does not need
+    alternative text, and therefore they will not flag the image in question as a potential
+    problem, meaning it is less likely to be repaired.
 
-    By contrast in the following example, the image has an <code>alt</code> attribute set to
-    the empty string:
+    In contrast, if an image is vital to understanding the contents of a document, implementors
+    should be aware that an image without an <{img/alt}> attribute is preferable to an
+    <{img/alt}> attribute set to the empty string.
+
+    Taking the previous example and omitting the <code>alt</code> attribute, as such:
 
     <xmp highlight="html" class="example">
-      <figure>
-        <img src="star-chart.jpg" alt>
-        <figcaption>
-          <p>
-            Figure 2: The zodiac is an area of the sky that extends approximately 8° north or south of the ecliptic...
-          </p>
-        </figcaption>
-      </figure>
+      <img src="bar-graph.png">
     </xmp>
 
-    As the <code>alt</code> attribute is set to the empty string, in this example, assistive
-    technologies will likely not announced the existence of the image. Thus to users of such
-    software, the <{figcaption}> would be describing "nothing" as there would be no announcement
-    of a "figure" in this instance.
+    will allow screen readers to announce the filename of the image (bar-graph.png). Doing so may
+    allow the user to try to learn what the image conveys, e.g. from its announced filename,
+    asking a friend to describe it, running Optical Character Recognition to see if the image
+    contains text, or submitting it to an image search to get more information, etc.
+
+    (None of these approaches are as good as giving the image correct alternative text).
   </div>
 
   Markup generators may specify a <dfn><code>generator-unable-to-provide-required-alt</code></dfn>
-  attribute on <{img}> elements for which they have been
-  unable to obtain a text alternative and for which they have therefore
-  omitted the <code>alt</code> attribute. The
-  value of this attribute must be the empty string. Documents
-  containing such attributes are not conforming, but conformance
-  checkers will silently ignore this error.
+  attribute on <{img}> elements for which they have been  unable to obtain a text alternative and
+  for which they have therefore omitted the <code>alt</code> attribute. The value of this
+  attribute must be the empty string. Documents containing such attributes are not conforming,
+  but conformance checkers will silently ignore this error.
 
   <p class="note">
-    This is intended to avoid markup generators from
-  being pressured into replacing the error of omitting the <code>alt</code> attribute with the even more
-  egregious error of providing phony text alternatives, because
-  state-of-the-art automated conformance checkers cannot distinguish
-  phony text alternatives from correct text alternatives.
+    This is intended to avoid markup generators from being pressured into replacing the error of
+    omitting the <code>alt</code> attribute with the even more egregious error of providing phony
+    text alternatives, because state-of-the-art automated conformance checkers cannot distinguish
+    phony text alternatives from correct text alternatives.
   </p>
 
   Markup generators should generally avoid using the image's own

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3623,29 +3623,33 @@
   For images that have captions, markup generators should use the
   <{figure}> and <{figcaption}> elements to provide the image's caption.
 
-  As a last resort, implementors should set the <code>alt</code> attribute to the empty
-  string, under the assumption that the image is a purely decorative image that doesn't add any
-  information but is still specific to the surrounding content, or omit the <code>alt</code>
-  attribute altogether, under the assumption that the image is a key part of the content.
+  As a last resort, implementors
+  <a href="https://www.w3.org/TR/ATAG20/#gl_b23">must omit the alt attribute altogether</a>. [[!ATAG20]]
 
   <div class="note">
-    Setting an <{image}> element's <code>alt</code> attribute to the empty string will convey
-    to assistive technologies, such as screen readers, that the image in question provides no
-    substantial informative value, and should be considered decorative to the section of the 
-    document in which it is found. Being that it serves no informative purpose, a screen reader 
-    may choose to completely ignore the presence of the image. In the context of a decorative 
-    image, not being announced poses no detriment to the end user's ability to fully 
-    grasp the information of the document.
+    Setting an <{image}> element's <{img/alt}>
+    attribute to the empty string means the image in question provides no
+    essential information. Assistive technology such as screen readers
+    may choose to completely ignore the presence of such images,
+    since it does not stop the user understanding the document and saves time.
 
-    However, in instances where an image is vital to understanding the contents of a document,
-    an image with an omitted <code>alt</code> attribute is preferable to an <code>alt</code>
-    attribute set to the empty string. In the former example, assistive technology would at
-    least indicate to a user that an image existed in the document.
+    Where an image is vital to understanding the contents of a document,
+    an image without an <{img/alt}> attribute is preferable to an <{img/alt}>
+    attribute set to the empty string.
 
-    For example, while the following image has no alternative text, it will be discoverable
-    by assistive technologies as an image, and its file name should be announced.
+    If an image has no alaternative text, screen readers will generally announce there is an image,
+    allowing the user to try to learn what the image conveys, e.g. from its filename,
+    asking a friend to look at it,
+    running Optical Character Recognition to see if it contains text,
+    submitting it to an image search to get more information, etc.
 
-    <xmp highlight="html">
+    (None of these approaches is as good as having a correct text alternative).
+
+    Similarly, if an image has an <{img/alt}> attribute that is the empty string,
+    content management software and accessibility checking software will generally assume this is because it does not need an alternative text,
+    and therefore not flag the image in question as a potential problem, meaning it is less likely to be repaired.
+
+    <xmp highlight="html" class="example">
       <figure>
         <img src="bar-graph.png">
         <figcaption>
@@ -3664,7 +3668,7 @@
     By contrast in the following example, the image has an <code>alt</code> attribute set to
     the empty string:
 
-    <xmp highlight="html">
+    <xmp highlight="html" class="example">
       <figure>
         <img src="star-chart.jpg" alt>
         <figcaption>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3612,9 +3612,9 @@
 
 <h6 id="guidance-for-markup-generators">Guidance for markup generators</h6>
 
-  Markup generators (such as WYSIWYG authoring tools) should, wherever possible, obtain
-  alternative text from their users. However, it is recognized that in many cases, this will not be
-  possible.
+  Wherever possible, markup generators (such as WYSIWYG authoring tools) should obtain
+  alternative text from their users. However, it is recognized that in many cases obtaining
+  alternative text from users may not be possible.
 
   For images that are the sole contents of links, markup generators should examine the link
   target to determine the title of the target, or the URL of the target, and use information
@@ -3623,12 +3623,63 @@
   For images that have captions, markup generators should use the
   <{figure}> and <{figcaption}> elements to provide the image's caption.
 
-  As a last resort, implementors should either set the <code>alt</code> attribute to the empty string, under
-  the assumption that the image is a purely decorative image that
-  doesn't add any information but is still specific to the surrounding
-  content, or omit the <code>alt</code> attribute
-  altogether, under the assumption that the image is a key part of the
-  content.
+  As a last resort, implementors should set the <code>alt</code> attribute to the empty
+  string, under the assumption that the image is a purely decorative image that doesn't add any
+  information but is still specific to the surrounding content, or omit the <code>alt</code>
+  attribute altogether, under the assumption that the image is a key part of the content.
+
+  <div class="note">
+    Setting an <{image}> element's <code>alt</code> attribute to the empty string will convey
+    to assistive technologies, such as screen readers, that the image in question has no relative
+    or informative value to the section of the document in which it is found. Being that it serves
+    no informative purpose, a screen reader may choose to completely ignore the presence of the
+    image, in favor of not announcing a graphic which has no alternative text to describe it.
+    In the context of a decorative image, this poses no detriment to the end user, as fully
+    understanding the document is not reliant on parsing the image.
+
+    However, in instances where an image is vital to understanding the contents of a document,
+    an image with an omitted <code>alt</code> attribute is preferable to an <code>alt</code>
+    attribute set to the empty string. In the former example, assistive technology would at
+    least indicate to a user that an image existed in the document.
+
+    For example, while the following image has no alternative text, it will be discoverable
+    by assistive technologies as an image, and its file name should be announced.
+
+    <xmp highlight="html">
+      <figure>
+        <img src="bar-graph.png">
+        <figcaption>
+          <p>
+            Figure 1: the bar graph indicates that in the last four years, profits have been on the rise.
+          </p>
+        </figcaption>
+      </figure>
+    </xmp>
+
+    In the above example, the <{figcaption}> provides context to all users about the image.
+    While the image has no alternative text to describe it, the presence of the image should
+    be announced, and users with low or no vision may understand what it could display,
+    based on the caption provided.
+
+    By contrast in the following example, the image has an <code>alt</code> attribute set to
+    the empty string:
+
+    <xmp highlight="html">
+      <figure>
+        <img src="star-chart.jpg" alt>
+        <figcaption>
+          <p>
+            Figure 2: The zodiac is an area of the sky that extends approximately 8° north or south of the ecliptic...
+          </p>
+        </figcaption>
+      </figure>
+    </xmp>
+
+    As the <code>alt</code> attribute is set to the empty string, in this example, assistive
+    technologies will likely not announced the existence of the image. Thus to users of such
+    software, the <{figcaption}> would be describing "nothing" as there would be no announcement
+    of a "figure" in this instance.
+  </div>
 
   Markup generators may specify a <dfn><code>generator-unable-to-provide-required-alt</code></dfn>
   attribute on <{img}> elements for which they have been

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3637,7 +3637,7 @@
     an image without an <{img/alt}> attribute is preferable to an <{img/alt}>
     attribute set to the empty string.
 
-    If an image has no alaternative text, screen readers will generally announce there is an image,
+    If an image has no alternative text, screen readers will generally announce there is an image,
     allowing the user to try to learn what the image conveys, e.g. from its filename,
     asking a friend to look at it,
     running Optical Character Recognition to see if it contains text,


### PR DESCRIPTION
[Fixes #885](https://github.com/w3c/html/issues/885)

Adding a note to provide additional context to how screen readers will interpret images that have an alt set to the empty string, vs no alt attribute set.

including code examples to further explain how an empty alt could be problematic.

Would definitely appreciate any feedback on the prose here / if anyone has thoughts on if this needs to be a more succinct note.

Thank you
