### PR TITLE
1224 editorial updates for section & article

### DIFF
--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -167,22 +167,23 @@
   document, page, application, or site. This could be a magazine, newspaper, technical or
   scholarly article, an essay or report, a blog or other social media post.
 
-  A general rule is that the <{article}> element is appropriate only if the element's
-  contents would be listed explicitly in the document's outline. Each <{article}> should be
-  identified, typically by including a heading(<{h1}>-<{h6}> element) as a child of the <{article}>
-  element.
+  A general rule is that the <{article}> element is appropriate only if the element's contents
+  would be listed explicitly in the document's outline. Each <{article}> should be identified,
+  typically by including a heading(<{h1}>-<{h6}> element) as a child of the <{article}> element.
 
-  <p>Assistive Technology may convey the semantics of the <{article}> to users. This
-  information can provide a hint to users as to the type of content. For example the <code>role</code> of
-  the element, which in this case matches the element name "article", can be announced by
-  screen reader software when a user navigates to an <{article}> element. User Agents
-  may also provide methods to navigate to <{article}> elements.</p>
+  <p>
+    Assistive Technology may convey the semantics of the <{article}> to users. This
+    information can provide a hint to users as to the type of content. For example the
+    <code>role</code> of the element, which in this case matches the element name "article",
+    can be announced by screen reader software when a user navigates to an <{article}> element.
+    User Agents may also provide methods to navigate to <{article}> elements.
+  </p>
 
-  When <{article}> elements are nested, the inner <{article}> elements represent
-  articles that are in principle related to the contents of the outer article. For instance, a blog
-  entry on a site could consist of summaries of other blog entries in <{article}> elements nested
-  within the <{article}> element for the blog entry.
 
+  When <{article}> elements are nested, the inner <{article}> elements represent articles that
+  are in principle related to the contents of the outer article. For instance, a blog entry on a
+  site could consist of summaries of other blog entries in <{article}> elements nested within
+  the <{article}> element for the blog entry.
 
   <div class="example">
     <p>
@@ -205,12 +206,15 @@
     </xmp>
   </div>
 
- <p class="note">The schema.org vocabulary can be used to provide more granular information about
-  the type of article, using the <a href="https://schema.org/Article">CreativeWork - Article</a>
-  subtypes, other information such as the publication date for the article can also be provided.</p>
+  <p class="note">
+    The schema.org vocabulary can be used to provide more granular information about
+    the type of article, using the <a href="https://schema.org/Article">CreativeWork - Article</a>
+    subtypes, other information such as the publication date for the article can also be provided.
+  </p>
 
   <div class="example">
-    This example shows a blog post using the <{article}> element, with some <i>schema.org</i> annotations:
+    This example shows a blog post using the <{article}> element, with some
+    <i>schema.org</i> annotations:
 
     <xmp highlight="html">
       <article vocab="http://schema.org/" typeof="Article">
@@ -227,41 +231,43 @@
       </article>
     </xmp>
 
-  Here is that same blog post, but showing some of the comments:
+    Here is that same blog post, but showing some of the comments:
 
-  <xmp highlight="html">
-    <article>
-      <header>
-        <h2>The Very First Rule of Life</h2>
-        <p><time datetime="2018-02-07">3 days ago</time></p>
-      </header>
-      <p>Always check that your computer is plugged in before you complain it isn't working.</p>
-      <section>
-        <h3>Comments</h3>
-        <ol>
-          <li id="c1">
-            <p>Posted by:
-              <span>George Washington</span>
-            </p>
-            <p><time datetime="2018-02-10">15 minutes ago</time></p>
-            <p>Yeah! I've done that!</p>
-          </li>
-          <li id="c2">
-            <p>Posted by:
-              <span>George Hammond</span>
-            </p>
-            <p><time datetime="2018-02-10">5 minutes ago</time></p>
-            <p>Hey, you have the same first name as me.</p>
-          </li>
-        </ol>
-      </section>
-    </article>
-  </xmp>
+    <xmp highlight="html">
+      <article>
+        <header>
+          <h2>The Very First Rule of Life</h2>
+          <p><time datetime="2018-02-07">3 days ago</time></p>
+        </header>
+        <p>Always check that your computer is plugged in before you complain it isn't working.</p>
+        <section>
+          <h3>Comments</h3>
+          <ol>
+            <li id="c1">
+              <p>Posted by:
+                <span>George Washington</span>
+              </p>
+              <p><time datetime="2018-02-10">15 minutes ago</time></p>
+              <p>Yeah! I've done that!</p>
+            </li>
+            <li id="c2">
+              <p>Posted by:
+                <span>George Hammond</span>
+              </p>
+              <p><time datetime="2018-02-10">5 minutes ago</time></p>
+              <p>Hey, you have the same first name as me.</p>
+            </li>
+          </ol>
+        </section>
+      </article>
+    </xmp>
 
