### PR TITLE
define the :defined pseudo-class

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -11,11 +11,12 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 
 <ul>
  <li>the <{autocapitalize}> attribute;</li>
- <li>focusing the dialog instead of the first focusable element if there are no autofocus elements, see issue 773</li>
+ <li>focusing the dialog instead of the first focusable element if there are no autofocus elements, see <a href="https://github.com/w3c/html/issues/773/">issue 773</a></li>
  <li>the <{media/disableRemotePlayback}> attribute;</li>
  <li>{{registerContentHandler()}}, {{unregisterContentHandler()}} and {{isContentHandlerRegistered()}} methods;</li>
  <li><a>customized built-in elements</a> and the <{global/is}> attribute</li>
  <li>The algorithm for <a>creating an outline</a></li>
+ <li><a href="https://github.com/w3c/html/pull/1329">The <code>:defined</code> pseudo-class</a></li>
 </ul>
 
 <p>The following changes from HTML 5.2 are considered "at risk"may be reverted if they cause compatibility problems:</p>

--- a/includes/status.include
+++ b/includes/status.include
@@ -17,10 +17,5 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
  <li><a>customized built-in elements</a> and the <{global/is}> attribute</li>
  <li>The algorithm for <a>creating an outline</a></li>
  <li><a href="https://github.com/w3c/html/pull/1329">The <code>:defined</code> pseudo-class</a></li>
-</ul>
-
-<p>The following changes from HTML 5.2 are considered "at risk"may be reverted if they cause compatibility problems:</p>
-
-<ul>
  <li>Allowing multiple <{meta}> elements with <code>name="description"</code></li>
 </ul>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -10,11 +10,14 @@
   <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various
   editorial and linking fixes.
 
+  <dl>
+  <dt><a href="">Add the <code>:defined</code> psuedo-class selector definition</a></dt>
+   <dd>Substantive change for custom elements.</dd>
+  </dl>
+
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
-     <dt><a href="">Add the <code>:defined</code> psuedo-class selector definition</a></dt>
-      <dd>Substantive change for custom elements.</dd>
     <dt>
       <a href="">Remove monkey-patch 2.9.10 for FileAPI</a>
     </dt>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -10,14 +10,11 @@
   <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various
   editorial and linking fixes.
 
-  <dl>
-  <dt><a href="">Add the <code>:defined</code> psuedo-class selector definition</a></dt>
-   <dd>Substantive change for custom elements.</dd>
-  </dl>
-
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
+  <dt><a href="https://github.com/w3c/html/pull/1329">Add the <code>:defined</code> psuedo-class selector definition</a></dt>
+   <dd>Substantive change for custom elements.</dd>
     <dt><a href="https://github.com/w3c/html/pull/1343">Add autonomous custom elements</a></dd>
     <dd>Substantive change, implemented in Firefox, Blink, Webkit</dd>
     <dd>Includes the {{CustomElementRegistry}} object, the {{CEReactions}} and {{HTMLConstructor}}

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,6 +13,8 @@
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
+     <dt><a href="">Add the <code>:defined</code> psuedo-class selector definition</a></dt>
+      <dd>Substantive change for custom elements.</dd>
     <dt>
       <a href="">Remove monkey-patch 2.9.10 for FileAPI</a>
     </dt>

--- a/sections/semantics.include
+++ b/sections/semantics.include
@@ -407,6 +407,10 @@ path: sections/semantics-common-idioms.include
 
       The '':read-only'' <a>pseudo-class</a> must match all other <a>HTML elements</a>.
 
+  : '':defined''
+  :: The '':defined'' <a>pseudo-class</a> must match any element whose <a>custom element state</a>
+     is either <code>uncustomized</code> or <code>custom</code>, decribed in [[DOM41]] as <a>defined</a>.
+
   : '':dir(ltr)''
   :: The '':dir(ltr)'' <a>pseudo-class</a> must match all elements whose <a>directionality</a> is
       '<a state for="dir">ltr</a>'.

--- a/single-page.bs
+++ b/single-page.bs
@@ -460,12 +460,16 @@ urlPrefix: http://www.w3.org/TR/custom-elements/#; type: dfn; spec: CUSTOM-ELEME
 
 # ************************************ DOM **************************************************
 
-urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
+urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM41
     type:interface; url: document
         text:Document
     urlPrefix: concept-; type: dfn
         text: cd data
         text: collection
+        url: element-defined
+          text:defined
+        url: element-custom-element-state
+          text: custom element state
         url: create-element
             text: creating an element
         urlPrefix: document-

--- a/single-page.bs
+++ b/single-page.bs
@@ -445,7 +445,7 @@ urlPrefix: https://drafts.csswg.org/cssom/#; type: dfn; spec: CSSOM;
 
 # ************************************ DOM **************************************************
 
-urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM41
+urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
     type:interface; url: document
         text:Document
     urlPrefix: concept-; type: dfn

--- a/single-page.bs
+++ b/single-page.bs
@@ -462,9 +462,9 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
             text: document's character encoding; url: encoding
             text: content type
         urlPrefix: element-
+            text: defined
             text: custom
             text: custom element state
-            text: defined
         text: document url
         text: element attribute
         text: element interface

--- a/single-page.bs
+++ b/single-page.bs
@@ -451,10 +451,6 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
     urlPrefix: concept-; type: dfn
         text: cd data
         text: collection
-        url: element-defined
-          text:defined
-        url: element-custom-element-state
-          text: custom element state
         url: create-element
             text: creating an element
             text: create an element


### PR DESCRIPTION
fix #1326 

As of today seems it only works in blink, hence the "not ready" label. Depending on e.g. FF plan we could put it in, as "at risk"...