### PR TITLE
Ignore DOCTYPE in srcdoc

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -96,6 +96,7 @@
   Sailesh Panchang,
   "SelenIT", <!-- github -->
   Shawn Steele,
+  Simon Pieters,
   Stéphane Deschamps,
   Steven Faulkner,
   Theresa O'Connor,

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -21,7 +21,7 @@
       Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
     </dd>
     <dt>
-      <a href="">Clarify that the DOCTYPE is ignored, if present, for srcdoc</a>
+      <a href="https://github.com/w3c/html/pull/1332">Clarify that the DOCTYPE is ignored, if present, for srcdoc</a>
     </dt>
     <dd>
       Clarification, match reality.

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -20,6 +20,12 @@
       FileAPI is better defined in <a href="https://w3c.github.io/FileAPI/">FileApi spec</a>.
       Fixed <a href="https://github.com/w3c/html/issues/1217">issue 1217</a>
     </dd>
+    <dt>
+      <a href="">Clarify that the DOCTYPE is ignored, if present, for srcdoc</a>
+    </dt>
+    <dd>
+      Clarification, match reality.
+    </dd>
     <dt><a href="https://github.com/w3c/html/pull/1323">Added <code>customElements</code> IDL attribute</a> to the {{Window}} object</dt>
       <dd>Fixes #1274. Substantive change matching new implementation of Custom Elements in Blink / Gecko.</dd>
       <dt><a href="https://github.com/w3c/html/pull/1220">Other Pragma Directives removed.</a></dt>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -3822,7 +3822,7 @@
 
     <li>Any number of [=comments=] and [=space characters=].</li>
 
-    <li>Optionally, a [=DOCTYPE=].</li>
+    <li>Optionally, a [=DOCTYPE=]. Any DOCTYPE will be ignored, and it will be parsed as if it had <xmp><!DOCTYPE html></xmp> </li>
 
     <li>Any number of [=comments=] and [=space characters=].</li>
 


### PR DESCRIPTION
Fix #254 

Optional DOCTYPE will be parsed as if it was html