### PR TITLE
Focus the dialog instead of the first item

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -11,6 +11,7 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
 
 <ul>
  <li>the <{autocapitalize}> attribute;</li>
+ <li>focusing the dialog instead of the first focusable element if there are no autofocus elements, see issue 773</li>
  <li>the <{media/disableRemotePlayback}> attribute;</li>
  <li><{registerContentHandler()}>, <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
 </ul>

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -38,7 +38,9 @@
   "adugamayuba", <!-- on github -->
   Ajay Data,
   Alex Danilo,
+  Alexander Surkov,
   Alexandre Borela,
+  Alastair Campbell,
   Amelia Bellamy-Royds,
   Andrea Rendine,
   Andrew Sullivan,
@@ -50,15 +52,22 @@
   Chaals McCathie Nevile,
   Chris Rebert,
   Collin Anderson,
+  Dan Beam,
   David Singer,
+  Darryl Pogue,
   "Decaid", <!-- on github -->
   Derek Gray,
   Devarshi Pant,
+  Dominic Mazzoni,
   Don Hollander,
   Dylan Barrel,
+  Elliott Sprehn,
   Eric Bailey,
   Fabian Pijcke,
+  freshp86, <!-- on github -->
+  Heydon Pickering,
   J.C.Jones,
+  James Craig,
   Jimmy Bosse,
   "Jinjiang 勾三股四", <!-- github -->
   Jirka Kosek,
@@ -68,11 +77,14 @@
   John Luke Bentley,
   Jonathan T Neal,
   Jothan Frake,
+  田村健人 (TAMURA Kent),
   Leif Halvard Silli,
   Léonie Watson,
   Maciej Stachowiak,
+  Marco Zehe,
   Mark Svancarek,
   Marvin Woo 吴秀诚,
+  Matt Falkenhagen,
   Mike™ Smith,
   Mike West,
   "Miketubby", <!-- github -->
@@ -80,6 +92,7 @@
   "Mr Blacksheep", <!-- on github -->
   Nicholas Stimpson,
   Noel Gordon,
+  Olli Pettay,
   Patrick H. Lauke,
   Paul Libbrecht,
   "paulpalaszewski", <!-- on github -->
@@ -94,10 +107,12 @@
   Ronald Eddy jr.,
   Ryosuke Niwa,
   Sailesh Panchang,
+  Sam Thorogood,
   "SelenIT", <!-- github -->
   Shawn Steele,
   Stéphane Deschamps,
   Steven Faulkner,
+  Takayoshi Kochi,
   Theresa O'Connor,
   Todor Todorov,
   Tomasz Jakut,

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -21,7 +21,7 @@
       Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
     </dd>
     <dt>
-      <a href=""></a>
+      <a href="">Focusing the dialog instead of the first focusable element if there are no autofocus elements</a>
     </dt>
     <dd>
       Substantive change. Fixes <a href="https://github.com/w3c/html/issues/773">issue 773</a>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -21,7 +21,7 @@
       Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
     </dd>
     <dt>
-      <a href="">Focusing the dialog instead of the first focusable element if there are no autofocus elements</a>
+      <a href="https://github.com/w3c/html/pull/1331">Focusing the dialog instead of the first focusable element if there are no autofocus elements</a>
     </dt>
     <dd>
       Substantive change. Fixes <a href="https://github.com/w3c/html/issues/773">issue 773</a>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -20,6 +20,12 @@
       FileAPI is better defined in <a href="https://w3c.github.io/FileAPI/">FileApi spec</a>.
       Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
     </dd>
+    <dt>
+      <a href=""></a>
+    </dt>
+    <dd>
+      Substantive change. Fixes <a href="https://github.com/w3c/html/issues/773">issue 773</a>
+    </dd>
     <dt><a href="https://github.com/w3c/html/pull/1323">Added <code>customElements</code> IDL attribute</a> to the {{Window}} object</dt>
       <dd>Fixes #1274. Substantive change matching new implementation of Custom Elements in Blink / Gecko.</dd>
       <dt><a href="https://github.com/w3c/html/pull/1220">Other Pragma Directives removed.</a></dt>

--- a/sections/semantics-interactive-elements.include
+++ b/sections/semantics-interactive-elements.include
@@ -663,10 +663,7 @@
     Let <var>control</var> be the first non-<a>inert</a> <a>focusable area</a> in
     <var>subject</var>'s <a>control group</a> whose <a>DOM anchor</a> has an <{formelements/autofocus}> attribute specified.
 
-    If there isn't one, then let <var>control</var> be the first non-<a>inert</a>
-    <a>focusable area</a> in <var>subject</var>'s <a>control group</a>.
-
-    If there isn't one of those either, then let <var>control</var> be <var>subject</var>.
+    If there isn't one, then let <var>control</var> be <var>subject</var>.
 
     </li>
 


### PR DESCRIPTION
Fix #773 

Focus the dialog if there are noe autofocus items available, instead of picking the first focusable item