### PR TITLE
1335 rel rev cleanup

### DIFF
--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -352,7 +352,7 @@
     <dd><code>sizes</code> — Sizes of the icons (for <{link/rel}>="<code>icon</code>")</dd>
     <dd><code>as</code> — Destination for a preload request (for <{link/rel}>="<code>preload</code>")</dd>
     <dd>
-      Also, the <{link/title}> attribute has special semantics on this element:  Title of the
+      Also, the <{link/title}> attribute has special semantics on this element: Title of the
       link; alternative style sheet set name.
     </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
@@ -434,8 +434,8 @@
   <p class="note">
     Each link created for a <{link}> element is handled separately. For instance, if there
     are two <{link}> elements with <code>rel="stylesheet"</code>, they each count as a
-    separate external resource, and each is affected by its own attributes independently. Similarly,
-    if a single <{link}> element has a <{link/rel}> attribute with the value
+    separate external resource, and each is affected by its own attributes independently.
+    Similarly, if a single <{link}> element has a <{link/rel}> attribute with the value
     <code>next stylesheet</code>, it creates both a <a>hyperlink</a> (for the <code>next</code>
     keyword) and an <a>external resource link</a> (for the <code>stylesheet</code> keyword), and
     they are affected by other attributes (such as <code>media</code> or <{global/title}>)
@@ -466,12 +466,13 @@
   The <dfn element-attr for="link"><code>media</code></dfn> attribute says which media the resource
   applies to. The value must be a <a>valid media query list</a>.
 
-  The <dfn element-attr for="link"><code>integrity</code></dfn> attribute represents the <a>integrity metadata</a>
-  for requests which this element is responsible for. The value is text. The attribute must not be specified on 
-  <{link}> elements that do not have a <{link/rel}> attribute that contains the <{link/stylesheet}> keyword. [[!SRI]]
+  The <dfn element-attr for="link"><code>integrity</code></dfn> attribute represents the
+  <a>integrity metadata</a> for requests which this element is responsible for. The value is text.
+  The attribute must not be specified on <{link}> elements that do not have a <{link/rel}>
+  attribute that contains the <{link/stylesheet}> keyword. [[!SRI]]
 
-  The <dfn element-attr for="link"><code>hreflang</code></dfn> attribute on the <{link}> element has
-  the same semantics as the {{HTMLLinkElement/hreflang}} attribute on the <{a}> element.
+  The <dfn element-attr for="link"><code>hreflang</code></dfn> attribute on the <{link}> element
+  has the same semantics as the {{HTMLLinkElement/hreflang}} attribute on the <{a}> element.
 
   The <dfn element-attr for="link"><code>type</code></dfn> attribute gives the <a>MIME type</a> of
   the linked resource. It is purely advisory. The value must be a <a>valid mime type</a>.
@@ -519,8 +520,11 @@
 
   The <dfn element-attr for="link"><code>as</code></dfn> attribute specifies the <a>potential destination</a> for a preload request for the resource given by the <code>href</code> attribute. It is an [=enumerated attribute=]. Each <a>potential destination</a> is a keyword for this attribute, mapping to a state of the same name. The attribute must be specified on <{link}> elements that have a <{link/rel}> attribute that contains the <{link/preload}> keyword, but must not be specified on <{link}> elements which do not. The processing model for how the <{link/as}> attribute is used is given in the steps to <a>obtain the resource</a>.
 
-  <p class="note">The attribute does not have a [=missing value default=] or [=invalid value default=], meaning that invalid or missing values for the attribute map to no state. This is accounted for in the processing
-  model.</p>
+  <p class="note">
+    The attribute does not have a [=missing value default=] or [=invalid value default=], meaning
+    that invalid or missing values for the attribute map to no state. This is accounted for in the
+    processing model.
+  </p>
 
   <hr>
 
@@ -691,7 +695,7 @@
 
   The <a>task source</a> for these <a>tasks</a> is the <a>DOM manipulation task source</a>.
 
