### PR TITLE
fixed tiny typo in note for <header> element

### DIFF
--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1105,7 +1105,7 @@
     </xmp>
   </div>
   <p class="note">
-    For cases where an developer wants to nest a <code>header</code> or <code>footer</code> within
+    For cases where a developer wants to nest a <code>header</code> or <code>footer</code> within
   another <code>header</code>: The <{header}> element can only contain a <{header}> or <{footer}>
   if they are themselves contained within <a>sectioning content</a>.
   </p>


### PR DESCRIPTION
“an developer” → “a developer”