-    <p>Notice the use of an ordered list <code>ol</code> to organize the comments. Also note the
-  comments are a subsection of the article, identified using a <code>section</code> element.</p>
-</div>
-
+    <p>
+      Notice the use of an ordered list (<code>ol</code> element) to organize the comments.
+      Also note these comments are considered a subsection of the article, identified
+      by the <code>section</code> element they are nested within.
+    </p>
+  </div>
 
 <h4 id="the-section-element">The <dfn element><code>section</code></dfn> element</h4>
 
@@ -341,10 +347,10 @@
     </dd>
   </dl>
 
-  The <a element>section</a> element <a>represents</a> a generic section of a document or application.
+  The <{section}> element <a>represents</a> a generic section of a document or application.
   A section, in this context, is a thematic grouping of content. Each <code>section</code> should be
   identified, typically by including a heading (<code>h1</code>-<code>h6</code> element) as a child
-  of the <a element>section</a> element.
+  of the <{section}> element.
 
   <p class="example">
     Examples of sections would be chapters, the various tabbed pages in a tabbed dialog box, or the
@@ -414,7 +420,7 @@
           <section>
             <h2>Ceremony</h2>
             <p>Opening Procession</p>
-            <p>Speech by Validactorian</p>
+            <p>Speech by Valedictorian</p>
             <p>Speech by Class President</p>
             <p>Presentation of Diplomas</p>
             <p>Closing Speech by Headmaster</p>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -420,8 +420,10 @@
   </div>
 
   <div class="example">
-    Here is a graduation program with two sections, one for the list of people graduating, and
-    one for the description of the ceremony.
+    Here is a graduation program with two sections, one for description of the ceremony, and
+    one for the listing of people graduating. Within the second <code>section</code> there could
+    exist <code>article</code>s, providing brief bios, academic achievements, and personal
+    note from the graduates.
 
     <xmp highlight="html">
       <!DOCTYPE html>
@@ -449,6 +451,13 @@
               <li>Thomas Raith</li>
               <li>Susan Rodriguez</li>
             </ul>
+            <article>
+              <h3>About Molly Carpenter</h3>
+              <p>
+                Molly was valedictorian of her class, graduating with a GPA of...
+              </p>
+            </article>
+            ...
           </section>
         </body>
       </html>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -356,9 +356,9 @@
   </dl>
 
   The <{section}> element <a>represents</a> a generic section of a document or application.
-  A section, in this context, is a thematic grouping of content. Each <code>section</code> should be
-  identified, typically by including a heading (<code>h1</code>-<code>h6</code> element) as a child
-  of the <{section}> element.
+  A section, in this context, is a thematic grouping of content. Each <code>section</code> should
+  be identified, typically by including a heading (<code>h1</code>-<code>h6</code> element) as a
+  child of the <{section}> element.
 
   <p class="example">
     Examples of sections would be chapters, the various tabbed pages in a tabbed dialog box, or the
@@ -381,11 +381,13 @@
     the element's contents would be listed explicitly in the document's <a>outline</a>.
   </p>
 