-  Unless otherwise specified for a given <{link/rel}> keyword, the element must 
+  Unless otherwise specified for a given <{link/rel}> keyword, the element must
   <a>delay the load event</a> of the element's <a>node document</a> until all the
   attempts to obtain the resource and its <a>critical subresources</a> are complete. (Resources
   that the user agent has not yet attempted to obtain, e.g., because it is waiting for the resource
@@ -1414,12 +1418,12 @@
 
   A <dfn>character encoding declaration</dfn> is a mechanism by which the <a>character encoding</a>
   used to store or transmit a document is specified.
-  
+
   The only acceptable character encoding declaration for the modern web is <a>UTF-8</a>.
-  
+
   This must be identified by the <a>character encoding</a> label's value being an
   <a>ASCII case-insensitive</a> match for the string "<code>utf-8</code>".
-  
+
   Regardless of whether a character encoding declaration is present or not, the actual character
   encoding used to encode the document must be <a>UTF-8</a>. [[!ENCODING]]
 

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -392,16 +392,18 @@
   The <dfn element-attr for="link"><code>crossorigin</code></dfn> attribute is a
   <a>CORS settings attribute</a>. It is intended for use with <a>external resource links</a>.
 
-  The types of link indicated (the relationships) are given by the value of the
-  <dfn element-attr for="link"><code>rel</code></dfn> attribute, which, if present, must have a
-  value that is a <a>set of space-separated tokens</a>. The <a>allowed keywords and their
-  meanings</a> are defined in a later section. If the <{link/rel}> attribute is absent, has no
-  keywords, or if none of the keywords used are allowed according to the definitions in this
-  specification, then the element does not create any links.
+  Along with the <{link/href}> attribute, a <{link}> element must have a <{link/rel}> attribute
+  with a value that is a <a>set of space-separated tokens</a> (keywords).
+
+  These keywords identify the relationships the types of indicated links have to the document.
+  The <a>allowed keywords and their meanings</a> are defined in a later section. If the
+  <{link/rel}> attribute is absent, has no keywords, or if none of the keywords used are allowed
+  according to the definitions in this specification, then the <{link}> element does not create
+  any links.
 
   <{link/rel}>'s [=supported tokens=] are the keywords defined in [=HTML link types=] which are
-  allowed on <{link}> elements, impact the processing model, and are supported by the user agent.
-  The possible [=supported tokens=] are
+  allowed to be used with <{link}> elements, impact the processing model, and are supported by
+  the user agent. The possible [=supported tokens=] are
   <{link/alternate}>,
   <code>dns-prefetch</code>,
   <{link/icon}>,
@@ -414,14 +416,12 @@
   <{link/search}>,
   <code data-x="rel-serviceworker">serviceworker</code>, and
   <{link/stylesheet}>.
-  <{link/rel}>'s <a>supported tokens</a> must only include the tokens from this list that the user
-  agent implements the processing model for.
-
-  A <{link}> element must have a <{link/rel}> attribute.
+  A <{link/rel}>'s [=supported tokens=] must only include the tokens (keywords) from this list
+  that the user agent implements the processing model for.
 
   If a <{link}> element has a <{link/rel}> attribute that contains only keywords that are
   <a>body-ok</a>, then the element is said to be <dfn>allowed in the body</dfn>. This means
-  that the element can be used where <a>phrasing content</a> is expected.
+  that the <code>link</code> element can be used where <a>phrasing content</a> is expected.
 
   Two categories of links can be created using the <{link}> element:
   <a>Links to external resources</a> and <a>hyperlinks</a>. The <a>link types</a> section defines

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -25,8 +25,8 @@
 
 <h4 id="links-introduction">Introduction</h4>
 
-  Links are a conceptual construct, created by <{a}>, <{area}>, and <{link}> elements.
-  They <a>represent</a> a connection between two resources, one of which is the current {{Document}}.
+  Links are a conceptual construct, created by <{a}>, <{area}>, and <{link}> elements. They
+  <a>represent</a> a connection between two resources, one of which is the current {{Document}}.
   There are two kinds of links in HTML:
 
   <dl>
@@ -42,19 +42,22 @@
     (for example to visit them in the browser or to download them).</dd>
   </dl>
 
-  For <{link}> elements with an <{links/href}>  attribute and a
-  <{link/rel}> attribute, links must be created for the keywords of the
-  <{link/rel}> attribute, as defined for those keywords in the <a>link types</a> section.
+  For <{link}> elements with an <{links/href}> attribute and a <{link/rel}> attribute, links
+  must be created for the keywords of the <{link/rel}> attribute, as defined for those keywords
+  in the <a>link types</a> section.
 
-  Similarly, for <{a}> and <{area}> elements with an <{links/href}> attribute and a <{links/rel}> attribute,
-  links must be created for the keywords of the <{links/rel}> attribute as defined for those keywords in the
-  <a>link types</a> section. Unlike <{link}> elements, however,  <{a}> and <{area}> elements with an <{links/href}>
-  attribute that either do not have a <{links/rel}> attribute, or whose <{links/rel}> attribute has no keywords
-  that are defined as specifying <a>hyperlinks</a>, must also create a <a>hyperlink</a>.
+  Similarly, for <{a}> and <{area}> elements with an <{links/href}> attribute and a
+  <{links/rel}> attribute, links must be created for the keywords of the <{links/rel}> attribute
+  as defined for those keywords in the <a>link types</a> section. Unlike <{link}> elements,
+  however, <{a}> and <{area}> elements with an <{links/href}> attribute that either do not have
+  a <{links/rel}> attribute, or whose <{links/rel}> attribute has no keywords that are defined as
+  specifying <a>hyperlinks</a>, must also create a <a>hyperlink</a>.
   This implied hyperlink has no special meaning (it has no <a>link type</a>)
-  beyond linking the element's <a>node document</a> to the resource given by the element's <code>href</code> attribute.
+  beyond linking the element's <a>node document</a> to the resource given by the element's
+  <code>href</code> attribute.
 
-  A <a>hyperlink</a> can have one or more <dfn lt="annotates|hyperlink annotations">hyperlink annotations</dfn>
+  A <a>hyperlink</a> can have one or more
+  <dfn lt="annotates|hyperlink annotations">hyperlink annotations</dfn>
   that modify the processing semantics of that hyperlink.
 
 <h4 id="links-created-by-a-and-area-elements">Links created by <{a}> and <{area}> elements</h4>
@@ -78,14 +81,12 @@
   specifies is to be downloaded.
 
   In the absence of a user preference, the default should be navigation if the element has no
-  <{links/download}> attribute, and should be to download the
-  specified resource if it does.
+  <{links/download}> attribute, and should be to download the specified resource if it does.
 
   Whether determined by the user's preferences or via the presence or absence of the attribute,
-  if the decision is to use the hyperlink for <a>navigation</a> then the user
-  agent must <a>follow the hyperlink</a>, and if the decision is
-  to use the hyperlink to download a resource, the user agent must <a>download the hyperlink</a>.
-  These terms are defined in subsequent sections
+  if the decision is to use the hyperlink for <a>navigation</a> then the user agent must
+  <a>follow the hyperlink</a>, and if the decision is to use the hyperlink to download a resource,
+  the user agent must <a>download the hyperlink</a>. These terms are defined in subsequent sections
   below.
 
   The <dfn element-attr for="a,area,links"><code>download</code></dfn> attribute, if present,
@@ -98,14 +99,16 @@
 
 
   The <dfn element-attr for="a,area,links"><code>ping</code></dfn> attribute, if present,
-  gives the URLs of the resources that are interested in being notified if the user follows the <a>hyperlink</a>.
-  The value must be a <a>set of space-separated tokens</a>, each of which must be a <a>valid non-empty URL</a>
-  whose scheme is an HTTP(S) scheme. The value is used by the user agent for <a>hyperlink auditing</a>.
+  gives the URLs of the resources that are interested in being notified if the user follows the
+  <a>hyperlink</a>.
+  The value must be a <a>set of space-separated tokens</a>, each of which must be a
+  <a>valid non-empty URL</a> whose scheme is an HTTP(S) scheme. The value is used by the user
+  agent for <a>hyperlink auditing</a>.
 
   The <dfn element-attr for="a,area,links"><code>rel</code></dfn> attribute on <{a}> and
   <{area}> elements controls what kinds of links the elements create. The attribute's value
-  must be a <a>set of space-separated tokens</a>. The <a>allowed keywords and their meanings</a> are
-  defined below.
+  must be a <a>set of space-separated tokens</a>.
+  The <a>allowed keywords and their meanings</a> are defined below.
 
   <{links/rel}>'s <a>supported tokens</a> are the keywords defined in <a>HTML link types</a> which are allowed on
   <{a}> and <{area}> elements, impact the processing model, and are supported by the user agent.

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -60,15 +60,16 @@
   <dfn lt="annotates|hyperlink annotations">hyperlink annotations</dfn>
   that modify the processing semantics of that hyperlink.
 
-<h4 id="links-created-by-a-and-area-elements">Links created by <{a}> and <{area}> elements</h4>
+<h4 id="links-created-by-a-area-and-link-elements">Links created by <{a}>, <{area}> and <{link}> elements</h4>
 
-  The <dfn element-attr for="a,area,links"><code>href</code></dfn> attribute on <{a}> and
-  <{area}> elements must have a value that is a <a>valid URL potentially surrounded by
-  spaces</a>.
+  The <dfn element-attr for="a,area,links"><code>href</code></dfn> attribute on <{a}>, <{area}>
+  and <{link}> elements must have a value that is a
+  <a>valid URL potentially surrounded by spaces</a>.
 
   <p class="note">
-    The <{links/href}> attribute on <{a}> and
-  <{area}> elements is not required; when those elements do not have <{links/href}> attributes they do not create hyperlinks.
+    The <{links/href}> attribute on <{a}> and <{area}> elements is not required; when those
+    elements do not have <{links/href}> attributes they do not create hyperlinks. If a <{link}>
+    element lacks the <{links/href}> attribute, then it does not define a link.
   </p>
 
   The <dfn element-attr for="a,area,links"><code>target</code></dfn> attribute, if present, must be
@@ -107,14 +108,17 @@
 
   The <dfn element-attr for="a,area,links"><code>rel</code></dfn> attribute on <{a}> and
   <{area}> elements controls what kinds of links the elements create. The attribute's value
-  must be a <a>set of space-separated tokens</a>.
+  must be a <a>set of space-separated tokens</a> (keywords).
   The <a>allowed keywords and their meanings</a> are defined below.
 
-  <{links/rel}>'s <a>supported tokens</a> are the keywords defined in <a>HTML link types</a> which are allowed on
-  <{a}> and <{area}> elements, impact the processing model, and are supported by the user agent.
-  The possible <a>supported tokens</a> are <{link/noreferrer}>, and <{link/noopener}>.
-  <{links/rel}>'s <a>supported tokens</a> must only include the tokens from this list
-  that the user agent implements the processing model for.
+  <{links/rel}>'s <a>supported tokens</a> are the keywords defined in <a>HTML link types</a>
+  which are allowed on <{a}> and <{area}> elements, impact the processing model, and are supported
+  by the user agent.
+  The possible <a>supported tokens</a> for <{a}> and <{area}> elements are <{link/noreferrer}>,
+  and <{link/noopener}>. <{links/rel}>'s <a>supported tokens</a> must only include the tokens
+  from this list that the user agent implements the processing model for.
+
+  The <{link/rel}> attribute has a different listing of <a>supported tokens</a> for the <{link}> element.
 
   Other specifications may add <a>HTML link types</a> as defined in <a>Other link types</a>, with
   the following additional requirements:


### PR DESCRIPTION
[Fixes #1335](https://github.com/w3c/html/issues/1335) by modifying the [Links created by `a` and `area` elements](https://w3c.github.io/html/links.html#links-created-by-a-and-area-elements) to include `link`, and by adding some information and references to the `link` element in some of the prose, in place of porting over entire sections of the `link` element's contents, so as to not be repetitive or cannibalize that section. 

Additionally, made some updates to the `link` prose in an attempt to clarify some of the information there (largely pertaining to the way the prose was talking about `rel`).

