### PR TITLE
Shwetank 194 clarify input date onchange

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -80,7 +80,9 @@
   "Mr Blacksheep", <!-- on github -->
   Nicholas Stimpson,
   Noel Gordon,
+  Patrick H. Lauke,
   Paul Libbrecht,
+  "paulpalaszewski", <!-- on github -->
   Pavel Dvořák,
   Pedro de Carvalho,
   Philippe Le Hégaret,

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3761,6 +3761,8 @@
   When the element is <a>suffering from a step mismatch</a>, the user agent may round the
   element's <a for="forms">value</a> to the nearest <a for="dates">date</a> for which the element would not <a>suffer from a step mismatch</a>.
 
+  The <code>change</code> event is fired whenever the user has selected a new <a>valid date string</a> - which can be triggered when the user enters a new value. When a user changes a new <a>valid date string</a> or uses a stepping function to increment or decrement a part of the overall date string, user agents may apply a timeout to determine that the changed value is no longer intermediate. At the completion of such timeout, <code>change</code> must fire. Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed, and <code>change</code> should fire on all such cases if the new date value is different than the previous one. 
+
   <strong>The <a>algorithm to convert a string to a number</a>, given a string <var>input</var>,
   is as follows</strong>: If <a>parsing a date</a> from <var>input</var> results in an
   error, then return an error; otherwise, return the number of milliseconds elapsed from midnight

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3761,7 +3761,9 @@
   When the element is <a>suffering from a step mismatch</a>, the user agent may round the
   element's <a for="forms">value</a> to the nearest <a for="dates">date</a> for which the element would not <a>suffer from a step mismatch</a>.
 
-  The <code>change</code> event is fired whenever the user has selected a new <a>valid date string</a> - which can be triggered when the user enters a new value. When a user changes a new <a>valid date string</a> or uses a stepping function to increment or decrement a part of the overall date string, user agents may apply a timeout to determine that the changed value is no longer intermediate. At the completion of such timeout, <code>change</code> must fire. Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed, and <code>change</code> should fire on all such cases if the new date value is different than the previous one. 
+  The <code>change</code> event is fired whenever the user has entered a new <a>valid date string</a>. Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed. The event should be fired on all such cases if the new date value is different than the previous one.
+
+  User agents may want to avoid firing the event on all intermediate values as and when the user cycles through the date values quickly. To do so, they may employ a timeout to avoid firing the event on intermediate values.
 
   <strong>The <a>algorithm to convert a string to a number</a>, given a string <var>input</var>,
   is as follows</strong>: If <a>parsing a date</a> from <var>input</var> results in an

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3761,7 +3761,7 @@
   When the element is <a>suffering from a step mismatch</a>, the user agent may round the
   element's <a for="forms">value</a> to the nearest <a for="dates">date</a> for which the element would not <a>suffer from a step mismatch</a>.
 
-  The <code>change</code> event is fired whenever the user seletcs a new <a>valid date string</a>.
+  The <code>change</code> event is fired whenever the user selects a new <a>valid date string</a>.
   Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed.
   The event should be fired on all such cases if the new date value is different than the previous one.
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3761,9 +3761,12 @@
   When the element is <a>suffering from a step mismatch</a>, the user agent may round the
   element's <a for="forms">value</a> to the nearest <a for="dates">date</a> for which the element would not <a>suffer from a step mismatch</a>.
 
-  The <code>change</code> event is fired whenever the user has entered a new <a>valid date string</a>. Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed. The event should be fired on all such cases if the new date value is different than the previous one.
+  The <code>change</code> event is fired whenever the user seletcs a new <a>valid date string</a>.
+  Moving focus away from the date picker component or explicitly confirming with a button are unambigous triggers that the user wants the value changed.
+  The event should be fired on all such cases if the new date value is different than the previous one.
 
-  User agents may want to avoid firing the event on all intermediate values as and when the user cycles through the date values quickly. To do so, they may employ a timeout to avoid firing the event on intermediate values.
+  User agents are not required to firing the event on intermediate values reached as the user cycles through a sequence of values.
+  For example, user agents may employ a timeout between changes, to avoid firing too many change events.
 
   <strong>The <a>algorithm to convert a string to a number</a>, given a string <var>input</var>,
   is as follows</strong>: If <a>parsing a date</a> from <var>input</var> results in an


### PR DESCRIPTION
Fixes [issue 194](https://github.com/w3c/html/issues/194)

Clarifies how and when `change` event should fire to date input types. 