-  <p>Assistive Technology may convey the semantics of the <{section}> to users when
-  the element has an explicit label. This information can provide a hint to users as to the type of content.
-  For example the <code>role</code> of the element, which in this case is "region",
-  can be announced by screen reader software when a user navigates to an <{section}> element. User Agents
-  may also provide methods to navigate to <{section}> elements.</p>
+  <p>
+    Assistive Technology may convey the semantics of the <{section}> to users when the element has
+    an explicit label. This information can provide a hint to users as to the type of content.
+    For example the <code>role</code> of the element, which in this case is "region", can be
+    announced by screen reader software when a user navigates to an <{section}> element.
+    User Agents may also provide methods to navigate to <{section}> elements.
+  </p>
 
   <div class="example">
     In the following example, we see an article (part of a larger Web page) about apples,
@@ -465,8 +467,8 @@
 
   <div class="example">
     In this example, a book author has marked up some sections as chapters and some as appendices,
-    and uses CSS to style the headers in these two classes of section differently. The whole book is
-    wrapped in an <{article}> element as part of an even larger document containing other books.
+    and uses CSS to style the headers in these two classes of section differently. The whole book
+    is wrapped in an <{article}> element as part of an even larger document containing other books.
 
     <xmp highlight="html">
       <style>
@@ -548,11 +550,13 @@
   The <{nav}> element <a>represents</a> a section of a page that links to other pages or to
   parts within the page: a section with navigation links.
 
-   <p>Assistive Technology may convey the semantics of the <{nav}> to users.
-   This information can provide a hint to users as to the type of content.  For example the <code>role</code>
-   of the element, which in this case is "navigation", can be announced by screen reader software when a
-   user navigates to an <{nav}> element. User Agents may also provide methods to navigate to
-   <{nav}> elements.</p>
+  <p>
+    Assistive Technology may convey the semantics of the <{nav}> to users. This information can
+    provide a hint to users as to the type of content.  For example the <code>role</code> of the
+    element, which in this case is "navigation", can be announced by screen reader software when
+    a user navigates to an <{nav}> element. User Agents may also provide methods to navigate to
+    <{nav}> elements.
+  </p>
 
   <p class="note">
     In cases where the content of a <{nav}> element represents a list of items, use list
@@ -571,8 +575,8 @@
   <p class="note">
     User agents (such as screen readers) that are targeted at users who can benefit from navigation
     information being omitted in the initial rendering, or who can benefit from navigation
-    information being immediately available, can use this element as a way to determine what content
-    on the page to initially skip or provide on request (or both).
+    information being immediately available, can use this element as a way to determine what
+    content on the page to initially skip or provide on request (or both).
   </p>
 
   <div class="example">
@@ -689,8 +693,7 @@
   </div>
 
   <div class="example">
-    In this example, <{nav}> is used in an e-mail application, to let the user switch
-    folders:
+    In this example, <{nav}> is used in an e-mail application, to let the user switch folders:
 
     <xmp highlight="html">
       <p><input type="button" value="Compose" onclick="compose()"></p>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -179,6 +179,15 @@
     User Agents may also provide methods to navigate to <{article}> elements.
   </p>
 
+  An <{article}> element may contain other nested elements to provide additional semantics
+  to different portions of the <code>article</code>. For instance, an <code>article</code>
+  may consist of a <{header}> that contains the primary heading of the <code>article</code>,
+  with other elements to provide lead-in or meta content about the <code>article</code> prose.
+
+  Additionally, an article may consist of various subsections that, together, form  the complete
+  composition. These subsections may be implicitly implied by the use of appropriately ranked
+  headings (<{h1}>-<{h6}> elements), or may be explicitly set by use of a <{section}> element
+  or elements.
 
   When <{article}> elements are nested, the inner <{article}> elements represent articles that
   are in principle related to the contents of the outer article. For instance, a blog entry on a
@@ -359,16 +368,18 @@
   </p>
 
   <p class="note">
-    Authors are encouraged to use the <{article}> element instead of the
-    <{section}> element when the content is complete, or self-contained, composition.
+    Unlike an <{article}>, a <{section}> may not be fully understandable if taken out of context
+    of its originating document or application. Authors are encouraged to use the <{article}>
+    element instead of the <{section}> element when the content is complete, or self-contained,
+    composition.
   </p>
 
   <p class="note">
-    The <{section}> element is not a generic container element. When an element is needed
-    only for styling purposes or as a convenience for scripting, authors are encouraged to use the
-    <{div}> element instead. A general rule is that the <{section}> element is
-    appropriate only if the element's contents would be listed explicitly in the document's
-    <a>outline</a>.
+    While the <{section}> element <a>represents</a> a generic section of a document or application,
+    <b>it is not a generic container element</b>. When a wrapping element is needed for styling
+    purposes, or as a convenience for scripting, authors are encouraged to use the
+    <{div}> element instead. A general rule is that the <{section}> element is appropriate only if
+    the element's contents would be listed explicitly in the document's <a>outline</a>.
   </p>
 
   <p>Assistive Technology may convey the semantics of the <{section}> to users when
@@ -381,9 +392,12 @@
     In the following example, we see an article (part of a larger Web page) about apples,
     containing two short sections.
 
-  <p class="note">The <{section}> has an <{aria/aria-label}> attribute providing a brief description of
-  the contents. Assistive technology may convey the <a attr-value for="aria/role"><code>region</code></a> role
-  along with the <{aria/aria-label}> value as a hint to users.</p>
+    <p class="note">
+      The <{section}> has an <{aria/aria-label}> attribute providing a brief description of the
+      contents. Assistive technology may convey the
+      <a attr-value for="aria/role"><code>region</code></a> role along with the <{aria/aria-label}>
+      value as a hint to users.
+    </p>
 
     <xmp highlight="html">
       <article>
@@ -407,7 +421,7 @@
 
   <div class="example">
     Here is a graduation program with two sections, one for the list of people graduating, and
-    one for the description of the ceremony.)
+    one for the description of the ceremony.
 
     <xmp highlight="html">
       <!DOCTYPE html>
@@ -444,8 +458,7 @@
   <div class="example">
     In this example, a book author has marked up some sections as chapters and some as appendices,
     and uses CSS to style the headers in these two classes of section differently. The whole book is
-    wrapped in an <{article}> element as part of an even larger document containing other
-    books.
+    wrapped in an <{article}> element as part of an even larger document containing other books.
 
     <xmp highlight="html">
       <style>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -185,9 +185,8 @@
   with other elements to provide lead-in or meta content about the <code>article</code> prose.
 
   Additionally, an article may consist of various subsections that, together, form  the complete
-  composition. These subsections may be implicitly implied by the use of appropriately ranked
-  headings (<{h1}>-<{h6}> elements), or may be explicitly set by use of a <{section}> element
-  or elements.
+  composition. These subsections may be implied by the use of appropriately ranked  headings
+  (<{h1}>-<{h6}> elements), or may be explicitly set by use of a <{section}> element or elements.
 
   When <{article}> elements are nested, the inner <{article}> elements represent articles that
   are in principle related to the contents of the outer article. For instance, a blog entry on a

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -369,7 +369,7 @@
   <p class="note">
     Unlike an <{article}>, a <{section}> may not be fully understandable if taken out of context
     of its originating document or application. Authors are encouraged to use the <{article}>
-    element instead of the <{section}> element when the content is complete, or self-contained,
+    element instead of the <{section}> element when the content is a complete, or self-contained,
     composition.
   </p>
 


### PR DESCRIPTION
[Fixes #1224](https://github.com/w3c/html/issues/1224), in that these suggested updates to the prose for `article` and `section` are meant to further clarify the existing purposes for each element.

`article`s remain elements that contain a full composition, and `section`s remain elements that demarcate sub-sections of an `article`, document or application.

Example 7 was updated to include a brief example of when an `article` within a `section` element may be appropriate.

Some minor typos and source formatting are includes in these updates.