### PR TITLE
Add Custom Elements to HTML

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -10,9 +10,11 @@ will be not be included in a Proposed Recommendation,
 per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process-20170301/#candidate-rec):</p>
 
 <ul>
- <li>the <{autocapitalize}> attribute;</li>
+ <li>the <{input/autocapitalize}> attribute;</li>
  <li>the <{media/disableRemotePlayback}> attribute;</li>
- <li><{registerContentHandler()}>, <{unregisterContentHandler()}> and <{isContentHandlerRegistered()}></li>
+ <li>{{registerContentHandler()}}, {{unregisterContentHandler()}} and {{isContentHandlerRegistered()}} methods;</li>
+ <li><a>customized built-in elements</a> and the <{global/is}> attribute</li>
+ 
 </ul>
 
 <p>The following changes from HTML 5.2 are considered "at risk"may be reverted if they cause compatibility problems:</p>

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -119,7 +119,7 @@
   Ronald Eddy jr.,
   Ryosuke Niwa,
   Sailesh Panchang,
-  Scottt Miles,
+  Scott Miles,
   "SelenIT", <!-- github -->
   Shawn Steele,
   Stéphane Deschamps,

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -88,6 +88,7 @@
   Koji Ishii,
   Leif Halvard Silli,
   Léonie Watson,
+  Lea Verou,
   Maciej Stachowiak,
   Mark Svancarek,
   Marvin Woo 吴秀诚,
@@ -98,6 +99,7 @@
   "Mr Blacksheep", <!-- on github -->
   Nicholas Stimpson,
   Noel Gordon,
+  Oliver Byford,
   Olli Pettay,
   Patrick H. Lauke,
   Paul Libbrecht,

--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -3,7 +3,8 @@
 
   Thanks are due to very many people for the work that has led to HTML and this version:
 
-  Tim Berners-Lee for inventing HTML, without which none of this would exist.
+  Tim Berners-Lee for creating HTML, without which none of this would exist, and the Web, without which
+  it would not matter much.
 
   Past editors of HTML specifications at W3C
   Alex Danilo,
@@ -26,8 +27,8 @@
   The many who worked to standardise HTML and XHTML over the last couple of decades or so, and the
   many more who worked on ideas subsequently incorporated into HTML.
 
-  Thanks to Tab Atkins, who produced the bikeshed tool used to build this spec, and
-  <a href="https://github.com">GitHub</a> for tools to manage its development.
+  Thanks to Tab Atkins for the bikeshed tool used to build this spec, Marcos Caceres,
+  Tobie Langel, and <a href="https://github.com">GitHub</a> for tools to manage its development.
 
   With apologies to people who have undeservedly not been named, thanks to:
 
@@ -38,9 +39,12 @@
   "adugamayuba", <!-- on github -->
   Ajay Data,
   Alex Danilo,
+  Alex Komoroske,
+  Alex Russell,
   Alexandre Borela,
   Amelia Bellamy-Royds,
   Andrea Rendine,
+  Andres Rios,
   Andrew Sullivan,
   Anika Henke,
   Anne-Gaelle Colom,
@@ -51,15 +55,25 @@
   Chris Harvey,
   Chris Rebert,
   Collin Anderson,
+  Daniel Buchner,
+  David Hyatt,
   David Singer,
   "Decaid", <!-- on github -->
   Derek Gray,
   Devarshi Pant,
+  Diego Ferreiro Val,
+  Dimitri Glazkov,
+  Dominic Cooney,
   Don Hollander,
   Dylan Barrel,
+  Elliott Sprehn,
   Eric Bailey,
+  Erik Arvidsson,
   Fabian Pijcke,
+  Hajime Morrita,
+  Hayato Ito,
   J.C.Jones,
+  Jan Miksovsky,
   Jimmy Bosse,
   "Jinjiang 勾三股四", <!-- github -->
   Jirka Kosek,
@@ -67,8 +81,11 @@
   John Klensin,
   John Levine,
   John Luke Bentley,
+  Jonas Sicking,
   Jonathan T Neal,
   Jothan Frake,
+  Justin Falgani,
+  Koji Ishii,
   Leif Halvard Silli,
   Léonie Watson,
   Maciej Stachowiak,
@@ -81,33 +98,44 @@
   "Mr Blacksheep", <!-- on github -->
   Nicholas Stimpson,
   Noel Gordon,
+  Olli Pettay,
   Patrick H. Lauke,
   Paul Libbrecht,
   "paulpalaszewski", <!-- on github -->
   Pavel Dvořák,
   Pedro de Carvalho,
   Philippe Le Hégaret,
+  Pierre-Marie Dartus,
   programmer3000, <!-- on github -->
+  Rafael Weinstein,
   Reinhardt Hierl,
   Richard Gibson,
   Richard Ishida,
   Richard Merdinger,
+  Rob Wormald,
+  Roland Steiner,
   Ronald Eddy jr.,
   Ryosuke Niwa,
   Sailesh Panchang,
+  Scottt Miles,
   "SelenIT", <!-- github -->
   Shawn Steele,
-  Simon Pieters,
   Stéphane Deschamps,
+  Steve Orvell,
   Steven Faulkner,
+  Steven Skelton,
+  Tab Atkins,
   Theresa O'Connor,
+  Tim Perry,
   Todor Todorov,
   Tomasz Jakut,
   Tomek Wytrębowicz,
   Tomer Cohen,
   Travis Leithead,
+  Trey Shugart,
   "Unor", <!-- on github -->
   "wallabag.it", <!-- twitter -->
+  William Chen,
   Wolfgang Illmeyer,
   and Yves Lafon
 

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -400,6 +400,12 @@
       <td><a>Text</a></td>
     </tr>
     <tr>
+      <th><{global/is}></th>
+      <td><a>Customized built-in elements</a></td>
+      <td>The <a>local name</a> of the element</td>
+      <td>A <a>valid custom element name</a></td>
+    </tr>
+    <tr>
       <th><code>ismap</code></th>
       <td><{img}></td>
       <td>Whether the image is a server-side image map</td>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,7 +13,14 @@
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
-    <dt><a href="https://github.com/w3c/html/pull/1328">Make <code>rev</code> content attribute reflecthe IDL attribute</a> and define the {{a/rev}} IDL attribute</dt>
+    <dt><a href="">Add autonomous custom elements</a></dd>
+    <dd>Substantive change, implemented in Firefox, Blink, Webkit</dd>
+    <dd>Includes {{CustomElementRegistry}}, {{[CEReactions]}},{{[HTMLConstructor]}},
+     defining <a>custom elements</a>, and <a>upgrades</a></dd>
+    <dt><a href="">Add customized built-in elements</a></dd>
+    <dd>Substantive change, implemented in Blink, Firefox(?)</dd> 
+    <dd>Includes <{global/is}> attribute, [=customized built-in elements|extending existing HTML elements=]</dd>
+    <dt><a href="https://github.com/w3c/html/pull/1328">Make <code>rev</code> content attribute reflect the IDL attribute</a>, define the {{a/rev}} IDL attribute</dt>
      <dd>Substantive change to fix #<a href="https://github.com/w3c/html/issues/1151">issue 1151</a> that helps match reality.</dd>
     <dt>
       <a href="https://github.com/w3c/html/pull/1225">Remove monkey-patch 2.9.10 for FileAPI</a>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -20,7 +20,7 @@
     <dt><a href="https://github.com/w3c/html/pull/1343">Add customized built-in elements</a></dd>
     <dd>Substantive change, implemented in Blink, Firefox(?)</dd>
     <dd>Includes <{global/is}> attribute, [=customized built-in elements|extending existing HTML elements=]</dd>
-    <dt><a href="https://github.com/w3c/html/pull/1328">Make <code>rev</code> content attribute reflect the IDL attribute</a>, define the {{a/rev}} IDL attribute</dt>
+    <dt><a href="https://github.com/w3c/html/pull/1328">Make <code>rev</code> content attribute reflect the IDL attribute</a>, define the <code>rev</code> IDL attribute</dt>
      <dd>Substantive change to fix #<a href="https://github.com/w3c/html/issues/1151">issue 1151</a> that helps match reality.</dd>
     <dt>
       <a href="https://github.com/w3c/html/pull/1225">Remove monkey-patch 2.9.10 for FileAPI</a>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,12 +13,12 @@
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
-    <dt><a href="">Add autonomous custom elements</a></dd>
+    <dt><a href="https://github.com/w3c/html/pull/1343">Add autonomous custom elements</a></dd>
     <dd>Substantive change, implemented in Firefox, Blink, Webkit</dd>
-    <dd>Includes {{CustomElementRegistry}}, {{[CEReactions]}},{{[HTMLConstructor]}},
-     defining <a>custom elements</a>, and <a>upgrades</a></dd>
-    <dt><a href="">Add customized built-in elements</a></dd>
-    <dd>Substantive change, implemented in Blink, Firefox(?)</dd> 
+    <dd>Includes the {{CustomElementRegistry}} object, the {{CEReactions}} and {{HTMLConstructor}}
+     extended IDL attributes, defining <a>custom elements</a>, and <a>upgrades</a></dd>
+    <dt><a href="https://github.com/w3c/html/pull/1343">Add customized built-in elements</a></dd>
+    <dd>Substantive change, implemented in Blink, Firefox(?)</dd>
     <dd>Includes <{global/is}> attribute, [=customized built-in elements|extending existing HTML elements=]</dd>
     <dt><a href="https://github.com/w3c/html/pull/1328">Make <code>rev</code> content attribute reflect the IDL attribute</a>, define the {{a/rev}} IDL attribute</dt>
      <dd>Substantive change to fix #<a href="https://github.com/w3c/html/issues/1151">issue 1151</a> that helps match reality.</dd>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -717,7 +717,7 @@ DOMString extends;
   </li>
 
   <li>a <dfn id="when-defined-promise-map">when-defined promise map</dfn>, mapping <a>valid custom element names</a>
-   to promises. It is used to implement the {{whenDefined}} method.</p>
+   to promises. It is used to implement the {{whenDefined()}} method.</p>
    </li>
    </ul>
 
@@ -852,7 +852,7 @@ DOMString extends;
              <li>
                <p>If <var>callbackValue</var> is not undefined, then set the value of the entry in
                 <var>lifecycleCallbacks</var> with key <var>callbackName</var> to the result of
-                converting <var>callbackValue</var> to the Web IDL {{Function}} callback type.
+                <a>converting</a> <var>callbackValue</var> to the Web IDL {{Function}} callback type.
                 Rethrow any exceptions from the conversion.</p>
              </li>
            </ol>
@@ -871,7 +871,10 @@ DOMString extends;
              </li>
 
              <li>
-               <p>If <var>observedAttributesIterable</var> is not undefined, then set <var>observedAttributes</var> to the result of <a href="https://heycam.github.io/webidl/#es-type-mapping">converting</a> <var>observedAttributesIterable</var> to a <code>sequence&lt;DOMString&gt;</code>. Rethrow any exceptions from the conversion.</p>
+               <p>If <var>observedAttributesIterable</var> is not undefined, then set
+               <var>observedAttributes</var> to the result of <a>converting</a>
+               <var>observedAttributesIterable</var> to a <code>sequence&lt;DOMString&gt;</code>.
+               Rethrow any exceptions from the conversion.</p>
              </li>
            </ol>
          </li>
@@ -982,27 +985,27 @@ DOMString extends;
    </ol>
 
    <div class="example">
-     <p>The {{whenDefined}} method can be used to avoid performing an action until all appropriate
+     <p>The {{whenDefined()}} method can be used to avoid performing an action until all appropriate
      <a href="#custom-element">custom elements</a> are <a>defined</a>. In this example,
       we combine it with the <a>:defined</a> pseudo-class to hide a dynamically-loaded article's contents
        until all the <a>autonomous custom elements</a> it uses are defined.</p>
-     <pre>
+     <xmp>
 articleContainer.hidden = true;
 
 fetch(articleURL)
-.then(response =&gt; response.text())
-.then(text =&gt; {
+.then(response => response.text())
+.then(text => {
  articleContainer.innerHTML = text;
 
  return Promise.all(
    [...articleContainer.querySelectorAll(":not(:defined)")]
-     .map(el =&gt; customElements.whenDefined(el.localName))
+     .map(el => customElements.whenDefined(el.localName))
  );
 })
-.then(() =&gt; {
+.then(() => {
  articleContainer.hidden = false;
 });
-</pre>
+</xmp>
    </div>
  </section>
 
@@ -1018,12 +1021,12 @@ fetch(articleURL)
 
        <div class="example">
          <p>This can occur due to reentrant invocation of this algorithm, as in the following example:</p>
-         <pre>
-&lt;!DOCTYPE html&gt;
-&lt;x-foo id="a"&gt;&lt;/x-foo&gt;
-&lt;x-foo id="b"&gt;&lt;/x-foo&gt;
+         <xmp>
+<!DOCTYPE html>
+<x-foo id="a"></x-foo>
+<x-foo id="b"></x-foo>
 
-&lt;script&gt;
+<script>
 // Defining enqueues upgrade reactions for both "a" and "b"
 customElements.define("x-foo", class extends HTMLElement {
 constructor() {
@@ -1039,8 +1042,8 @@ constructor() {
  document.body.appendChild(b);
 }
 })
-&lt;/script&gt;
-</pre>
+</script>
+</xmp>
 
          <p>This step will thus bail out the algorithm early when <a>upgrade an element</a> is invoked with "<code>b</code>" a second time.</p>
        </div>
@@ -1051,7 +1054,7 @@ constructor() {
      </li>
 
      <li>
-       <p>For each <var>attribute</var> in <var>element</var>'s <a for="Element">attribute list</a>, in order,
+       <p>For each <var>attribute</var> in <var>element</var>'s <!--a@@-->attribute list, in order,
         <a>enqueue a custom element callback reaction</a> with <var>element</var>,
         callback name "<code>attributeChangedCallback</code>", and an argument list containing
         <var>attribute</var>'s local name, null, <var>attribute</var>'s value, and <var>attribute</var>'s namespace.</p>
@@ -1130,7 +1133,7 @@ constructor() {
      <li>
        <p>Let <var>definition</var> be the result of <a>looking up a custom element definition</a>
         given <var>element</var>'s <a>node document</a>, <var>element</var>'s namespace,
-         <var>element</var>'s local name, and <var>element</var>'s <{is}> value</a>.</p>
+         <var>element</var>'s local name, and <var>element</var>'s <a>is value</a>.</p>
      </li>
 
      <li>
@@ -1617,7 +1620,7 @@ constructor() {
  super();
 }
 }
-</pre>
+</xmp>
      </div>
    </li>
 
@@ -1659,7 +1662,6 @@ customElements.define("auto-embiggened", AutoEmbiggenedImage, { extends: "img" }
 const image = new AutoEmbiggenedImage(15, 20);
 console.assert(image.width === 150);
 console.assert(image.height === 200);
-</pre>
  </xmp>
  <!-- end CEinsert @@ -->
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1218,8 +1218,8 @@ constructor() {
      </li>
 
      <li>
-       <p>A <dfn>callback reaction</dfn>, which will call a lifecycle callback,
-        and contains a callback function as well as a list of arguments.</p>
+       <p>A <dfn>callback reaction</dfn>, which will call a <a>lifecycle callback</a>,
+        and contains a {{Function!!callback}} as well as a list of arguments.</p>
      </li>
    </ul>
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -2437,19 +2437,24 @@ console.assert(image.height === 200);
 
   <ul class="brief">
     * <{global/accesskey}>
+    * Attributes whose name begins with [=global aria-* attributes|aria-*=]
     * <{global/class}>
     * <{global/contenteditable}>
     * <{global/dir}>
+    * Attributes whose name begins with [=customized data attribute|data-=]
     * <{global/draggable}>
     * <{global/hidden}>
     * <{global/id}>
+    * <{global/is}>
     * <{global/lang}>
     * <{global/nonce}>
+    * <{aria/role}>
     * <{global/spellcheck}>
     * <{global/style}>
     * <{global/tabindex}>
     * <{global/title}>
     * <{global/translate}>
+    * <{xmlns/xmlns}>
   </ul>
 
   These attributes are only defined by this specification as attributes for [=HTML elements=]. When
@@ -2475,18 +2480,11 @@ console.assert(image.height === 200);
   </div>
 
   <hr>
+  When specified on [=HTML elements=], the <dfn element-attr for="global"><code>class</code></dfn>
+  attribute's value must be a [=set of space-separated tokens=]
+  representing the various classes that the element belongs to.
 
-  The DOM specification defines additional user agent requirements for the
-  <dfn element-attr for="global"><code>class</code></dfn>,
-  <dfn element-attr for="global"><code>id</code></dfn>, and
-  <dfn element-attr for="global"><code>slot</code></dfn> attributes for any element in any
-  namespace. [[DOM]]
-
-  The <{global/class}>, <{global/id}>, and <{global/slot}> attributes may be specified on all
-  [=HTML elements=].
-
-  When specified on [=HTML elements=], the <{global/class}> attribute must have a value that is a
-  [=set of space-separated tokens=] representing the various classes that the element belongs to.
+  The DOM specification defines additional user agent requirements for this attribute. [[DOM41]]
 
   <div class="note">
     Assigning classes to an element affects class matching in selectors in CSS, the
@@ -2497,9 +2495,11 @@ console.assert(image.height === 200);
     rather than values that describe the desired presentation of the content.
   </div>
 
-  When specified on [=HTML elements=], the <{global/id}> attribute value must be unique amongst all
-  the [=IDs=] in the element's [=tree=] and must contain at least one character. The value must not
-  contain any [=space characters=].
+  When specified on [=HTML elements=], the <dfn element-attr for="global"><code>id</code></dfn>
+  attribute value must be unique amongst all the [=IDs=] in the element's [=tree=]
+  and must contain at least one character. The value must not contain any [=space characters=].
+
+  The DOM specification defines additional user agent requirements for this  attribute. [[DOM41]]
 
   <div class="note">
     The <{global/id}> attribute specifies its element's [=id|unique identifier (ID)=].
@@ -2515,8 +2515,16 @@ console.assert(image.height === 200);
   Identifiers are opaque strings. Particular meanings should not be derived from the value of the
   <{global/id}> attribute.
 
-  There are no conformance requirements for the <{global/slot}> attribute specific to
-  [=HTML elements=].
+  When specified on an [=HTML element=] the <dfn element-attr for="global"><code>is</code></dfn>
+  attribute identifies the element as a <a>customized built-in element</a>. Its value must be a
+  <a>valid custom element name</a>.
+
+  Changing the value of the <{global/is}> attribute after the [=create an element|element is created=]
+  does not change an element's behaviour.
+
+  There are no conformance requirements for the <dfn element-attr for="global"><code>slot</code></dfn>
+  attribute specific to [=HTML elements=]. The DOM specification defines requirements for this
+  attribute. [[DOM41]]
 
   <hr />
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -693,7 +693,7 @@
    object for that {{Window}} object.
 
    <pre class="idl">
-interface <dfn id="customelementregistry">CustomElementRegistry</dfn> {
+interface CustomElementRegistry {
 [CEReactions] void define(DOMString name, Function constructor, optional ElementDefinitionOptions options);
 any get(DOMString name);
 Promise&lt;void&gt; whenDefined(DOMString name);
@@ -779,7 +779,7 @@ DOMString extends;
 
      <li>
        <p>If this {{CustomElementRegistry}} contains an entry with
-       <a for="customElements">constructor</a> <var>constructor</var>, then throw a
+       <a lt="custom element constructor">constructor</a> <var>constructor</var>, then throw a
       "{{NotSupportedError}}" {{DOMException}} and abort these steps.</p>
      </li>
 
@@ -1131,9 +1131,10 @@ constructor() {
 
    <ol>
      <li>
-       <p>Let <var>definition</var> be the result of <a>looking up a custom element definition</a>
-        given <var>element</var>'s <a>node document</a>, <var>element</var>'s namespace,
-         <var>element</var>'s local name, and <var>element</var>'s <a>is value</a>.</p>
+       <p>Let <var>definition</var> be the result of
+       <a>looking up a custom element definition</a>
+        given <var>element</var>'s <a>node document</a>, <var>element</var>'s <a for="Element">namespace</a>,
+         <var>element</var>'s <a>local name</a>, and <var>element</var>'s <a>is value</a>.</p>
      </li>
 
      <li>
@@ -1447,7 +1448,7 @@ constructor() {
 
   The [{{HTMLConstructor}}] extended attribute must take no arguments,
   and must not appear on anything other than an interface. It must appear only once on an interface,
-  and the interface must not be annotated with the [{{Constructor}}] or [{{NoInterfaceObject}}]
+  and the interface must not be annotated with the [{{Constructor!!extended-attribute}}] or [{{NoInterfaceObject}}]
   extended attributes. (However, the interface may be annotated with [{{NamedConstructor}}];
   there is no conflict there.) It must not be used on a callback interface.</p>
 
@@ -2449,7 +2450,7 @@ console.assert(image.height === 200);
     * <{global/class}>
     * <{global/contenteditable}>
     * <{global/dir}>
-    * Attributes whose name begins with [=customized data attribute|data-=]
+    * Attributes whose name begins with [=custom data attribute|data-=]
     * <{global/draggable}>
     * <{global/hidden}>
     * <{global/id}>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -694,7 +694,7 @@
 
    <pre class="idl">
 interface <dfn id="customelementregistry">CustomElementRegistry</dfn> {
-[CEReactions] void <a href="#dom-customelementregistry-define">define</a>(DOMString name, Function constructor, optional ElementDefinitionOptions options);
+[CEReactions] void define(DOMString name, Function constructor, optional ElementDefinitionOptions options);
 any get(DOMString name);
 Promise&lt;void&gt; whenDefined(DOMString name);
 };
@@ -707,17 +707,17 @@ DOMString extends;
   Every {{CustomElementRegistry}} has:
 
   <ul>
-  <li> a set of <a>custom element definitions</a>, initially empty.
+  <li>a set of <a>custom element definitions</a>, initially empty.
   In general, algorithms in this specification look up elements in the registry by any of
-  <a for="customElements">name</a>, <a>local name</a>, or <a for="customElements">constructor</a>.
+  <a for="customElements">name</a>, <a>local name</a>, or {{constructor}}.
   </li>
 
-  <li><dfn id="element-definition-is-running">element definition is running</dfn>
+  <li>an <dfn id="element-definition-is-running">element definition is running</dfn>
   flag, used to prevent reentrant invocations of <a>element definition</a>. It is initially unset.
   </li>
 
   <li>a <dfn id="when-defined-promise-map">when-defined promise map</dfn>, mapping <a>valid custom element names</a>
-   to promises. It is used to implement the {{whenDefined()}} method.</p>
+   to promises. It is used to implement the {{whenDefined}} method.</p>
    </li>
    </ul>
 
@@ -742,7 +742,7 @@ DOMString extends;
 
      <dd>
        Retrieves the <a>custom element constructor</a> defined for the given <a for="customElements">name</a>.
-       Returns undefined if there is no <a>custom element definition</a> with the given <a lt="custom-element-definition-name">name</a>.
+       Returns undefined if there is no <a>custom element definition</a> with the given <a for="customElements">name</a>.
      </dd>
 
      <dt><var>window</var> . {{customElements}} . {{whenDefined}}(<var>name</var>)</dt>
@@ -759,12 +759,12 @@ DOMString extends;
    <dfn id="element-definition">Element definition</dfn> is the process of adding a
    <a>custom element definition</a> to the {{CustomElementRegistry}}.
    This is accomplished by the {{define()}} method. When invoked, the
-   <dfn><code>define(<var>name</var>, <var>constructor</var>, <var>options</var>)</code></dfn>
+   <dfn method for="CustomElementRegistry" lt="define()"><code>define(<var>name</var>, <var>constructor</var>, <var>options</var>)</code></dfn>
    method must run these steps:</p>
 
    <ol>
      <li>
-       <p>If <a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a>(<var>constructor</var>) is false, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+       <p>If <a>IsConstructor</a>(<var>constructor</var>) is false, then throw a {{TypeError}} and abort these steps.</p>
      </li>
 
      <li>
@@ -802,7 +802,7 @@ DOMString extends;
 
          <li>
            <p>If the <a>element interface</a> for <var>extends</var> and the <a>HTML namespace</a>
-            is <a>HTMLUnknownElement</a></code>
+            is {{HTMLUnknownElement}}
             (e.g., if <var>extends</var> does not indicate an element definition in this specification),
             then throw a "{{NotSupportedError}}" {{DOMException}}.</p>
          </li>
@@ -846,13 +846,13 @@ DOMString extends;
 
            <ol>
              <li>
-               <p>Let <var>callbackValue</var> be {{Get}}(<var>prototype</var>, <var>callbackName</var>). Rethrow any exceptions.</p>
+               <p>Let <var>callbackValue</var> be {{get}}(<var>prototype</var>, <var>callbackName</var>). Rethrow any exceptions.</p>
              </li>
 
              <li>
                <p>If <var>callbackValue</var> is not undefined, then set the value of the entry in
                 <var>lifecycleCallbacks</var> with key <var>callbackName</var> to the result of
-                {{converting}} <var>callbackValue</var> to the Web IDL {{Function}} callback type.
+                converting <var>callbackValue</var> to the Web IDL {{Function}} callback type.
                 Rethrow any exceptions from the conversion.</p>
              </li>
            </ol>
@@ -890,7 +890,7 @@ DOMString extends;
 
      <li>
        <p>Let <var>definition</var> be a new <a>custom element definition</a> with
-       <a for="customElements">name</a> <var>name</var>, <a for="customElements>local name</a> <var>localName</var>,
+       <a for="customElements">name</a> <var>name</var>, <a for="customElements">local name</a> <var>localName</var>,
         <a>constructor</a> <var>constructor</var>, <a>prototype</a> <var>prototype</var>,
         <a>observed attributes</a> <var>observedAttributes</var>, and
         <a>lifecycle callbacks</a> <var>lifecycleCallbacks</var>.</p>
@@ -936,7 +936,7 @@ DOMString extends;
      </li>
    </ol>
 
-   <p>When invoked, the <dfn id="dom-customelementregistry-get"><code>get(<var>name</var>)</code></dfn> method must run these steps:</p>
+   <p>When invoked, the <dfn for="customElements" lt="get"><code>get(<var>name</var>)</code></dfn> method must run these steps:</p>
 
    <ol>
      <li>
@@ -949,7 +949,8 @@ DOMString extends;
      </li>
    </ol>
 
-   <p>When invoked, the <dfn id="dom-customelementregistry-whendefined"><code>whenDefined(<var>name</var>)</code></dfn> method must run these steps:</p>
+   When invoked, the <dfn method for="CustomElementRegistry" lt="whenDefined()"><code>whenDefined(<var>name</var>)</code></dfn>
+   method must run these steps:</p>
 
    <ol>
      <li>
@@ -981,7 +982,7 @@ DOMString extends;
    </ol>
 
    <div class="example">
-     <p>The {{whenDefined()}} method can be used to avoid performing an action until all appropriate
+     <p>The {{whenDefined}} method can be used to avoid performing an action until all appropriate
      <a href="#custom-element">custom elements</a> are <a>defined</a>. In this example,
       we combine it with the <a>:defined</a> pseudo-class to hide a dynamically-loaded article's contents
        until all the <a>autonomous custom elements</a> it uses are defined.</p>
@@ -1008,7 +1009,7 @@ fetch(articleURL)
  <section>
    <h4 id="upgrades">Upgrades</h4>
 
-   <p>To <dfn>upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
+   <p>To <dfn lt="upgrade">upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
     and an element <var>element</var>, run the following steps:</p>
 
    <ol>
@@ -1050,7 +1051,7 @@ constructor() {
      </li>
 
      <li>
-       <p>For each <var>attribute</var> in <var>element</var>'s <a>attribute list</a>, in order,
+       <p>For each <var>attribute</var> in <var>element</var>'s <a for="Element">attribute list</a>, in order,
         <a>enqueue a custom element callback reaction</a> with <var>element</var>,
         callback name "<code>attributeChangedCallback</code>", and an argument list containing
         <var>attribute</var>'s local name, null, <var>attribute</var>'s value, and <var>attribute</var>'s namespace.</p>
@@ -1072,8 +1073,8 @@ constructor() {
      <li>
        <p>Let <var>constructResult</var> be <a href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>C</var>).</p>
 
-       <p class="note">If <var>C</var> <a href="#custom-element-conformance">non-conformantly</a>
-        uses an API decorated with the {{[CEReactions]}} extended attribute,
+       <p class="note">If <var>C</var> non-conformantly
+        uses an API decorated with the [{{CEReactions}}] extended attribute,
        then the reactions enqueued at the beginning of this algorithm will execute during this step,
        before <var>C</var> finishes and control returns to this algorithm.
         Otherwise, they will execute after <var>C</var> and the rest of the upgrade process finishes.</p>
@@ -1083,14 +1084,13 @@ constructor() {
        <p>Remove the last entry from the end of <var>definition</var>'s <a>construction stack</a>.</p>
 
        <div class="note">
-         <p>Assuming <var>C</var> calls <code>super()</code> (as it will if it is
-          <a for="customElements">conformant</a>),
+         <p>Assuming <var>C</var> calls <code>super()</code>
           and that the call succeeds, this will be the <a>already constructed marker</a>
           that replaced the <var>element</var> pushed at the beginning of this algorithm.
-          (The <a>HTML element constructor</a> carries out this replacement.)</p>
+          (The HTML element constructor carries out this replacement.)</p>
 
-         <p>If <var>C</var> does not call <code>super()</code> (i.e. it is not <a>conformant</a>),
-          or if any step in the <a>HTML element constructor</a> throws, then this entry will still be <var>element</var>.</p>
+         <p>If <var>C</var> does not call <code>super()</code> (i.e. it is not conformant),
+          or if any step in the HTML element constructor throws, then this entry will still be <var>element</var>.</p>
        </div>
      </li>
 
@@ -1141,14 +1141,14 @@ constructor() {
  </section>
 
  <section>
-   <h4 id="custom-element-reactions">Custom element reactions</h4>
+   <h4 id="sec-custom-element-reactions">Custom element reactions</h4>
 
    A <a>custom element</a> can react to certain occurrences by running author code.
-   These reactions are called <dfn id="concept-custom-element-reaction">custom element reactions</dfn>.
+   These reactions are called <dfn>custom element reactions</dfn>.
 
    <ul>
      <li>
-       <p>When <a>upgraded</a>, its <a>constructor</a> is run.</p>
+       <p>When <a lt="upgrade">upgraded</a>, its <a>constructor</a> is run.</p>
      </li>
 
      <li>
@@ -1198,7 +1198,7 @@ constructor() {
    <dfn>backup element queue</dfn>, which is an initially empty
     <a>element queue</a>. Elements are pushed onto the <a>backup element queue</a>
      during operations that affect the DOM without going through an API decorated with
-     {{[CEReactions]}}, or through the parser's <a>create an element for the token</a> algorithm.
+     [{{CEReactions}}], or through the parser's <a>create an element for the token</a> algorithm.
      An example of this is a user-initiated editing operation which modifies the descendants or attributes of an
       <a>editable</a> element. To prevent reentrancy when processing the <a>backup element queue</a>,
       each <a>custom element reactions stack</a> also has a
@@ -1366,17 +1366,17 @@ constructor() {
    </ol>
    <hr>
 
-   The <dfn attribute>[CEReactions]</dfn> IDL <a>extended attribute</a> is to ensure
-   <a>custom element reactions</a> are triggered appropriately.
+   The <dfn  export dfn-type="extended-attribute" lt="CEReactions"><code>[CEReactions]</code></dfn>
+   IDL <a>extended attribute</a> is to ensure <a>custom element reactions</a> are triggered appropriately.
    It indicates that the relevant algorithm is to be supplemented with additional steps
    to appropriately track and invoke <a>custom element reactions</a>.
 
-   The {{[CEReactions]}} extended attribute must take no arguments,
+   The [{{CEReactions}}] extended attribute must take no arguments,
    and must not appear on anything other than an operation, attribute, setter, or deleter.
    Additionally, it must not appear on {{readonly}} attributes,
    unless the readonly attribute is also annotated with [PutForwards].
 
-   Operations, attributes, setters, or deleters annotated with the {{[CEReactions]}}
+   Operations, attributes, setters, or deleters annotated with the [{{CEReactions}}]
    extended attribute must run the following steps
    surrounding the main algorithm specified for the operation, setter, deleter, or for the attribute's setter:
 
@@ -1408,7 +1408,7 @@ constructor() {
 
    Any nonstandard APIs introduced by the user agent that could modify the DOM in such a way as to
    <a>enqueue a custom element callback reaction</a> or <a>enqueue a custom element upgrade reaction</a>,
-    for example by modifying any attributes or child elements, must also be decorated with the {{[CEReactions]}} attribute.</p>
+    for example by modifying any attributes or child elements, must also be decorated with the [{{CEReactions}}] attribute.</p>
 
    <div class="note">
      <p>As of the time of this writing, the following nonstandard or not-yet-standardized APIs are known to fall into this category:</p>
@@ -1437,17 +1437,18 @@ constructor() {
 <section>
  <h4 id="html-element-constructors">HTML: HTML element constructors</h4>
 
-  To support the <a>custom elements</a>, all HTML elements have special constructor behavior.
-  This is indicated via the <dfn attribute><code>[HTMLConstructor]</code></dfn> IDL <a>extended attribute</a>.
-  It indicates that the interface object for the given interface will have a specific behavior when called, as defined in detail below.</p>
+  To support <a>custom elements</a>, all HTML elements have special constructor behavior.
+  The <dfn export dfn-type="extended-attribute" lt="HTMLConstructor"><code>[HTMLConstructor]</code></dfn>
+  IDL <a>extended attribute</a> indicates that the interface object for the given interface
+  will have a specific behavior, as defined in detail below.</p>
 
-  The {{[HTMLConstructor]}} extended attribute must take no arguments,
+  The [{{HTMLConstructor}}] extended attribute must take no arguments,
   and must not appear on anything other than an interface. It must appear only once on an interface,
-  and the interface must not be annotated with the {{[Constructor]}} or {{[NoInterfaceObject]}}
-  extended attributes. (However, the interface may be annotated with {{[NamedConstructor]}};
+  and the interface must not be annotated with the [{{Constructor}}] or [{{NoInterfaceObject}}]
+  extended attributes. (However, the interface may be annotated with [{{NamedConstructor}}];
   there is no conflict there.) It must not be used on a callback interface.</p>
 
-  <a>Interface objects</a> for interfaces annotated with the {{[HTMLConstructor]}} extended attribute
+  <a>Interface objects</a> for interfaces annotated with the [{{HTMLConstructor}}] extended attribute
    must run the following steps as the function body behavior for both \[[Call]] and \[[Construct]]
    invocations of the corresponding JavaScript function object.
 
@@ -1481,8 +1482,8 @@ document.createElement("bad-1");  // (2)
      <p>Let <var>definition</var> be the entry in <var>registry</var> with <a>constructor</a> equal to NewTarget.
       If there is no such definition, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
 
-     <p class="note">Since there can be no entry in <var>registry</var> with a <a>constructor</a>
-     of undefined, this step also prevents HTML element constructors from being called as functions
+     <p class="note">Since there can be no entry in <var>registry</var> whose <a>constructor</a>
+     is undefined, this step also prevents HTML element constructors from being called as functions
      (since in that case NewTarget will be undefined).</p>
    </li>
 
@@ -1509,7 +1510,7 @@ customElements.define("bad-2", class Bad2 extends HTMLParagraphElement {});
    </li>
 
    <li>
-     <p>Otherwise (i.e., if <var>definition</var> is for a <a href="#customized-built-in-element">customized built-in element</a>):</p>
+     <p>Otherwise (i.e., if <var>definition</var> is for a <a>customized built-in element</a>):</p>
 
      <ol>
        <li>
@@ -1582,7 +1583,7 @@ customElements.define("bad-3", class Bad3 extends HTMLQuoteElement {}, { extends
 
      <div class="example">
        This can occur when the author code inside the <a>custom element constructor</a>
-       <a>non-conformantly</a> creates another instance of the class being constructed,
+       non-conformantly creates another instance of the class being constructed,
        before calling <code>super()</code>:</p>
        <pre>
 let doSillyThing = false;
@@ -1604,7 +1605,7 @@ constructor() {
 
      <div class="example">
        This can also occur when author code inside the <a>custom element constructor</a>
-       <a>non-conformantly</a> calls <code>super()</code> twice, since per the JavaScript specification,
+       non-conformantly calls <code>super()</code> twice, since per the JavaScript specification,
        this actually executes the superclass constructor (i.e. this algorithm) twice,
        before throwing an error:</p>
        <xmp class="bad">
@@ -1639,7 +1640,7 @@ constructor() {
  </ol>
  <hr>
 
-  In addition to the constructor behavior implied by {{[HTMLConstructor]}},
+  In addition to the constructor behavior implied by [{{HTMLConstructor}}],
   some elements also have <a>named constructors</a>
    (which are really factory functions with a modified <code>prototype</code> property).</p>
 
@@ -2126,7 +2127,7 @@ console.assert(image.height === 200);
 
   As a general rule, elements whose content model allows any [=flow content=] or
   [=phrasing content=] should have at least one node in its <a lt="element content">contents</a> that is
-  <dfn id="palpable-content-2">palpable content</dfn> and that does not have the <{global/hidden}>
+  <dfn id="palpable-content-2" lt="palpable content|palpable">palpable content</dfn> and that does not have the <{global/hidden}>
   attribute specified.
 
   <p class="note">[=Palpable content=] makes an element non-empty by providing either some

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -11,6 +11,7 @@
   - the "Document" object, significantly extending what is defined in the DOM specification
       including attributes of it like document.cookies, document.referrer, document.head, document.forms, etc.
   - The HTMLElement interface
+  = The CEReactions extended attribute
   - How elements and attributes are described in the spec
   - Content models - used in element descriptions
   - Global attributes
@@ -677,6 +678,885 @@
   [=valid custom element names=] is done to ensure that any potential future [=upgrades=] only cause
   a linear transition of the element's prototype chain, from {{HTMLElement}} to a subclass, instead
   of a lateral one, from {{HTMLUnknownElement}} to an unrelated subclass.</p>
+
+<!-- startCEinsert @@ -->
+<section>
+   <h4 id="custom-elements-api">The CustomElementRegistry interface</h4>
+
+   <p>Each {{Window}} object is associated with a unique instance of a {{CustomElementRegistry}}
+    object, allocated when the {{Window}} object is created.</p>
+
+   <p class="note">Custom element registries are associated with {{Window}} objects, instead of {{Document}} objects, since each <a>custom element constructor</a> inherits from the
+    {{HTMLElement}} interface, and there is exactly one {{HTMLElement}} interface per {{Window}} object.</p>
+
+   The {{Window/customElements}} attribute of the {{Window}} interface returns the {{CustomElementRegistry}}
+   object for that {{Window}} object.
+
+   <pre class="idl">
+interface <dfn id="customelementregistry">CustomElementRegistry</dfn> {
+[CEReactions] void <a href="#dom-customelementregistry-define">define</a>(DOMString name, Function constructor, optional ElementDefinitionOptions options);
+any get(DOMString name);
+Promise&lt;void&gt; whenDefined(DOMString name);
+};
+
+dictionary <dfn id="elementdefinitionoptions">ElementDefinitionOptions</dfn> {
+DOMString extends;
+};
+</pre>
+
+  Every {{CustomElementRegistry}} has:
+
+  <ul>
+  <li> a set of <a>custom element definitions</a>, initially empty.
+  In general, algorithms in this specification look up elements in the registry by any of
+  <a for="customElements">name</a>, <a>local name</a>, or <a for="customElements">constructor</a>.
+  </li>
+
+  <li><dfn id="element-definition-is-running">element definition is running</dfn>
+  flag, used to prevent reentrant invocations of <a>element definition</a>. It is initially unset.
+  </li>
+
+  <li>a <dfn id="when-defined-promise-map">when-defined promise map</dfn>, mapping <a>valid custom element names</a>
+   to promises. It is used to implement the {{whenDefined()}} method.</p>
+   </li>
+   </ul>
+
+
+   <dl class="domintro note">
+     <dt><var>window</var> . {{customElements}} . {{define}}(<var>name</var>, <var>constructor</var>)</dt>
+
+     <dd>
+       Defines a new <a>autonomous custom element</a>, mapping the given name to the given constructor.
+     </dd>
+
+     <dt><var>window</var> . {{customElements}} . {{define}}(<var>name</var>, <var>constructor</var>), { extends: <var>baseLocalName</var> })</dt>
+
+     <dd>
+       Defines a new <a>customized built-in element</a>, mapping the given name to the given constructor for the
+       <a>element type</a> identified by the supplied <var>baseLocalName</var>.
+       A "{{NotSupportedError}}" {{DOMException}} will be thrown upon trying to extend a
+       <a>custom element</a> or an unknown element.
+     </dd>
+
+     <dt><var>window</var> . {{customElements}} . {{get}}(<var>name</var>)</dt>
+
+     <dd>
+       Retrieves the <a>custom element constructor</a> defined for the given <a for="customElements">name</a>.
+       Returns undefined if there is no <a>custom element definition</a> with the given <a lt="custom-element-definition-name">name</a>.
+     </dd>
+
+     <dt><var>window</var> . {{customElements}} . {{whenDefined}}(<var>name</var>)</dt>
+
+     <dd>
+       Returns a promise that will be fulfilled when a <a>custom element</a>
+       becomes defined with the name |name|.
+       (If such a <a>custom element</a> is already defined, the returned promise will be immediately fulfilled.)
+       Returns a promise rejected with a "{{SyntaxError}}" {{DOMException}} if |name| is not a
+       <a>valid custom element name</a>.
+     </dd>
+   </dl>
+
+   <dfn id="element-definition">Element definition</dfn> is the process of adding a
+   <a>custom element definition</a> to the {{CustomElementRegistry}}.
+   This is accomplished by the {{define()}} method. When invoked, the
+   <dfn><code>define(<var>name</var>, <var>constructor</var>, <var>options</var>)</code></dfn>
+   method must run these steps:</p>
+
+   <ol>
+     <li>
+       <p>If <a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a>(<var>constructor</var>) is false, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>If <var>name</var> is not a <a>valid custom element name</a>, then throw a
+       "{{SyntaxError}}" {{DOMException}} and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>If this {{CustomElementRegistry}} contains an entry with <a for="customElements">name</a> <var>name</var>,
+        then throw a "{{NotSupportedError}} {{DOMException}} and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>If this {{CustomElementRegistry}} contains an entry with
+       <a for="customElements">constructor</a> <var>constructor</var>, then throw a
+      "{{NotSupportedError}}" {{DOMException}} and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>Let <var>localName</var> be <var>name</var>.</p>
+     </li>
+
+     <li>
+       <p>Let <var>extends</var> be the value of the <code>extends</code> member of <var>options</var>, or null if no such member exists.</p>
+     </li>
+
+     <li>
+       <p>If <var>extends</var> is not null, then:</p>
+
+       <ol>
+         <li>
+           <p>If <var>extends</var> is a <a>valid custom element name</a>, then throw a
+           "{{NotSupportedError}}" {{DOMException}}.</p>
+         </li>
+
+         <li>
+           <p>If the <a>element interface</a> for <var>extends</var> and the <a>HTML namespace</a>
+            is <a>HTMLUnknownElement</a></code>
+            (e.g., if <var>extends</var> does not indicate an element definition in this specification),
+            then throw a "{{NotSupportedError}}" {{DOMException}}.</p>
+         </li>
+
+         <li>
+           <p>Set <var>localName</var> to <var>extends</var>.</p>
+         </li>
+       </ol>
+     </li>
+
+     <li>
+       <p>If this {{CustomElementRegistry}}'s <a>element definition is running</a> flag is set,
+        then throw a "{{NotSupportedError}}" {{DOMException}} and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>Set this {{CustomElementRegistry}}'s <a>element definition is running</a> flag.</p>
+     </li>
+
+     <li>
+       <p>Run the following substeps while catching any exceptions:</p>
+
+       <ol>
+         <li>
+           <p>Let <var>prototype</var> be <a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>constructor</var>, "prototype"). Rethrow any exceptions.</p>
+         </li>
+
+         <li>
+           <p>If <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a>(<var>prototype</var>) is not Object, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> exception.</p>
+         </li>
+
+         <li>
+           <p>Let <var>lifecycleCallbacks</var> be a map with the four keys "<code>connectedCallback</code>",
+            "<code>disconnectedCallback</code>", "<code>adoptedCallback</code>", and
+             "<code>attributeChangedCallback</code>", each of which belongs to an entry whose value is null.</p>
+         </li>
+
+         <li>
+           <p>For each of the four keys <var>callbackName</var> in <var>lifecycleCallbacks</var>,
+           in the order listed in the previous step:</p>
+
+           <ol>
+             <li>
+               <p>Let <var>callbackValue</var> be {{Get}}(<var>prototype</var>, <var>callbackName</var>). Rethrow any exceptions.</p>
+             </li>
+
+             <li>
+               <p>If <var>callbackValue</var> is not undefined, then set the value of the entry in
+                <var>lifecycleCallbacks</var> with key <var>callbackName</var> to the result of
+                {{converting}} <var>callbackValue</var> to the Web IDL {{Function}} callback type.
+                Rethrow any exceptions from the conversion.</p>
+             </li>
+           </ol>
+         </li>
+
+         <li>
+           <p>Let <var>observedAttributes</var> be an empty <code>sequence&lt;DOMString&gt;</code>.</p>
+         </li>
+
+         <li>
+           <p>If the value of the entry in <var>lifecycleCallbacks</var> with key "<code>attributeChangedCallback</code>" is not null, then:</p>
+
+           <ol>
+             <li>
+               <p>Let <var>observedAttributesIterable</var> be <a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<var>constructor</var>, "observedAttributes"). Rethrow any exceptions.</p>
+             </li>
+
+             <li>
+               <p>If <var>observedAttributesIterable</var> is not undefined, then set <var>observedAttributes</var> to the result of <a href="https://heycam.github.io/webidl/#es-type-mapping">converting</a> <var>observedAttributesIterable</var> to a <code>sequence&lt;DOMString&gt;</code>. Rethrow any exceptions from the conversion.</p>
+             </li>
+           </ol>
+         </li>
+       </ol>
+
+       <p>Then, perform the following substep, regardless of whether the above steps threw an exception or not:</p>
+
+       <ol>
+         <li>
+           <p>Unset this {{CustomElementRegistry}}'s <a>element definition is running</a> flag.</p>
+         </li>
+       </ol>
+
+       <p>Finally, if the first set of substeps threw an exception, then rethrow that exception, and terminate this algorithm. Otherwise, continue onward.</p>
+     </li>
+
+     <li>
+       <p>Let <var>definition</var> be a new <a>custom element definition</a> with
+       <a for="customElements">name</a> <var>name</var>, <a for="customElements>local name</a> <var>localName</var>,
+        <a>constructor</a> <var>constructor</var>, <a>prototype</a> <var>prototype</var>,
+        <a>observed attributes</a> <var>observedAttributes</var>, and
+        <a>lifecycle callbacks</a> <var>lifecycleCallbacks</var>.</p>
+     </li>
+
+     <li>
+       <p>Add <var>definition</var> to this {{CustomElementRegistry}}.</p>
+     </li>
+
+     <li>
+       <p>Let <var>document</var> be this {{CustomElementRegistry}}'s <a>relevant global object</a>'s <a>associated <code>Document</code></a>.</p>
+     </li>
+
+     <li>
+       <p>Let <var>upgrade candidates</var> be all elements that are <a>shadow-including descendants</a>
+        of <var>document</var>, whose namespace is the <a>HTML namespace</a> and whose local name is
+         <var>localName</var>, in <a>shadow-including tree order</a>.
+         Additionally, if <var>extends</var> is non-null, only include elements whose <{global/is}>
+         value is equal to <var>name</var>.</p>
+     </li>
+
+     <li>
+       <p>For each element <var>element</var> in <var>upgrade candidates</var>,
+       <a>enqueue a custom element upgrade reaction</a> given <var>element</var> and <var>definition</var>.</p>
+     </li>
+
+     <li>
+       <p>If this {{CustomElementRegistry}}'s <a>when-defined promise map</a> contains an entry with key <var>name</var>:</p>
+
+       <ol>
+         <li>
+           <p>Let <var>promise</var> be the value of that entry.</p>
+         </li>
+
+         <li>
+           <p>Resolve <var>promise</var> with undefined.</p>
+         </li>
+
+         <li>
+           <p>Delete the entry with key <var>name</var> from this {{CustomElementRegistry}}'s <a>when-defined promise map</a>.</p>
+         </li>
+       </ol>
+     </li>
+   </ol>
+
+   <p>When invoked, the <dfn id="dom-customelementregistry-get"><code>get(<var>name</var>)</code></dfn> method must run these steps:</p>
+
+   <ol>
+     <li>
+       <p>If this {{CustomElementRegistry}} contains an entry with <a for="customElements">name</a> <var>name</var>,
+        then return that entry's <a>constructor</a>.</p>
+     </li>
+
+     <li>
+       <p>Otherwise, return undefined.</p>
+     </li>
+   </ol>
+
+   <p>When invoked, the <dfn id="dom-customelementregistry-whendefined"><code>whenDefined(<var>name</var>)</code></dfn> method must run these steps:</p>
+
+   <ol>
+     <li>
+       <p>If <var>name</var> is not a <a>valid custom element name</a>,
+        then return a new promise rejected with a "{{SyntaxError}}" {{DOMException}} and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>If this {{CustomElementRegistry}} contains an entry with <a for="customElements">name</a> <var>name</var>,
+       then return a new promise resolved with undefined and abort these steps.</p>
+     </li>
+
+     <li>
+       <p>Let <var>map</var> be this {{CustomElementRegistry}}'s <a>when-defined promise map</a>.</p>
+     </li>
+
+     <li>
+       <p>If <var>map</var> does not contain an entry with key <var>name</var>,
+        create an entry in <var>map</var> with key <var>name</var> and whose value is a new promise.</p>
+     </li>
+
+     <li>
+       <p>Let <var>promise</var> be the value of the entry in <var>map</var> with key <var>name</var>.</p>
+     </li>
+
+     <li>
+       <p>Return <var>promise</var>.</p>
+     </li>
+   </ol>
+
+   <div class="example">
+     <p>The {{whenDefined()}} method can be used to avoid performing an action until all appropriate
+     <a href="#custom-element">custom elements</a> are <a>defined</a>. In this example,
+      we combine it with the <a>:defined</a> pseudo-class to hide a dynamically-loaded article's contents
+       until all the <a>autonomous custom elements</a> it uses are defined.</p>
+     <pre>
+articleContainer.hidden = true;
+
+fetch(articleURL)
+.then(response =&gt; response.text())
+.then(text =&gt; {
+ articleContainer.innerHTML = text;
+
+ return Promise.all(
+   [...articleContainer.querySelectorAll(":not(:defined)")]
+     .map(el =&gt; customElements.whenDefined(el.localName))
+ );
+})
+.then(() =&gt; {
+ articleContainer.hidden = false;
+});
+</pre>
+   </div>
+ </section>
+
+ <section>
+   <h4 id="upgrades">Upgrades</h4>
+
+   <p>To <dfn id="concept-upgrade-an-element">upgrade an element</dfn>, given as input a <a href="#custom-element-definition">custom element definition</a> <var>definition</var> and an element <var>element</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>If <var>element</var> is <a href="#concept-element-custom">custom</a>, abort these steps.</p>
+
+       <div class="example">
+         <p>This can occur due to reentrant invocation of this algorithm, as in the following example:</p>
+         <pre>
+&lt;!DOCTYPE html&gt;
+&lt;x-foo id="a"&gt;&lt;/x-foo&gt;
+&lt;x-foo id="b"&gt;&lt;/x-foo&gt;
+
+&lt;script&gt;
+// Defining enqueues upgrade reactions for both "a" and "b"
+customElements.define("x-foo", class extends HTMLElement {
+constructor() {
+ super();
+
+ const b = document.querySelector("#b");
+ b.remove();
+
+ // While this constructor is running for "a", "b" is still
+ // undefined, and so inserting it into the document will enqueue a
+ // second upgrade reaction for "b" in addition to the one enqueued
+ // by defining x-foo.
+ document.body.appendChild(b);
+}
+})
+&lt;/script&gt;
+</pre>
+
+         <p>This step will thus bail out the algorithm early when <a href="#concept-upgrade-an-element">upgrade an element</a> is invoked with "<code>b</code>" a second time.</p>
+       </div>
+     </li>
+
+     <li>
+       <p>If <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> is "<code>failed</code>", then abort these steps.</p>
+     </li>
+
+     <li>
+       <p>For each <var>attribute</var> in <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-element-attribute">attribute list</a>, in order, <a href="#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>element</var>, callback name "<code>attributeChangedCallback</code>", and an argument list containing <var>attribute</var>'s local name, null, <var>attribute</var>'s value, and <var>attribute</var>'s namespace.</p>
+     </li>
+
+     <li>
+       <p>If <var>element</var> is <a href="https://dom.spec.whatwg.org/#connected">connected</a>, then <a href="#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>element</var>, callback name "<code>connectedCallback</code>", and an empty argument list.</p>
+     </li>
+
+     <li>
+       <p>Add <var>element</var> to the end of <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+     </li>
+
+     <li>
+       <p>Let <var>C</var> be <var>definition</var>'s <a href="#concept-custom-element-definition-constructor">constructor</a>.</p>
+     </li>
+
+     <li>
+       <p>Let <var>constructResult</var> be <a href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>C</var>).</p>
+
+       <p class="note">If <var>C</var> <a href="#custom-element-conformance">non-conformantly</a> uses an API decorated with the <code><a href="#cereactions">[CEReactions]</a></code> extended attribute, then the reactions enqueued at the beginning of this algorithm will execute during this step, before <var>C</var> finishes and control returns to this algorithm. Otherwise, they will execute after <var>C</var> and the rest of the upgrade process finishes.</p>
+     </li>
+
+     <li>
+       <p>Remove the last entry from the end of <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+
+       <div class="note">
+         <p>Assuming <var>C</var> calls <code>super()</code> (as it will if it is <a href="#custom-element-conformance">conformant</a>), and that the call succeeds, this will be the <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a> that replaced the <var>element</var> we pushed at the beginning of this algorithm. (The <a href="#html-element-constructors">HTML element constructor</a> carries out this replacement.)</p>
+
+         <p>If <var>C</var> does not call <code>super()</code> (i.e. it is not <a href="#custom-element-conformance">conformant</a>), or if any step in the <a href="#html-element-constructors">HTML element constructor</a> throws, then this entry will still be <var>element</var>.</p>
+       </div>
+     </li>
+
+     <li>
+       <p>If <var>constructResult</var> is an abrupt completion, then:</p>
+
+       <ol>
+         <li>
+           <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>failed</code>".</p>
+         </li>
+
+         <li>
+           <p>Return <var>constructResult</var> (i.e., rethrow the exception), and terminate these steps.</p>
+         </li>
+       </ol>
+     </li>
+
+     <li>
+       <p>If <a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a>(<var>constructResult</var>.[[\value]], <var>element</var>) is false, then throw an <a href="https://heycam.github.io/webidl/#invalidstateerror">"<code>InvalidStateError</code>"</a> <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and terminate these steps.</p>
+
+       <p class="note">This can occur if <var>C</var> constructs another instance of the same custom element before calling <code>super()</code>, or if <var>C</var> uses JavaScript's <code>return</code>-override feature to return an arbitrary object from the constructor.</p>
+     </li>
+
+     <li>
+       <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>custom</code>".</p>
+     </li>
+
+     <li>
+       <p>Set <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a> to <var>definition</var>.</p>
+     </li>
+   </ol>
+
+   <p>To <dfn id="concept-try-upgrade">try to upgrade an element</dfn>, given as input an element <var>element</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>Let <var>definition</var> be the result of <a href="#look-up-a-custom-element-definition">looking up a custom element definition</a> given <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>, <var>element</var>'s namespace, <var>element</var>'s local name, and <var>element</var>'s <a href="#concept-element-is-value"><code>is</code> value</a>.</p>
+     </li>
+
+     <li>
+       <p>If <var>definition</var> is not null, then <a href="#enqueue-a-custom-element-upgrade-reaction">enqueue a custom element upgrade reaction</a> given <var>element</var> and <var>definition</var>.</p>
+     </li>
+   </ol>
+ </section>
+
+ <section>
+   <h4 id="custom-element-reactions">Custom element reactions</h4>
+
+   <p>A <a href="#custom-element">custom element</a> possesses the ability to respond to certain occurrences by running author code:</p>
+
+   <ul>
+     <li>
+       <p>When <a href="#upgrades">upgraded</a>, its <a href="#custom-element-constructor">constructor</a> is run.</p>
+     </li>
+
+     <li>
+       <p>When it <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-connected">becomes connected</a>, its <code>connectedCallback</code> is run.</p>
+     </li>
+
+     <li>
+       <p>When it <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-disconnected">becomes disconnected</a>, its <code>disconnectedCallback</code> is run.</p>
+     </li>
+
+     <li>
+       <p>When it is <a href="https://dom.spec.whatwg.org/#concept-node-adopt">adopted</a> into a new document, its <code>adoptedCallback</code> is run.</p>
+     </li>
+
+     <li>
+       <p>When any of its attributes are <a href="#concept-element-attributes-change">changed</a>, <a href="#concept-element-attributes-append">appended</a>, <a href="#concept-element-attributes-remove">removed</a>, or <a href="#concept-element-attributes-replace">replaced</a>, its <code>attributeChangedCallback</code> is run.</p>
+     </li>
+   </ul>
+
+   <p>We call these reactions collectively <dfn id="concept-custom-element-reaction">custom element reactions</dfn>.</p>
+
+   <p>The way in which <a href="#concept-custom-element-reaction">custom element reactions</a> are invoked is done with special care, to avoid running author code during the middle of delicate operations. Effectively, they are delayed until "just before returning to user script". This means that for most purposes they appear to execute synchronously, but in the case of complicated composite operations (like <a href="#concept-node-clone">cloning</a>, or <a href="https://dom.spec.whatwg.org/#concept-range">range</a> manipulation), they will instead be delayed until after all the relevant user agent processing steps have completed, and then run together as a batch.</p>
+
+   <p>Additionally, the precise ordering of these reactions is managed via a somewhat-complicated stack-of-queues system, described below. The intention behind this system is to guarantee that <a href="#concept-custom-element-reaction">custom element reactions</a> always are invoked in the same order as their triggering actions, at least within the local context of a single <a href="#custom-element">custom element</a>. (Because <a href="#concept-custom-element-reaction">custom element reaction</a> code can perform its own mutations, it is not possible to give a global ordering guarantee across multiple elements.)</p>
+   <hr>
+
+   <p>Each <a href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">unit of related similar-origin browsing contexts</a> has a <dfn id="custom-element-reactions-stack">custom element reactions stack</dfn>, which is initially empty. The <dfn id="current-element-queue">current element queue</dfn> is the <a href="#element-queue">element queue</a> at the top of the <a href="#custom-element-reactions-stack">custom element reactions stack</a>. Each item in the stack is an <dfn id="element-queue">element queue</dfn>, which is initially empty as well. Each item in an <a href="#element-queue">element queue</a> is an element. (The elements are not necessarily <a href="#concept-element-custom">custom</a> yet, since this queue is used for <a href="#upgrades">upgrades</a> as well.)</p>
+
+   <p>Each <a href="#custom-element-reactions-stack">custom element reactions stack</a> has an associated <dfn id="backup-element-queue">backup element queue</dfn>, which an initially-empty <a href="#element-queue">element queue</a>. Elements are pushed onto the <a href="#backup-element-queue">backup element queue</a> during operations that affect the DOM without going through an API decorated with <code><a href="#cereactions">[CEReactions]</a></code>, or through the parser's <a href="#create-an-element-for-the-token">create an element for the token</a> algorithm. An example of this is a user-initiated editing operation which modifies the descendants or attributes of an <a href="https://w3c.github.io/editing/execCommand.html#editable">editable</a> element. To prevent reentrancy when processing the <a href="#backup-element-queue">backup element queue</a>, each <a href="#custom-element-reactions-stack">custom element reactions stack</a> also has a <dfn id="processing-the-backup-element-queue">processing the backup element queue</dfn> flag, initially unset.</p>
+
+   <p>All elements have an associated <dfn id="custom-element-reaction-queue">custom element reaction queue</dfn>, initially empty. Each item in the <a href="#custom-element-reaction-queue">custom element reaction queue</a> is of one of two types:</p>
+
+   <ul>
+     <li>
+       <p>An <dfn id="upgrade-reaction">upgrade reaction</dfn>, which will <a href="#upgrades">upgrade</a> the custom element and contains a <a href="#custom-element-definition">custom element definition</a>; or</p>
+     </li>
+
+     <li>
+       <p>A <dfn id="callback-reaction">callback reaction</dfn>, which will call a lifecycle callback, and contains a callback function as well as a list of arguments.</p>
+     </li>
+   </ul>
+
+   <p>This is all summarised in the following schematic diagram:</p>
+
+   <p><img src="custom-element-reactions.svg" alt="A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." style="width: 80%; max-width: 580px;"></p>
+
+   <p>To <dfn id="enqueue-an-element-on-the-appropriate-element-queue">enqueue an element on the appropriate element queue</dfn>, given an element <var>element</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>If the <a href="#custom-element-reactions-stack">custom element reactions stack</a> is empty, then:</p>
+
+       <ol>
+         <li>
+           <p>Add <var>element</var> to the <a href="#backup-element-queue">backup element queue</a>.</p>
+         </li>
+
+         <li>
+           <p>If the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag is set, abort this algorithm.</p>
+         </li>
+
+         <li>
+           <p>Set the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag.</p>
+         </li>
+
+         <li>
+           <p><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to perform the following steps:</p>
+
+           <ol>
+             <li>
+               <p><a href="#invoke-custom-element-reactions">Invoke custom element reactions</a> in the <a href="#backup-element-queue">backup element queue</a>.</p>
+             </li>
+
+             <li>
+               <p>Unset the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag.</p>
+             </li>
+           </ol>
+         </li>
+       </ol>
+     </li>
+
+     <li>
+       <p>Otherwise, add <var>element</var> to the <a href="#current-element-queue">current element queue</a>.</p>
+     </li>
+   </ol>
+
+   <p>To <dfn id="enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</dfn>, given a <a href="#custom-element">custom element</a> <var>element</var>, a callback name <var>callbackName</var>, and a list of arguments <var>args</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>Let <var>definition</var> be <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a>.</p>
+     </li>
+
+     <li>
+       <p>Let <var>callback</var> be the value of the entry in <var>definition</var>'s <a href="#concept-custom-element-definition-lifecycle-callbacks">lifecycle callbacks</a> with key <var>callbackName</var>.</p>
+     </li>
+
+     <li>
+       <p>If <var>callback</var> is null, then abort these steps.</p>
+     </li>
+
+     <li>
+       <p>If <var>callbackName</var> is "<code>attributeChangedCallback</code>", then:</p>
+
+       <ol>
+         <li>
+           <p>Let <var>attributeName</var> be the first element of <var>args</var>.</p>
+         </li>
+
+         <li>
+           <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-observed-attributes">observed attributes</a> does not contain <var>attributeName</var>, then abort these steps.</p>
+         </li>
+       </ol>
+     </li>
+
+     <li>
+       <p>Add a new <a href="#callback-reaction">callback reaction</a> to <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>, with callback function <var>callback</var> and arguments <var>args</var>.</p>
+     </li>
+
+     <li>
+       <p><a href="#enqueue-an-element-on-the-appropriate-element-queue">Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
+     </li>
+   </ol>
+
+   <p>To <dfn id="enqueue-a-custom-element-upgrade-reaction">enqueue a custom element upgrade reaction</dfn>, given an element <var>element</var> and <a href="#custom-element-definition">custom element definition</a> <var>definition</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>Add a new <a href="#upgrade-reaction">upgrade reaction</a> to <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>, with <a href="#custom-element-definition">custom element definition</a> <var>definition</var>.</p>
+     </li>
+
+     <li>
+       <p><a href="#enqueue-an-element-on-the-appropriate-element-queue">Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
+     </li>
+   </ol>
+
+   <p>To <dfn id="invoke-custom-element-reactions">invoke custom element reactions</dfn> in an <a href="#element-queue">element queue</a> <var>queue</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>For each <a href="#custom-element">custom element</a> <var>element</var> in <var>queue</var>:</p>
+
+       <ol>
+         <li>
+           <p>Let <var>reactions</var> be <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>.</p>
+         </li>
+
+         <li>
+           <p>Repeat until <var>reactions</var> is empty:</p>
+
+           <ol>
+             <li>
+               <p>Remove the first element of <var>reactions</var>, and let <var>reaction</var> be that element. Switch on <var>reaction</var>'s type:</p>
+
+               <dl class="switch">
+                 <dt>
+                   <a href="#upgrade-reaction">upgrade reaction</a>
+                 </dt>
+
+                 <dd>
+                   <a href="#concept-upgrade-an-element">Upgrade</a> <var>element</var> using <var>reaction</var>'s <a href="#custom-element-definition">custom element definition</a>.
+                 </dd>
+
+                 <dt>
+                   <a href="#callback-reaction">callback reaction</a>
+                 </dt>
+
+                 <dd>
+                   <a href="https://heycam.github.io/webidl/#es-invoking-callback-functions">Invoke</a> <var>reaction</var>'s callback function with <var>reaction</var>'s arguments, and with <var>element</var> as the <a href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>.
+                 </dd>
+               </dl>
+
+               <p>If this throws any exception, then <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>.</p>
+             </li>
+           </ol>
+         </li>
+       </ol>
+     </li>
+   </ol>
+   <hr>
+
+   <p>To ensure <a href="#concept-custom-element-reaction">custom element reactions</a> are triggered appropriately, we introduce the <dfn id="cereactions"><code>[CEReactions]</code></dfn> IDL <a href="https://heycam.github.io/webidl/#dfn-extended-attribute">extended attribute</a>. It indicates that the relevant algorithm is to be supplemented with additional steps in order to appropriately track and invoke <a href="#concept-custom-element-reaction">custom element reactions</a>.</p>
+
+   <p>The <code><a href="#cereactions">[CEReactions]</a></code> extended attribute must take no arguments, and must not appear on anything other than an operation, attribute, setter, or deleter. Additionally, it must not appear on readonly attributes, unless the readonly attribute is also annotated with <code>[PutForwards]</code>.</p>
+
+   <p>Operations, attributes, setters, or deleters annotated with the <code><a href="#cereactions">[CEReactions]</a></code> extended attribute must run the following steps surrounding the main algorithm specified for the operation, setter, deleter, or for the attribute's setter:</p>
+
+   <dl>
+     <dt>Before executing the algorithm's steps</dt>
+
+     <dd>
+       Push a new <a href="#element-queue">element queue</a> onto the <a href="#custom-element-reactions-stack">custom element reactions stack</a>.
+     </dd>
+
+     <dt>After executing the algorithm's steps</dt>
+
+     <dd>
+       Pop the <a href="#element-queue">element queue</a> from the <a href="#custom-element-reactions-stack">custom element reactions stack</a>, and <a href="#invoke-custom-element-reactions">invoke custom element reactions</a> in that queue.
+     </dd>
+   </dl>
+
+   <div class="note">
+     <p>The intent behind this extended attribute is somewhat subtle. One way of accomplishing its goals would be to say that every operation, attribute, setter, and deleter on the platform should have these steps inserted, and to allow implementers to optimize away unnecessary cases (where no DOM mutation is possible that could cause <a href="#concept-custom-element-reaction">custom element reactions</a> to occur).</p>
+
+     <p>However, in practice this imprecision could lead to non-interoperable implementations of <a href="#concept-custom-element-reaction">custom element reactions</a>, as some implementations might forget to invoke these steps in some cases. Instead, we settled on the approach of explicitly annotating all relevant IDL constructs, as a way of ensuring interoperable behavior and helping implementations easily pinpoint all cases where these steps are necessary.</p>
+   </div>
+
+   <p>Any nonstandard APIs introduced by the user agent that could modify the DOM in such a way as to cause <a href="#enqueue-a-custom-element-callback-reaction">enqueuing a custom element callback reaction</a> or <a href="#enqueue-a-custom-element-upgrade-reaction">enqueuing a custom element upgrade reaction</a>, for example by modifying any attributes or child elements, must also be decorated with the <code><a href="#cereactions">[CEReactions]</a></code> attribute.</p>
+
+   <div class="note">
+     <p>As of the time of this writing, the following nonstandard or not-yet-standardized APIs are known to fall into this category:</p>
+
+     <ul>
+       <li>
+         <p><code><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code>'s <code>outerText</code> IDL attribute</p>
+       </li>
+
+       <li>
+         <p><code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlinputelement">HTMLInputElement</a></code>'s <code>webkitdirectory</code> and <code>incremental</code> IDL attributes</p>
+       </li>
+
+       <li>
+         <p><code><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a></code>'s <code>disabled</code> and <code>scope</code> IDL attributes</p>
+       </li>
+
+       <li>
+         <p><code><a href="https://dom.spec.whatwg.org/#interface-shadowroot">ShadowRoot</a></code>'s <code>innerHTML</code> IDL attribute</p>
+       </li>
+     </ul>
+   </div>
+ </section>
+</section>
+
+<section>
+ <h4 id="html-element-constructors">HTML: HTML element constructors</h4>
+
+ <p>To support the <a href="#custom-elements">custom elements</a> feature, all HTML elements have special constructor behavior. This is indicated via the <dfn id="htmlconstructor"><code>[HTMLConstructor]</code></dfn> IDL <a href="https://heycam.github.io/webidl/#dfn-extended-attribute">extended attribute</a>. It indicates that the interface object for the given interface will have a specific behavior when called, as defined in detail below.</p>
+
+ <p>The <code><a href="#htmlconstructor">[HTMLConstructor]</a></code> extended attribute must take no arguments, and must not appear on anything other than an interface. It must appear only once on an interface, and the interface must not be annotated with the <code>[Constructor]</code> or <code>[NoInterfaceObject]</code> extended attributes. (However, the interface may be annotated with <code>[NamedConstructor]</code>; there is no conflict there.) It must not be used on a callback interface.</p>
+
+ <p><a href="https://heycam.github.io/webidl/#dfn-interface-object">Interface objects</a> for interfaces annotated with the <code><a href="#htmlconstructor">[HTMLConstructor]</a></code> extended attribute must run the following steps as the function body behavior for both [[\Call]] and [[\Construct]] invocations of the corresponding JavaScript function object. When invoked with [[\Call]], the NewTarget value is undefined, and so the algorithm below will immediately throw. When invoked with [[\Construct]], the [[\Construct]] <var>newTarget</var> parameter provides the NewTarget value.</p>
+
+ <ol>
+   <li>
+     <p>Let <var>registry</var> be the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <code><a href="#customelementregistry">CustomElementRegistry</a></code> object.</p>
+   </li>
+
+   <li>
+     <p>If NewTarget is equal to the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+
+     <div class="example no-backref">
+       <p>This can occur when a custom element is defined using an <a href="https://dom.spec.whatwg.org/#concept-element-interface">element interface</a> as its constructor:</p>
+       <pre>
+customElements.define("bad-1", HTMLButtonElement);
+new HTMLButtonElement();          // (1)
+document.createElement("bad-1");  // (2)
+</pre>
+
+       <p>In this case, during the execution of <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code> (either explicitly, as in (1), or implicitly, as in (2)), both the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> and NewTarget are <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code>. If this check was not present, it would be possible to create an instance of <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code> whose local name was <code>bad-1</code>.</p>
+     </div>
+   </li>
+
+   <li>
+     <p>Let <var>definition</var> be the entry in <var>registry</var> with <a href="#concept-custom-element-definition-constructor">constructor</a> equal to NewTarget. If there is no such definition, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+
+     <p class="note">Since there can be no entry in <var>registry</var> with a <a href="#concept-custom-element-definition-constructor">constructor</a> of undefined, this step also prevents HTML element constructors from being called as functions (since in that case NewTarget will be undefined).</p>
+   </li>
+
+   <li>
+     <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a> is equal to <var>definition</var>'s <a href="#concept-custom-element-definition-name">name</a> (i.e., <var>definition</var> is for an <a href="#autonomous-custom-element">autonomous custom element</a>), then:</p>
+
+     <ol>
+       <li>
+         <p>If the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> is not <code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+
+         <div class="example no-backref">
+           <p>This can occur when a custom element is defined to not extend any local names, but inherits from a non-<code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code> class:</p>
+           <pre>
+customElements.define("bad-2", class Bad2 extends HTMLParagraphElement {});
+</pre>
+
+           <p>In this case, during the (implicit) <code>super()</code> call that occurs when constructing an instance of <code>Bad2</code>, the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> is <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlparagraphelement">HTMLParagraphElement</a></code>, not <code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code>.</p>
+         </div>
+       </li>
+     </ol>
+   </li>
+
+   <li>
+     <p>Otherwise (i.e., if <var>definition</var> is for a <a href="#customized-built-in-element">customized built-in element</a>):</p>
+
+     <ol>
+       <li>
+         <p>Let <var>valid local names</var> be the list of local names for elements defined in this specification or in <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#other-applicable-specifications">other applicable specifications</a> that use the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> as their <a href="https://dom.spec.whatwg.org/#concept-element-interface">element interface</a>.</p>
+       </li>
+
+       <li>
+         <p>If <var>valid local names</var> does not contain <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+
+         <div class="example no-backref">
+           <p>This can occur when a custom element is defined to extend a given local name but inherits from the wrong class:</p>
+           <pre>
+customElements.define("bad-3", class Bad3 extends HTMLQuoteElement {}, { extends: "p" });
+</pre>
+
+           <p>In this case, during the (implicit) <code>super()</code> call that occurs when constructing an instance of <code>Bad3</code>, <var>valid local names</var> is the list containing <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-q-element">q</a></code> and <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-blockquote-element">blockquote</a></code>, but <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a> is <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-p-element">p</a></code>, which is not in that list.</p>
+         </div>
+       </li>
+     </ol>
+   </li>
+
+   <li>
+     <p>Let <var>prototype</var> be <var>definition</var>'s <a href="#concept-custom-element-definition-prototype">prototype</a>.</p>
+   </li>
+
+   <li>
+     <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a> is empty, then:</p>
+
+     <ol>
+       <li>
+         <p>Let <var>element</var> be a new element that implements the interface to which the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> corresponds, with no attributes, namespace set to the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-namespace-2">HTML namespace</a>, local name set to <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a>, and <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> set to the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated <code>Document</code></a>.</p>
+       </li>
+
+       <li>
+         <p>Perform <var>element</var>.[[\SetPrototypeOf]](<var>prototype</var>). Rethrow any exceptions.</p>
+       </li>
+
+       <li>
+         <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>custom</code>".</p>
+       </li>
+
+       <li>
+         <p>Set <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a> to <var>definition</var>.</p>
+       </li>
+
+       <li>
+         <p>Return <var>element</var>.</p>
+       </li>
+     </ol>
+
+     <p class="note">This occurs when author script constructs a new custom element directly, e.g. via <code>new MyCustomElement()</code>.</p>
+   </li>
+
+   <li>
+     <p>Let <var>element</var> be the last entry in <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+   </li>
+
+   <li>
+     <p>If <var>element</var> is an <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a>, then throw an <a href="https://heycam.github.io/webidl/#invalidstateerror">"<code>InvalidStateError</code>"</a> <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
+
+     <div class="example">
+       This can occur when the author code inside the
+       <a href="#custom-element-constructor">custom element constructor</a>
+       <a href="#custom-element-conformance">non-conformantly</a> creates another instance of the class being constructed, before calling <code>super()</code>:</p>
+       <pre>
+let doSillyThing = false;
+
+class DontDoThis extends HTMLElement {
+constructor() {
+ if (doSillyThing) {
+   doSillyThing = false;
+   new DontDoThis();
+   // Now the construction stack will contain an <i>already constructed</i> marker.
+ }
+
+ // This will then fail with an "InvalidStateError" DOMException:
+ super();
+}
+}
+</pre>
+     </div>
+
+     <div class="example">
+       This can also occur when author code inside the
+       <a href="#custom-element-constructor">custom element constructor</a>
+       <a href="#custom-element-conformance">non-conformantly</a> calls <code>super()</code> twice,
+       since per the JavaScript specification, this actually executes the superclass constructor
+       (i.e. this algorithm) twice, before throwing an error:</p>
+       <xmp class="bad">
+class DontDoThisEither extends HTMLElement {
+constructor() {
+ super();
+
+ // This will throw, but not until it has already called into the HTMLElement constructor
+ super();
+}
+}
+</pre>
+     </div>
+   </li>
+
+   <li>
+     <p>Perform <var>element</var>.[[\SetPrototypeOf]](<var>prototype</var>). Rethrow any exceptions.</p>
+   </li>
+
+   <li>
+     <p>Replace the last entry in <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a> with an <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a>.</p>
+   </li>
+
+   <li>
+     <p>Return <var>element</var>.</p>
+
+     <p class="note">This step is normally reached when <a href="#upgrades">upgrading</a> a custom element; the existing element is returned, so that the <code>super()</code> call inside the <a href="#custom-element-constructor">custom element constructor</a> assigns that existing element to <b>this</b>.</p>
+   </li>
+ </ol>
+ <hr>
+
+  In addition to the constructor behavior implied by <code><a href="#htmlconstructor">[HTMLConstructor]</a></code>,
+  some elements also have <a href="https://heycam.github.io/webidl/#dfn-named-constructor">named constructors</a>
+   (which are really factory functions with a modified <code>prototype</code> property).</p>
+
+ <div class="example">
+   <p>Named constructors for HTML elements can also be used in an <code>extends</code> clause when defining a <a>custom element constructor</a>:</p>
+   <xmp>
+class AutoEmbiggenedImage extends Image {
+constructor(width, height) {
+ super(width * 10, height * 10);
+}
+}
+
+customElements.define("auto-embiggened", AutoEmbiggenedImage, { extends: "img" });
+
+const image = new AutoEmbiggenedImage(15, 20);
+console.assert(image.width === 150);
+console.assert(image.height === 200);
+</pre>
+ </xmp>
+ <!-- end CEinsert @@ -->
 
 <h4 id="element-definitions">Element definitions</h4>
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1447,48 +1447,57 @@ constructor() {
   extended attributes. (However, the interface may be annotated with {{[NamedConstructor]}};
   there is no conflict there.) It must not be used on a callback interface.</p>
 
- <p><a href="https://heycam.github.io/webidl/#dfn-interface-object">Interface objects</a> for interfaces annotated with the <code><a href="#htmlconstructor">[HTMLConstructor]</a></code> extended attribute must run the following steps as the function body behavior for both [[\Call]] and [[\Construct]] invocations of the corresponding JavaScript function object. When invoked with [[\Call]], the NewTarget value is undefined, and so the algorithm below will immediately throw. When invoked with [[\Construct]], the [[\Construct]] <var>newTarget</var> parameter provides the NewTarget value.</p>
+  <a>Interface objects</a> for interfaces annotated with the {{[HTMLConstructor]}} extended attribute must run the following steps as the function body behavior for both [[\Call]] and [[\Construct]] invocations of the corresponding JavaScript function object. When invoked with [[\Call]], the NewTarget value is undefined, and so the algorithm below will immediately throw. When invoked with [[\Construct]], the [[\Construct]] <var>newTarget</var> parameter provides the NewTarget value.</p>
 
  <ol>
    <li>
-     <p>Let <var>registry</var> be the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <code><a href="#customelementregistry">CustomElementRegistry</a></code> object.</p>
+     <p>Let <var>registry</var> be the <a>current global object</a>'s {{CustomElementRegistry}} object.</p>
    </li>
 
    <li>
      <p>If NewTarget is equal to the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
 
      <div class="example no-backref">
-       <p>This can occur when a custom element is defined using an <a href="https://dom.spec.whatwg.org/#concept-element-interface">element interface</a> as its constructor:</p>
+       <p>This can occur when a custom element is defined using an <a>element interface</a> as its constructor:</p>
        <pre>
 customElements.define("bad-1", HTMLButtonElement);
 new HTMLButtonElement();          // (1)
 document.createElement("bad-1");  // (2)
 </pre>
 
-       <p>In this case, during the execution of <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code> (either explicitly, as in (1), or implicitly, as in (2)), both the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> and NewTarget are <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code>. If this check was not present, it would be possible to create an instance of <code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlbuttonelement">HTMLButtonElement</a></code> whose local name was <code>bad-1</code>.</p>
+      In this case, during the execution of {{HTMLButtonElement}} (either explicitly, as in (1),
+      or implicitly, as in (2)), both the <a>active function object</a> and NewTarget are {{HTMLButtonElement}}.
+      If this check was not present, it would be possible to create an instance of {{HTMLButtonElement}}
+      whose local name was <code>bad-1</code>.</p>
      </div>
    </li>
 
    <li>
-     <p>Let <var>definition</var> be the entry in <var>registry</var> with <a href="#concept-custom-element-definition-constructor">constructor</a> equal to NewTarget. If there is no such definition, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+     <p>Let <var>definition</var> be the entry in <var>registry</var> with <a>constructor</a> equal to NewTarget.
+      If there is no such definition, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
 
-     <p class="note">Since there can be no entry in <var>registry</var> with a <a href="#concept-custom-element-definition-constructor">constructor</a> of undefined, this step also prevents HTML element constructors from being called as functions (since in that case NewTarget will be undefined).</p>
+     <p class="note">Since there can be no entry in <var>registry</var> with a <a>constructor</a>
+     of undefined, this step also prevents HTML element constructors from being called as functions
+     (since in that case NewTarget will be undefined).</p>
    </li>
 
    <li>
-     <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a> is equal to <var>definition</var>'s <a href="#concept-custom-element-definition-name">name</a> (i.e., <var>definition</var> is for an <a href="#autonomous-custom-element">autonomous custom element</a>), then:</p>
+     <p>If <var>definition</var>'s <a>local name</a> is equal to <var>definition</var>'s <a for="customElements">name</a>
+     (i.e., <var>definition</var> is for an <a >autonomous custom element</a>), then:</p>
 
      <ol>
        <li>
-         <p>If the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> is not <code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+         <p>If the <a>active function object</a> is not {{HTMLElement}}, then throw a {{TypeError}} and abort these steps.</p>
 
          <div class="example no-backref">
-           <p>This can occur when a custom element is defined to not extend any local names, but inherits from a non-<code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code> class:</p>
+           <p>This can occur when a custom element is defined to not extend any local names, but inherits from a non-{{HTMLElement}} class:</p>
            <pre>
 customElements.define("bad-2", class Bad2 extends HTMLParagraphElement {});
 </pre>
 
-           <p>In this case, during the (implicit) <code>super()</code> call that occurs when constructing an instance of <code>Bad2</code>, the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> is <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlparagraphelement">HTMLParagraphElement</a></code>, not <code><a href="https://html.spec.whatwg.org/multipage/#htmlelement">HTMLElement</a></code>.</p>
+          In this case, during the (implicit) <code>super()</code> call that occurs
+          when constructing an instance of <code>Bad2</code>, the <a>active function object</a> is
+          {{HTMLParagraphElement}}, not {{HTMLElement}}.</p>
          </div>
        </li>
      </ol>
@@ -1499,11 +1508,14 @@ customElements.define("bad-2", class Bad2 extends HTMLParagraphElement {});
 
      <ol>
        <li>
-         <p>Let <var>valid local names</var> be the list of local names for elements defined in this specification or in <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#other-applicable-specifications">other applicable specifications</a> that use the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> as their <a href="https://dom.spec.whatwg.org/#concept-element-interface">element interface</a>.</p>
+         <p>Let <var>valid local names</var> be the list of local names for elements defined in this specification
+         or in <a>other applicable specifications</a> that use the <a>active function object</a>
+         as their <a>element interface</a>.</p>
        </li>
 
        <li>
-         <p>If <var>valid local names</var> does not contain <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+         <p>If <var>valid local names</var> does not contain <var>definition</var>'s <a>local name</a>,
+         then throw a {{TypeError}} and abort these steps.</p>
 
          <div class="example no-backref">
            <p>This can occur when a custom element is defined to extend a given local name but inherits from the wrong class:</p>
@@ -1511,22 +1523,28 @@ customElements.define("bad-2", class Bad2 extends HTMLParagraphElement {});
 customElements.define("bad-3", class Bad3 extends HTMLQuoteElement {}, { extends: "p" });
 </pre>
 
-           <p>In this case, during the (implicit) <code>super()</code> call that occurs when constructing an instance of <code>Bad3</code>, <var>valid local names</var> is the list containing <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-q-element">q</a></code> and <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-blockquote-element">blockquote</a></code>, but <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a> is <code><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-p-element">p</a></code>, which is not in that list.</p>
+           <p>In this case, during the (implicit) <code>super()</code>
+           call that occurs when constructing an instance of <code>Bad3</code>, <var>valid local names</var>
+           is the list containing <{q}> and <{blockquote}>, but <var>definition</var>'s <a>local name</a>
+           is <{p}>, which is not in that list.</p>
          </div>
        </li>
      </ol>
    </li>
 
    <li>
-     <p>Let <var>prototype</var> be <var>definition</var>'s <a href="#concept-custom-element-definition-prototype">prototype</a>.</p>
+     <p>Let <var>prototype</var> be <var>definition</var>'s <a>prototype</a>.</p>
    </li>
 
    <li>
-     <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a> is empty, then:</p>
+     <p>If <var>definition</var>'s <a>construction stack</a> is empty, then:</p>
 
      <ol>
        <li>
-         <p>Let <var>element</var> be a new element that implements the interface to which the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a> corresponds, with no attributes, namespace set to the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-namespace-2">HTML namespace</a>, local name set to <var>definition</var>'s <a href="#concept-custom-element-definition-local-name">local name</a>, and <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> set to the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated <code>Document</code></a>.</p>
+         <p>Let <var>element</var> be a new element that implements the interface to which the
+          <a>active function object</a> corresponds, with no attributes, namespace set to the
+          <a>HTML namespace</a>, local name set to <var>definition</var>'s <a>local name</a>, and
+          <a>node document</a> set to the <a>current global object</a>'s <a>associated <code>Document</code></a>.</p>
        </li>
 
        <li>
@@ -1534,11 +1552,11 @@ customElements.define("bad-3", class Bad3 extends HTMLQuoteElement {}, { extends
        </li>
 
        <li>
-         <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>custom</code>".</p>
+         <p>Set <var>element</var>'s <a>custom element state</a> to "<code>custom</code>".</p>
        </li>
 
        <li>
-         <p>Set <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a> to <var>definition</var>.</p>
+         <p>Set <var>element</var>'s <a>custom element definition</a> to <var>definition</var>.</p>
        </li>
 
        <li>
@@ -1550,16 +1568,17 @@ customElements.define("bad-3", class Bad3 extends HTMLQuoteElement {}, { extends
    </li>
 
    <li>
-     <p>Let <var>element</var> be the last entry in <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+     <p>Let <var>element</var> be the last entry in <var>definition</var>'s <a>construction stack</a>.</p>
    </li>
 
    <li>
-     <p>If <var>element</var> is an <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a>, then throw an <a href="https://heycam.github.io/webidl/#invalidstateerror">"<code>InvalidStateError</code>"</a> <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and abort these steps.</p>
+     <p>If <var>element</var> is an <a>already constructed marker</a>, then throw an
+      "{{InvalidStateError}}" {{DOMException}} and abort these steps.</p>
 
      <div class="example">
-       This can occur when the author code inside the
-       <a href="#custom-element-constructor">custom element constructor</a>
-       <a href="#custom-element-conformance">non-conformantly</a> creates another instance of the class being constructed, before calling <code>super()</code>:</p>
+       This can occur when the author code inside the <a>custom element constructor</a>
+       <a>non-conformantly</a> creates another instance of the class being constructed,
+       before calling <code>super()</code>:</p>
        <pre>
 let doSillyThing = false;
 
@@ -1579,11 +1598,10 @@ constructor() {
      </div>
 
      <div class="example">
-       This can also occur when author code inside the
-       <a href="#custom-element-constructor">custom element constructor</a>
-       <a href="#custom-element-conformance">non-conformantly</a> calls <code>super()</code> twice,
-       since per the JavaScript specification, this actually executes the superclass constructor
-       (i.e. this algorithm) twice, before throwing an error:</p>
+       This can also occur when author code inside the <a>custom element constructor</a>
+       <a>non-conformantly</a> calls <code>super()</code> twice, since per the JavaScript specification,
+       this actually executes the superclass constructor (i.e. this algorithm) twice,
+       before throwing an error:</p>
        <xmp class="bad">
 class DontDoThisEither extends HTMLElement {
 constructor() {
@@ -1602,23 +1620,27 @@ constructor() {
    </li>
 
    <li>
-     <p>Replace the last entry in <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a> with an <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a>.</p>
+     <p>Replace the last entry in <var>definition</var>'s <a>construction stack</a> with an
+     <a>already constructed marker</a>.</p>
    </li>
 
    <li>
      <p>Return <var>element</var>.</p>
 
-     <p class="note">This step is normally reached when <a href="#upgrades">upgrading</a> a custom element; the existing element is returned, so that the <code>super()</code> call inside the <a href="#custom-element-constructor">custom element constructor</a> assigns that existing element to <b>this</b>.</p>
+     <p class="note">This step is normally reached when <a>upgrading</a> a custom element;
+      the existing element is returned, so that the <code>super()</code> call inside the
+      <a>custom element constructor</a> assigns that existing element to <b>this</b>.</p>
    </li>
  </ol>
  <hr>
 
-  In addition to the constructor behavior implied by <code><a href="#htmlconstructor">[HTMLConstructor]</a></code>,
-  some elements also have <a href="https://heycam.github.io/webidl/#dfn-named-constructor">named constructors</a>
+  In addition to the constructor behavior implied by {{[HTMLConstructor]}},
+  some elements also have <a>named constructors</a>
    (which are really factory functions with a modified <code>prototype</code> property).</p>
 
  <div class="example">
-   <p>Named constructors for HTML elements can also be used in an <code>extends</code> clause when defining a <a>custom element constructor</a>:</p>
+   <p>Named constructors for HTML elements can also be used in an <code>extends</code>
+    clause when defining a <a>custom element constructor</a>:</p>
    <xmp>
 class AutoEmbiggenedImage extends Image {
 constructor(width, height) {

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -1008,11 +1008,12 @@ fetch(articleURL)
  <section>
    <h4 id="upgrades">Upgrades</h4>
 
-   <p>To <dfn id="concept-upgrade-an-element">upgrade an element</dfn>, given as input a <a href="#custom-element-definition">custom element definition</a> <var>definition</var> and an element <var>element</var>, run the following steps:</p>
+   <p>To <dfn>upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
+    and an element <var>element</var>, run the following steps:</p>
 
    <ol>
      <li>
-       <p>If <var>element</var> is <a href="#concept-element-custom">custom</a>, abort these steps.</p>
+       <p>If <var>element</var> is <a>custom</a>, abort these steps.</p>
 
        <div class="example">
          <p>This can occur due to reentrant invocation of this algorithm, as in the following example:</p>
@@ -1040,43 +1041,56 @@ constructor() {
 &lt;/script&gt;
 </pre>
 
-         <p>This step will thus bail out the algorithm early when <a href="#concept-upgrade-an-element">upgrade an element</a> is invoked with "<code>b</code>" a second time.</p>
+         <p>This step will thus bail out the algorithm early when <a>upgrade an element</a> is invoked with "<code>b</code>" a second time.</p>
        </div>
      </li>
 
      <li>
-       <p>If <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> is "<code>failed</code>", then abort these steps.</p>
+       <p>If <var>element</var>'s <a>custom element state</a> is "<code>failed</code>", then abort these steps.</p>
      </li>
 
      <li>
-       <p>For each <var>attribute</var> in <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-element-attribute">attribute list</a>, in order, <a href="#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>element</var>, callback name "<code>attributeChangedCallback</code>", and an argument list containing <var>attribute</var>'s local name, null, <var>attribute</var>'s value, and <var>attribute</var>'s namespace.</p>
+       <p>For each <var>attribute</var> in <var>element</var>'s <a>attribute list</a>, in order,
+        <a>enqueue a custom element callback reaction</a> with <var>element</var>,
+        callback name "<code>attributeChangedCallback</code>", and an argument list containing
+        <var>attribute</var>'s local name, null, <var>attribute</var>'s value, and <var>attribute</var>'s namespace.</p>
      </li>
 
      <li>
-       <p>If <var>element</var> is <a href="https://dom.spec.whatwg.org/#connected">connected</a>, then <a href="#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>element</var>, callback name "<code>connectedCallback</code>", and an empty argument list.</p>
+       <p>If <var>element</var> is <a>connected</a>, then <a>enqueue a custom element callback reaction</a>
+        with <var>element</var>, callback name "<code>connectedCallback</code>", and an empty argument list.</p>
      </li>
 
      <li>
-       <p>Add <var>element</var> to the end of <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+       <p>Add <var>element</var> to the end of <var>definition</var>'s <a>construction stack</a>.</p>
      </li>
 
      <li>
-       <p>Let <var>C</var> be <var>definition</var>'s <a href="#concept-custom-element-definition-constructor">constructor</a>.</p>
+       <p>Let <var>C</var> be <var>definition</var>'s <a>constructor</a>.</p>
      </li>
 
      <li>
        <p>Let <var>constructResult</var> be <a href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>C</var>).</p>
 
-       <p class="note">If <var>C</var> <a href="#custom-element-conformance">non-conformantly</a> uses an API decorated with the <code><a href="#cereactions">[CEReactions]</a></code> extended attribute, then the reactions enqueued at the beginning of this algorithm will execute during this step, before <var>C</var> finishes and control returns to this algorithm. Otherwise, they will execute after <var>C</var> and the rest of the upgrade process finishes.</p>
+       <p class="note">If <var>C</var> <a href="#custom-element-conformance">non-conformantly</a>
+        uses an API decorated with the {{[CEReactions]}} extended attribute,
+       then the reactions enqueued at the beginning of this algorithm will execute during this step,
+       before <var>C</var> finishes and control returns to this algorithm.
+        Otherwise, they will execute after <var>C</var> and the rest of the upgrade process finishes.</p>
      </li>
 
      <li>
-       <p>Remove the last entry from the end of <var>definition</var>'s <a href="#concept-custom-element-definition-construction-stack">construction stack</a>.</p>
+       <p>Remove the last entry from the end of <var>definition</var>'s <a>construction stack</a>.</p>
 
        <div class="note">
-         <p>Assuming <var>C</var> calls <code>super()</code> (as it will if it is <a href="#custom-element-conformance">conformant</a>), and that the call succeeds, this will be the <a href="#concept-already-constructed-marker"><i>already constructed</i> marker</a> that replaced the <var>element</var> we pushed at the beginning of this algorithm. (The <a href="#html-element-constructors">HTML element constructor</a> carries out this replacement.)</p>
+         <p>Assuming <var>C</var> calls <code>super()</code> (as it will if it is
+          <a for="customElements">conformant</a>),
+          and that the call succeeds, this will be the <a>already constructed marker</a>
+          that replaced the <var>element</var> pushed at the beginning of this algorithm.
+          (The <a>HTML element constructor</a> carries out this replacement.)</p>
 
-         <p>If <var>C</var> does not call <code>super()</code> (i.e. it is not <a href="#custom-element-conformance">conformant</a>), or if any step in the <a href="#html-element-constructors">HTML element constructor</a> throws, then this entry will still be <var>element</var>.</p>
+         <p>If <var>C</var> does not call <code>super()</code> (i.e. it is not <a>conformant</a>),
+          or if any step in the <a>HTML element constructor</a> throws, then this entry will still be <var>element</var>.</p>
        </div>
      </li>
 
@@ -1085,7 +1099,7 @@ constructor() {
 
        <ol>
          <li>
-           <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>failed</code>".</p>
+           <p>Set <var>element</var>'s <a>custom element state</a> to "<code>failed</code>".</p>
          </li>
 
          <li>
@@ -1095,17 +1109,18 @@ constructor() {
      </li>
 
      <li>
-       <p>If <a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a>(<var>constructResult</var>.[[\value]], <var>element</var>) is false, then throw an <a href="https://heycam.github.io/webidl/#invalidstateerror">"<code>InvalidStateError</code>"</a> <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and terminate these steps.</p>
+       <p>If <a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a>(<var>constructResult</var>.[[\value]], <var>element</var>)
+        is false, then throw an "{{InvalidStateError}}" {{DOMException}} and terminate these steps.</p>
 
        <p class="note">This can occur if <var>C</var> constructs another instance of the same custom element before calling <code>super()</code>, or if <var>C</var> uses JavaScript's <code>return</code>-override feature to return an arbitrary object from the constructor.</p>
      </li>
 
      <li>
-       <p>Set <var>element</var>'s <a href="#concept-element-custom-element-state">custom element state</a> to "<code>custom</code>".</p>
+       <p>Set <var>element</var>'s <a>custom element state</a> to "<code>custom</code>".</p>
      </li>
 
      <li>
-       <p>Set <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a> to <var>definition</var>.</p>
+       <p>Set <var>element</var>'s <a>custom element definition</a> to <var>definition</var>.</p>
      </li>
    </ol>
 
@@ -1113,11 +1128,14 @@ constructor() {
 
    <ol>
      <li>
-       <p>Let <var>definition</var> be the result of <a href="#look-up-a-custom-element-definition">looking up a custom element definition</a> given <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>, <var>element</var>'s namespace, <var>element</var>'s local name, and <var>element</var>'s <a href="#concept-element-is-value"><code>is</code> value</a>.</p>
+       <p>Let <var>definition</var> be the result of <a>looking up a custom element definition</a>
+        given <var>element</var>'s <a>node document</a>, <var>element</var>'s namespace,
+         <var>element</var>'s local name, and <var>element</var>'s <{is}> value</a>.</p>
      </li>
 
      <li>
-       <p>If <var>definition</var> is not null, then <a href="#enqueue-a-custom-element-upgrade-reaction">enqueue a custom element upgrade reaction</a> given <var>element</var> and <var>definition</var>.</p>
+       <p>If <var>definition</var> is not null, then <a>enqueue a custom element upgrade reaction</a>
+        given <var>element</var> and <var>definition</var>.</p>
      </li>
    </ol>
  </section>
@@ -1125,86 +1143,116 @@ constructor() {
  <section>
    <h4 id="custom-element-reactions">Custom element reactions</h4>
 
-   <p>A <a href="#custom-element">custom element</a> possesses the ability to respond to certain occurrences by running author code:</p>
+   A <a>custom element</a> can react to certain occurrences by running author code.
+   These reactions are called <dfn id="concept-custom-element-reaction">custom element reactions</dfn>.
 
    <ul>
      <li>
-       <p>When <a href="#upgrades">upgraded</a>, its <a href="#custom-element-constructor">constructor</a> is run.</p>
+       <p>When <a>upgraded</a>, its <a>constructor</a> is run.</p>
      </li>
 
      <li>
-       <p>When it <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-connected">becomes connected</a>, its <code>connectedCallback</code> is run.</p>
+       <p>When it <a>becomes connected</a>, its <code>connectedCallback</code> is run.</p>
      </li>
 
      <li>
-       <p>When it <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-disconnected">becomes disconnected</a>, its <code>disconnectedCallback</code> is run.</p>
+       <p>When it <a>becomes disconnected</a>, its <code>disconnectedCallback</code> is run.</p>
      </li>
 
      <li>
-       <p>When it is <a href="https://dom.spec.whatwg.org/#concept-node-adopt">adopted</a> into a new document, its <code>adoptedCallback</code> is run.</p>
+       <p>When it is <a>adopted</a> into a new document, its <code>adoptedCallback</code> is run.</p>
      </li>
 
      <li>
-       <p>When any of its attributes are <a href="#concept-element-attributes-change">changed</a>, <a href="#concept-element-attributes-append">appended</a>, <a href="#concept-element-attributes-remove">removed</a>, or <a href="#concept-element-attributes-replace">replaced</a>, its <code>attributeChangedCallback</code> is run.</p>
+       <p>When any of its attributes are <a>changed</a>, <a>appended</a>, <a>removed</a>, or <a>replaced</a>,
+        its <code>attributeChangedCallback</code> is run.</p>
      </li>
    </ul>
 
-   <p>We call these reactions collectively <dfn id="concept-custom-element-reaction">custom element reactions</dfn>.</p>
 
-   <p>The way in which <a href="#concept-custom-element-reaction">custom element reactions</a> are invoked is done with special care, to avoid running author code during the middle of delicate operations. Effectively, they are delayed until "just before returning to user script". This means that for most purposes they appear to execute synchronously, but in the case of complicated composite operations (like <a href="#concept-node-clone">cloning</a>, or <a href="https://dom.spec.whatwg.org/#concept-range">range</a> manipulation), they will instead be delayed until after all the relevant user agent processing steps have completed, and then run together as a batch.</p>
+   The way in which <a>custom element reactions</a> are invoked is done with special care,
+    to avoid running author code during the middle of delicate operations.
+     Effectively, they are delayed until "just before returning to user script".
+     This means that for most purposes they appear to execute synchronously,
+     but in the case of complicated composite operations (like <a>cloning</a>, or <>range</a> manipulation),
+      they will instead be delayed until after all the relevant user agent processing steps have completed,
+       and then run together as a batch.
 
-   <p>Additionally, the precise ordering of these reactions is managed via a somewhat-complicated stack-of-queues system, described below. The intention behind this system is to guarantee that <a href="#concept-custom-element-reaction">custom element reactions</a> always are invoked in the same order as their triggering actions, at least within the local context of a single <a href="#custom-element">custom element</a>. (Because <a href="#concept-custom-element-reaction">custom element reaction</a> code can perform its own mutations, it is not possible to give a global ordering guarantee across multiple elements.)</p>
+   Additionally, the precise ordering of these reactions is managed by a stack-of-queues system, described below.
+    The intention behind this system is to guarantee that <a>custom element reactions</a>
+     are always invoked in the same order as their triggering actions,
+     at least within the local context of a single <a>custom element</a>.
+     (Because <a>custom element reaction</a> code can perform its own mutations,
+      it is not possible to give a global ordering guarantee across multiple elements.)</p>
    <hr>
 
-   <p>Each <a href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">unit of related similar-origin browsing contexts</a> has a <dfn id="custom-element-reactions-stack">custom element reactions stack</dfn>, which is initially empty. The <dfn id="current-element-queue">current element queue</dfn> is the <a href="#element-queue">element queue</a> at the top of the <a href="#custom-element-reactions-stack">custom element reactions stack</a>. Each item in the stack is an <dfn id="element-queue">element queue</dfn>, which is initially empty as well. Each item in an <a href="#element-queue">element queue</a> is an element. (The elements are not necessarily <a href="#concept-element-custom">custom</a> yet, since this queue is used for <a href="#upgrades">upgrades</a> as well.)</p>
+   Each <a>unit of related similar-origin browsing contexts</a> has a
+   <dfn>custom element reactions stack</dfn>, which is initially empty.
+   The <dfn>current element queue</dfn> is the <a>element queue</a>
+    at the top of the <a>custom element reactions stack</a>. Each item in the stack is an
+    <dfn>element queue</dfn>, which is initially empty as well.
+    Each item in an <a>element queue</a> is an element.
+    (The elements are not necessarily <a>custom</a> yet, since this queue is used for <a>upgrades</a> as well.)
 
-   <p>Each <a href="#custom-element-reactions-stack">custom element reactions stack</a> has an associated <dfn id="backup-element-queue">backup element queue</dfn>, which an initially-empty <a href="#element-queue">element queue</a>. Elements are pushed onto the <a href="#backup-element-queue">backup element queue</a> during operations that affect the DOM without going through an API decorated with <code><a href="#cereactions">[CEReactions]</a></code>, or through the parser's <a href="#create-an-element-for-the-token">create an element for the token</a> algorithm. An example of this is a user-initiated editing operation which modifies the descendants or attributes of an <a href="https://w3c.github.io/editing/execCommand.html#editable">editable</a> element. To prevent reentrancy when processing the <a href="#backup-element-queue">backup element queue</a>, each <a href="#custom-element-reactions-stack">custom element reactions stack</a> also has a <dfn id="processing-the-backup-element-queue">processing the backup element queue</dfn> flag, initially unset.</p>
+   Each <a>custom element reactions stack</a> has an associated
+   <dfn>backup element queue</dfn>, which is an initially empty
+    <a>element queue</a>. Elements are pushed onto the <a>backup element queue</a>
+     during operations that affect the DOM without going through an API decorated with
+     {{[CEReactions]}}, or through the parser's <a>create an element for the token</a> algorithm.
+     An example of this is a user-initiated editing operation which modifies the descendants or attributes of an
+      <a>editable</a> element. To prevent reentrancy when processing the <a>backup element queue</a>,
+      each <a>custom element reactions stack</a> also has a
+      <dfn>processing the backup element queue</dfn> flag, initially unset.</p>
 
-   <p>All elements have an associated <dfn id="custom-element-reaction-queue">custom element reaction queue</dfn>, initially empty. Each item in the <a href="#custom-element-reaction-queue">custom element reaction queue</a> is of one of two types:</p>
+   <p>All elements have an associated <dfn>custom element reaction queue</dfn>, initially empty.
+    Each item in the <a>custom element reaction queue</a> is of one of two types:</p>
 
    <ul>
      <li>
-       <p>An <dfn id="upgrade-reaction">upgrade reaction</dfn>, which will <a href="#upgrades">upgrade</a> the custom element and contains a <a href="#custom-element-definition">custom element definition</a>; or</p>
+       <p>An <dfn>upgrade reaction</dfn>, which <a>upgrades</a> the custom element and contains a
+        <a>custom element definition</a>; or</p>
      </li>
 
      <li>
-       <p>A <dfn id="callback-reaction">callback reaction</dfn>, which will call a lifecycle callback, and contains a callback function as well as a list of arguments.</p>
+       <p>A <dfn>callback reaction</dfn>, which will call a lifecycle callback,
+        and contains a callback function as well as a list of arguments.</p>
      </li>
    </ul>
 
    <p>This is all summarised in the following schematic diagram:</p>
 
-   <p><img src="custom-element-reactions.svg" alt="A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." style="width: 80%; max-width: 580px;"></p>
+   <p><img src="custom-element-reactions.svg" alt="@@A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." style="width: 80%; max-width: 580px;"></p>
 
-   <p>To <dfn id="enqueue-an-element-on-the-appropriate-element-queue">enqueue an element on the appropriate element queue</dfn>, given an element <var>element</var>, run the following steps:</p>
+   <p>To <dfn>enqueue an element on the appropriate element queue</dfn>, given an element <var>element</var>,
+    run the following steps:</p>
 
    <ol>
      <li>
-       <p>If the <a href="#custom-element-reactions-stack">custom element reactions stack</a> is empty, then:</p>
+       <p>If the <a>custom element reactions stack</a> is empty, then:</p>
 
        <ol>
          <li>
-           <p>Add <var>element</var> to the <a href="#backup-element-queue">backup element queue</a>.</p>
+           <p>Add <var>element</var> to the <a>backup element queue</a>.</p>
          </li>
 
          <li>
-           <p>If the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag is set, abort this algorithm.</p>
+           <p>If the <a>processing the backup element queue</a> flag is set, abort this algorithm.</p>
          </li>
 
          <li>
-           <p>Set the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag.</p>
+           <p>Set the <a>processing the backup element queue</a> flag.</p>
          </li>
 
          <li>
-           <p><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to perform the following steps:</p>
+           <p><a>Queue a microtask</a> to perform the following steps:</p>
 
            <ol>
              <li>
-               <p><a href="#invoke-custom-element-reactions">Invoke custom element reactions</a> in the <a href="#backup-element-queue">backup element queue</a>.</p>
+               <p><a>Invoke custom element reactions</a> in the <a>backup element queue</a>.</p>
              </li>
 
              <li>
-               <p>Unset the <a href="#processing-the-backup-element-queue">processing the backup element queue</a> flag.</p>
+               <p>Unset the <a>processing the backup element queue</a> flag.</p>
              </li>
            </ol>
          </li>
@@ -1212,19 +1260,21 @@ constructor() {
      </li>
 
      <li>
-       <p>Otherwise, add <var>element</var> to the <a href="#current-element-queue">current element queue</a>.</p>
+       <p>Otherwise, add <var>element</var> to the <a>current element queue</a>.</p>
      </li>
    </ol>
 
-   <p>To <dfn id="enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</dfn>, given a <a href="#custom-element">custom element</a> <var>element</var>, a callback name <var>callbackName</var>, and a list of arguments <var>args</var>, run the following steps:</p>
+   <p>To <dfn>enqueue a custom element callback reaction</dfn>, given a <a>custom element</a> <var>element</var>,
+    a callback name <var>callbackName</var>, and a list of arguments <var>args</var>, run the following steps:</p>
 
    <ol>
      <li>
-       <p>Let <var>definition</var> be <var>element</var>'s <a href="#concept-element-custom-element-definition">custom element definition</a>.</p>
+       <p>Let <var>definition</var> be <var>element</var>'s <a>custom element definition</a>.</p>
      </li>
 
      <li>
-       <p>Let <var>callback</var> be the value of the entry in <var>definition</var>'s <a href="#concept-custom-element-definition-lifecycle-callbacks">lifecycle callbacks</a> with key <var>callbackName</var>.</p>
+       <p>Let <var>callback</var> be the value of the entry in <var>definition</var>'s
+       <a>lifecycle callbacks</a> with key <var>callbackName</var>.</p>
      </li>
 
      <li>
@@ -1240,41 +1290,45 @@ constructor() {
          </li>
 
          <li>
-           <p>If <var>definition</var>'s <a href="#concept-custom-element-definition-observed-attributes">observed attributes</a> does not contain <var>attributeName</var>, then abort these steps.</p>
+           <p>If <var>definition</var>'s <a>observed attributes</a> does not contain <var>attributeName</var>,
+            then abort these steps.</p>
          </li>
        </ol>
      </li>
 
      <li>
-       <p>Add a new <a href="#callback-reaction">callback reaction</a> to <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>, with callback function <var>callback</var> and arguments <var>args</var>.</p>
+       <p>Add a new <a>callback reaction</a> to <var>element</var>'s <a>custom element reaction queue</a>,
+        with callback function <var>callback</var> and arguments <var>args</var>.</p>
      </li>
 
      <li>
-       <p><a href="#enqueue-an-element-on-the-appropriate-element-queue">Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
-     </li>
-   </ol>
-
-   <p>To <dfn id="enqueue-a-custom-element-upgrade-reaction">enqueue a custom element upgrade reaction</dfn>, given an element <var>element</var> and <a href="#custom-element-definition">custom element definition</a> <var>definition</var>, run the following steps:</p>
-
-   <ol>
-     <li>
-       <p>Add a new <a href="#upgrade-reaction">upgrade reaction</a> to <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>, with <a href="#custom-element-definition">custom element definition</a> <var>definition</var>.</p>
-     </li>
-
-     <li>
-       <p><a href="#enqueue-an-element-on-the-appropriate-element-queue">Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
+       <p><a>Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
      </li>
    </ol>
 
-   <p>To <dfn id="invoke-custom-element-reactions">invoke custom element reactions</dfn> in an <a href="#element-queue">element queue</a> <var>queue</var>, run the following steps:</p>
+   <p>To <dfn>enqueue a custom element upgrade reaction</dfn>, given an element <var>element</var>
+   and <a>custom element definition</a> <var>definition</var>, run the following steps:</p>
 
    <ol>
      <li>
-       <p>For each <a href="#custom-element">custom element</a> <var>element</var> in <var>queue</var>:</p>
+       <p>Add a new <a>upgrade reaction</a> to <var>element</var>'s <a>custom element reaction queue</a>,
+       with <a>custom element definition</a> <var>definition</var>.</p>
+     </li>
+
+     <li>
+       <p><a>Enqueue an element on the appropriate element queue</a> given <var>element</var>.</p>
+     </li>
+   </ol>
+
+   <p>To <dfn>invoke custom element reactions</dfn> in an <a>element queue</a> <var>queue</var>, run the following steps:</p>
+
+   <ol>
+     <li>
+       <p>For each <a>custom element</a> <var>element</var> in <var>queue</var>:</p>
 
        <ol>
          <li>
-           <p>Let <var>reactions</var> be <var>element</var>'s <a href="#custom-element-reaction-queue">custom element reaction queue</a>.</p>
+           <p>Let <var>reactions</var> be <var>element</var>'s <a>custom element reaction queue</a>.</p>
          </li>
 
          <li>
@@ -1282,19 +1336,20 @@ constructor() {
 
            <ol>
              <li>
-               <p>Remove the first element of <var>reactions</var>, and let <var>reaction</var> be that element. Switch on <var>reaction</var>'s type:</p>
+               <p>Remove the first element of <var>reactions</var>, and let <var>reaction</var> be that element.
+                Switch on <var>reaction</var>'s type:</p>
 
                <dl class="switch">
                  <dt>
-                   <a href="#upgrade-reaction">upgrade reaction</a>
+                   <a>upgrade reaction</a>
                  </dt>
 
                  <dd>
-                   <a href="#concept-upgrade-an-element">Upgrade</a> <var>element</var> using <var>reaction</var>'s <a href="#custom-element-definition">custom element definition</a>.
+                   <a>Upgrade</a> <var>element</var> using <var>reaction</var>'s <a>custom element definition</a>.
                  </dd>
 
                  <dt>
-                   <a href="#callback-reaction">callback reaction</a>
+                   <a>callback reaction</a>
                  </dt>
 
                  <dd>
@@ -1302,7 +1357,7 @@ constructor() {
                  </dd>
                </dl>
 
-               <p>If this throws any exception, then <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>.</p>
+               <p>If this throws any exception, then <a>report the exception</a>.</p>
              </li>
            </ol>
          </li>
@@ -1311,52 +1366,68 @@ constructor() {
    </ol>
    <hr>
 
-   <p>To ensure <a href="#concept-custom-element-reaction">custom element reactions</a> are triggered appropriately, we introduce the <dfn id="cereactions"><code>[CEReactions]</code></dfn> IDL <a href="https://heycam.github.io/webidl/#dfn-extended-attribute">extended attribute</a>. It indicates that the relevant algorithm is to be supplemented with additional steps in order to appropriately track and invoke <a href="#concept-custom-element-reaction">custom element reactions</a>.</p>
+   The <dfn attribute>[CEReactions]</dfn> IDL <a>extended attribute</a> is to ensure
+   <a>custom element reactions</a> are triggered appropriately.
+   It indicates that the relevant algorithm is to be supplemented with additional steps
+   to appropriately track and invoke <a>custom element reactions</a>.
 
-   <p>The <code><a href="#cereactions">[CEReactions]</a></code> extended attribute must take no arguments, and must not appear on anything other than an operation, attribute, setter, or deleter. Additionally, it must not appear on readonly attributes, unless the readonly attribute is also annotated with <code>[PutForwards]</code>.</p>
+   The {{[CEReactions]}} extended attribute must take no arguments,
+   and must not appear on anything other than an operation, attribute, setter, or deleter.
+   Additionally, it must not appear on {{readonly}} attributes,
+   unless the readonly attribute is also annotated with [PutForwards].
 
-   <p>Operations, attributes, setters, or deleters annotated with the <code><a href="#cereactions">[CEReactions]</a></code> extended attribute must run the following steps surrounding the main algorithm specified for the operation, setter, deleter, or for the attribute's setter:</p>
+   Operations, attributes, setters, or deleters annotated with the {{[CEReactions]}}
+   extended attribute must run the following steps
+   surrounding the main algorithm specified for the operation, setter, deleter, or for the attribute's setter:
 
    <dl>
      <dt>Before executing the algorithm's steps</dt>
 
      <dd>
-       Push a new <a href="#element-queue">element queue</a> onto the <a href="#custom-element-reactions-stack">custom element reactions stack</a>.
+       Push a new <a>element queue</a> onto the <a>custom element reactions stack</a>.
      </dd>
 
      <dt>After executing the algorithm's steps</dt>
 
      <dd>
-       Pop the <a href="#element-queue">element queue</a> from the <a href="#custom-element-reactions-stack">custom element reactions stack</a>, and <a href="#invoke-custom-element-reactions">invoke custom element reactions</a> in that queue.
+       Pop the <a>element queue</a> from the <a>custom element reactions stack</a>, and
+       <a>invoke custom element reactions</a> in that queue.
      </dd>
    </dl>
 
    <div class="note">
-     <p>The intent behind this extended attribute is somewhat subtle. One way of accomplishing its goals would be to say that every operation, attribute, setter, and deleter on the platform should have these steps inserted, and to allow implementers to optimize away unnecessary cases (where no DOM mutation is possible that could cause <a href="#concept-custom-element-reaction">custom element reactions</a> to occur).</p>
+     The intent behind this extended attribute is somewhat subtle.
+     One way of accomplishing its goals would be to say that every operation, attribute, setter,
+     and deleter on the platform should have these steps inserted,
+     and to allow implementers to optimize away unnecessary cases
+     (where no DOM mutation is possible that could cause <a>custom element reactions</a> to occur).</p>
 
-     <p>However, in practice this imprecision could lead to non-interoperable implementations of <a href="#concept-custom-element-reaction">custom element reactions</a>, as some implementations might forget to invoke these steps in some cases. Instead, we settled on the approach of explicitly annotating all relevant IDL constructs, as a way of ensuring interoperable behavior and helping implementations easily pinpoint all cases where these steps are necessary.</p>
+     However, this could lead to non-interoperable implementations if implementations do not invoke these steps
+     in some cases. Explicitly annotating all relevant IDL constructs helps ensure interoperable behavior, by identifying all cases where these steps are necessary.
    </div>
 
-   <p>Any nonstandard APIs introduced by the user agent that could modify the DOM in such a way as to cause <a href="#enqueue-a-custom-element-callback-reaction">enqueuing a custom element callback reaction</a> or <a href="#enqueue-a-custom-element-upgrade-reaction">enqueuing a custom element upgrade reaction</a>, for example by modifying any attributes or child elements, must also be decorated with the <code><a href="#cereactions">[CEReactions]</a></code> attribute.</p>
+   Any nonstandard APIs introduced by the user agent that could modify the DOM in such a way as to
+   <a>enqueue a custom element callback reaction</a> or <a>enqueue a custom element upgrade reaction</a>,
+    for example by modifying any attributes or child elements, must also be decorated with the {{[CEReactions]}} attribute.</p>
 
    <div class="note">
      <p>As of the time of this writing, the following nonstandard or not-yet-standardized APIs are known to fall into this category:</p>
 
      <ul>
        <li>
-         <p><code><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code>'s <code>outerText</code> IDL attribute</p>
+         <p>{{HTMLElement}}'s <code>outerText</code> IDL attribute</p>
        </li>
 
        <li>
-         <p><code><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlinputelement">HTMLInputElement</a></code>'s <code>webkitdirectory</code> and <code>incremental</code> IDL attributes</p>
+         <p>{{HTMLInputElement}}'s <code>webkitdirectory</code> and <code>incremental</code> IDL attributes</p>
        </li>
 
        <li>
-         <p><code><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a></code>'s <code>disabled</code> and <code>scope</code> IDL attributes</p>
+         <p>{{HTMLLinkElement}}'s <code>disabled</code> and <code>scope</code> IDL attributes</p>
        </li>
 
        <li>
-         <p><code><a href="https://dom.spec.whatwg.org/#interface-shadowroot">ShadowRoot</a></code>'s <code>innerHTML</code> IDL attribute</p>
+         <p>{{ShadowRoot}}'s <code>innerHTML</code> IDL attribute</p>
        </li>
      </ul>
    </div>
@@ -1366,9 +1437,15 @@ constructor() {
 <section>
  <h4 id="html-element-constructors">HTML: HTML element constructors</h4>
 
- <p>To support the <a href="#custom-elements">custom elements</a> feature, all HTML elements have special constructor behavior. This is indicated via the <dfn id="htmlconstructor"><code>[HTMLConstructor]</code></dfn> IDL <a href="https://heycam.github.io/webidl/#dfn-extended-attribute">extended attribute</a>. It indicates that the interface object for the given interface will have a specific behavior when called, as defined in detail below.</p>
+  To support the <a>custom elements</a>, all HTML elements have special constructor behavior.
+  This is indicated via the <dfn attribute><code>[HTMLConstructor]</code></dfn> IDL <a>extended attribute</a>.
+  It indicates that the interface object for the given interface will have a specific behavior when called, as defined in detail below.</p>
 
- <p>The <code><a href="#htmlconstructor">[HTMLConstructor]</a></code> extended attribute must take no arguments, and must not appear on anything other than an interface. It must appear only once on an interface, and the interface must not be annotated with the <code>[Constructor]</code> or <code>[NoInterfaceObject]</code> extended attributes. (However, the interface may be annotated with <code>[NamedConstructor]</code>; there is no conflict there.) It must not be used on a callback interface.</p>
+  The {{[HTMLConstructor]}} extended attribute must take no arguments,
+  and must not appear on anything other than an interface. It must appear only once on an interface,
+  and the interface must not be annotated with the {{[Constructor]}} or {{[NoInterfaceObject]}}
+  extended attributes. (However, the interface may be annotated with {{[NamedConstructor]}};
+  there is no conflict there.) It must not be used on a callback interface.</p>
 
  <p><a href="https://heycam.github.io/webidl/#dfn-interface-object">Interface objects</a> for interfaces annotated with the <code><a href="#htmlconstructor">[HTMLConstructor]</a></code> extended attribute must run the following steps as the function body behavior for both [[\Call]] and [[\Construct]] invocations of the corresponding JavaScript function object. When invoked with [[\Call]], the NewTarget value is undefined, and so the algorithm below will immediately throw. When invoked with [[\Construct]], the [[\Construct]] <var>newTarget</var> parameter provides the NewTarget value.</p>
 

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -679,8 +679,7 @@
   a linear transition of the element's prototype chain, from {{HTMLElement}} to a subclass, instead
   of a lateral one, from {{HTMLUnknownElement}} to an unrelated subclass.</p>
 
-<!-- startCEinsert @@ -->
-<section>
+
    <h4 id="custom-elements-api">The CustomElementRegistry interface</h4>
 
    <p>Each {{Window}} object is associated with a unique instance of a {{CustomElementRegistry}}
@@ -904,15 +903,15 @@ DOMString extends;
      </li>
 
      <li>
-       <p>Let <var>document</var> be this {{CustomElementRegistry}}'s <a>relevant global object</a>'s <a>associated <code>Document</code></a>.</p>
+       <p>Let <var>document</var> be this {{CustomElementRegistry}}'s <a>relevant global object</a>'s <a lt="document associated with a window">associated <code>Document</code></a>.</p>
      </li>
 
      <li>
        <p>Let <var>upgrade candidates</var> be all elements that are <a>shadow-including descendants</a>
         of <var>document</var>, whose namespace is the <a>HTML namespace</a> and whose local name is
          <var>localName</var>, in <a>shadow-including tree order</a>.
-         Additionally, if <var>extends</var> is non-null, only include elements whose <{global/is}>
-         value is equal to <var>name</var>.</p>
+         Additionally, if <var>extends</var> is non-null, only include elements whose <a>is value</a>
+         is equal to <var>name</var>.</p>
      </li>
 
      <li>
@@ -1007,12 +1006,9 @@ fetch(articleURL)
 });
 </xmp>
    </div>
- </section>
-
- <section>
    <h4 id="upgrades">Upgrades</h4>
 
-   <p>To <dfn export lt="upgrade">upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
+   <p>To <dfn export lt="upgrade|upgrade an element">upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
     and an element <var>element</var>, run the following steps:</p>
 
    <ol>
@@ -1142,9 +1138,7 @@ constructor() {
         given <var>element</var> and <var>definition</var>.</p>
      </li>
    </ol>
- </section>
 
- <section>
    <h4 id="sec-custom-element-reactions">Custom element reactions</h4>
 
    A <a>custom element</a> can react to certain occurrences by running author code.
@@ -1435,10 +1429,7 @@ constructor() {
        </li>
      </ul>
    </div>
- </section>
-</section>
 
-<section>
  <h4 id="html-element-constructors">HTML: HTML element constructors</h4>
 
   To support <a>custom elements</a>, all HTML elements have special constructor behavior.

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -11,7 +11,7 @@
   - the "Document" object, significantly extending what is defined in the DOM specification
       including attributes of it like document.cookies, document.referrer, document.head, document.forms, etc.
   - The HTMLElement interface
-  = The CEReactions extended attribute
+  - The CEReactions extended attribute
   - How elements and attributes are described in the spec
   - Content models - used in element descriptions
   - Global attributes
@@ -1447,7 +1447,12 @@ constructor() {
   extended attributes. (However, the interface may be annotated with {{[NamedConstructor]}};
   there is no conflict there.) It must not be used on a callback interface.</p>
 
-  <a>Interface objects</a> for interfaces annotated with the {{[HTMLConstructor]}} extended attribute must run the following steps as the function body behavior for both [[\Call]] and [[\Construct]] invocations of the corresponding JavaScript function object. When invoked with [[\Call]], the NewTarget value is undefined, and so the algorithm below will immediately throw. When invoked with [[\Construct]], the [[\Construct]] <var>newTarget</var> parameter provides the NewTarget value.</p>
+  <a>Interface objects</a> for interfaces annotated with the {{[HTMLConstructor]}} extended attribute
+   must run the following steps as the function body behavior for both \[[Call]] and \[[Construct]]
+   invocations of the corresponding JavaScript function object.
+
+   When invoked with \[[Call]], <code>newTarget</code> is undefined, and the algorithm will throw.
+   When invoked with \[[Construct]], the \[[Construct]] <code>newTarget</code> parameter provides the <var>NewTarget</var> value.</p>
 
  <ol>
    <li>
@@ -1455,7 +1460,7 @@ constructor() {
    </li>
 
    <li>
-     <p>If NewTarget is equal to the <a href="https://tc39.github.io/ecma262/#active-function-object">active function object</a>, then throw a <code><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps.</p>
+     <p>If <var>NewTarget</var> is equal to the <a>active function object</a>, then throw a {{TypeError}} and abort these steps.</p>
 
      <div class="example no-backref">
        <p>This can occur when a custom element is defined using an <a>element interface</a> as its constructor:</p>

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -699,7 +699,7 @@ any get(DOMString name);
 Promise&lt;void&gt; whenDefined(DOMString name);
 };
 
-dictionary <dfn id="elementdefinitionoptions">ElementDefinitionOptions</dfn> {
+dictionary ElementDefinitionOptions {
 DOMString extends;
 };
 </pre>
@@ -712,24 +712,24 @@ DOMString extends;
   <a for="customElements">name</a>, <a>local name</a>, or {{constructor}}.
   </li>
 
-  <li>an <dfn id="element-definition-is-running">element definition is running</dfn>
+  <li>an <dfn export>element definition is running</dfn>
   flag, used to prevent reentrant invocations of <a>element definition</a>. It is initially unset.
   </li>
 
-  <li>a <dfn id="when-defined-promise-map">when-defined promise map</dfn>, mapping <a>valid custom element names</a>
+  <li>a <dfn export>when-defined promise map</dfn>, mapping <a>valid custom element names</a>
    to promises. It is used to implement the {{whenDefined()}} method.</p>
    </li>
    </ul>
 
 
    <dl class="domintro note">
-     <dt><var>window</var> . {{customElements}} . {{define}}(<var>name</var>, <var>constructor</var>)</dt>
+     <dt><var>window</var> . {{customElements}} . {{define()|define(<var>name</var>}}, <var>constructor</var>)</dt>
 
      <dd>
        Defines a new <a>autonomous custom element</a>, mapping the given name to the given constructor.
      </dd>
 
-     <dt><var>window</var> . {{customElements}} . {{define}}(<var>name</var>, <var>constructor</var>), { extends: <var>baseLocalName</var> })</dt>
+     <dt><var>window</var> . {{customElements}} . {{define()|define(<var>name</var>, <var>constructor</var>), { extends: <var>baseLocalName</var> })}}</dt>
 
      <dd>
        Defines a new <a>customized built-in element</a>, mapping the given name to the given constructor for the
@@ -745,7 +745,7 @@ DOMString extends;
        Returns undefined if there is no <a>custom element definition</a> with the given <a for="customElements">name</a>.
      </dd>
 
-     <dt><var>window</var> . {{customElements}} . {{whenDefined}}(<var>name</var>)</dt>
+     <dt><var>window</var> . {{customElements}} . {{whenDefined()|whenDefined(<var>name</var>)}}</dt>
 
      <dd>
        Returns a promise that will be fulfilled when a <a>custom element</a>
@@ -756,10 +756,10 @@ DOMString extends;
      </dd>
    </dl>
 
-   <dfn id="element-definition">Element definition</dfn> is the process of adding a
+   <dfn export>Element definition</dfn> is the process of adding a
    <a>custom element definition</a> to the {{CustomElementRegistry}}.
    This is accomplished by the {{define()}} method. When invoked, the
-   <dfn method for="CustomElementRegistry" lt="define()"><code>define(<var>name</var>, <var>constructor</var>, <var>options</var>)</code></dfn>
+   {{define()|define(<var>name</var>, <var>constructor</var>, <var>options</var>)}}
    method must run these steps:</p>
 
    <ol>
@@ -939,7 +939,7 @@ DOMString extends;
      </li>
    </ol>
 
-   <p>When invoked, the <dfn for="customElements" lt="get"><code>get(<var>name</var>)</code></dfn> method must run these steps:</p>
+   <p>When invoked, the <dfn method for="customElements" lt="get()"><code>get(<var>name</var>)</code></dfn> method must run these steps:</p>
 
    <ol>
      <li>
@@ -952,7 +952,7 @@ DOMString extends;
      </li>
    </ol>
 
-   When invoked, the <dfn method for="CustomElementRegistry" lt="whenDefined()"><code>whenDefined(<var>name</var>)</code></dfn>
+   When invoked, the {{whenDefined()|whenDefined(<var>name</var>)}}
    method must run these steps:</p>
 
    <ol>
@@ -1012,7 +1012,7 @@ fetch(articleURL)
  <section>
    <h4 id="upgrades">Upgrades</h4>
 
-   <p>To <dfn lt="upgrade">upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
+   <p>To <dfn export lt="upgrade">upgrade an element</dfn>, given a <a>custom element definition</a> <var>definition</var>
     and an element <var>element</var>, run the following steps:</p>
 
    <ol>
@@ -1127,7 +1127,7 @@ constructor() {
      </li>
    </ol>
 
-   <p>To <dfn id="concept-try-upgrade">try to upgrade an element</dfn>, given as input an element <var>element</var>, run the following steps:</p>
+   <p>To <dfn export>try to upgrade an element</dfn>, given as input an element <var>element</var>, run the following steps:</p>
 
    <ol>
      <li>
@@ -1148,7 +1148,7 @@ constructor() {
    <h4 id="sec-custom-element-reactions">Custom element reactions</h4>
 
    A <a>custom element</a> can react to certain occurrences by running author code.
-   These reactions are called <dfn>custom element reactions</dfn>.
+   These reactions are called <dfn export>custom element reactions</dfn>.
 
    <ul>
      <li>
@@ -1191,34 +1191,34 @@ constructor() {
    <hr>
 
    Each <a>unit of related similar-origin browsing contexts</a> has a
-   <dfn>custom element reactions stack</dfn>, which is initially empty.
-   The <dfn>current element queue</dfn> is the <a>element queue</a>
+   <dfn export>custom element reactions stack</dfn>, which is initially empty.
+   The <dfn export>current element queue</dfn> is the <a>element queue</a>
     at the top of the <a>custom element reactions stack</a>. Each item in the stack is an
-    <dfn>element queue</dfn>, which is initially empty as well.
+    <dfn export>element queue</dfn>, which is initially empty as well.
     Each item in an <a>element queue</a> is an element.
     (The elements are not necessarily <a>custom</a> yet, since this queue is used for <a>upgrades</a> as well.)
 
    Each <a>custom element reactions stack</a> has an associated
-   <dfn>backup element queue</dfn>, which is an initially empty
+   <dfn export>backup element queue</dfn>, which is an initially empty
     <a>element queue</a>. Elements are pushed onto the <a>backup element queue</a>
      during operations that affect the DOM without going through an API decorated with
      [{{CEReactions}}], or through the parser's <a>create an element for the token</a> algorithm.
      An example of this is a user-initiated editing operation which modifies the descendants or attributes of an
       <a>editable</a> element. To prevent reentrancy when processing the <a>backup element queue</a>,
       each <a>custom element reactions stack</a> also has a
-      <dfn>processing the backup element queue</dfn> flag, initially unset.</p>
+      <dfn export>processing the backup element queue</dfn> flag, initially unset.</p>
 
-   <p>All elements have an associated <dfn>custom element reaction queue</dfn>, initially empty.
+   <p>All elements have an associated <dfn export>custom element reaction queue</dfn>, initially empty.
     Each item in the <a>custom element reaction queue</a> is of one of two types:</p>
 
    <ul>
      <li>
-       <p>An <dfn>upgrade reaction</dfn>, which <a>upgrades</a> the custom element and contains a
+       <p>An <dfn export>upgrade reaction</dfn>, which <a>upgrades</a> the custom element and contains a
         <a>custom element definition</a>; or</p>
      </li>
 
      <li>
-       <p>A <dfn>callback reaction</dfn>, which will call a <a>lifecycle callback</a>,
+       <p>A <dfn export>callback reaction</dfn>, which will call a <a>lifecycle callback</a>,
         and contains a {{Function!!callback}} as well as a list of arguments.</p>
      </li>
    </ul>
@@ -1227,7 +1227,7 @@ constructor() {
 
    <p><img src="custom-element-reactions.svg" alt="@@A custom element reactions stack consists of a stack of element queues. Zooming in on a particular queue, we see that it contains a number of elements (in our example, &lt;x-a&gt;, then &lt;x-b&gt;, then &lt;x-c&gt;). Any particular element in the queue then has a custom element reaction queue. Zooming in on the custom element reaction queue, we see that it contains a variety of queued-up reactions (in our example, upgrade, then attribute changed, then another attribute changed, then connected)." style="width: 80%; max-width: 580px;"></p>
 
-   <p>To <dfn>enqueue an element on the appropriate element queue</dfn>, given an element <var>element</var>,
+   <p>To <dfn export>enqueue an element on the appropriate element queue</dfn>, given an element <var>element</var>,
     run the following steps:</p>
 
    <ol>
@@ -1268,7 +1268,7 @@ constructor() {
      </li>
    </ol>
 
-   <p>To <dfn>enqueue a custom element callback reaction</dfn>, given a <a>custom element</a> <var>element</var>,
+   <p>To <dfn export>enqueue a custom element callback reaction</dfn>, given a <a>custom element</a> <var>element</var>,
     a callback name <var>callbackName</var>, and a list of arguments <var>args</var>, run the following steps:</p>
 
    <ol>
@@ -1310,7 +1310,7 @@ constructor() {
      </li>
    </ol>
 
-   <p>To <dfn>enqueue a custom element upgrade reaction</dfn>, given an element <var>element</var>
+   <p>To <dfn export>enqueue a custom element upgrade reaction</dfn>, given an element <var>element</var>
    and <a>custom element definition</a> <var>definition</var>, run the following steps:</p>
 
    <ol>
@@ -1324,7 +1324,7 @@ constructor() {
      </li>
    </ol>
 
-   <p>To <dfn>invoke custom element reactions</dfn> in an <a>element queue</a> <var>queue</var>, run the following steps:</p>
+   <p>To <dfn export>invoke custom element reactions</dfn> in an <a>element queue</a> <var>queue</var>, run the following steps:</p>
 
    <ol>
      <li>
@@ -1370,7 +1370,7 @@ constructor() {
    </ol>
    <hr>
 
-   The <dfn  export dfn-type="extended-attribute" lt="CEReactions"><code>[CEReactions]</code></dfn>
+   The <dfn export dfn-type="extended-attribute" lt="CEReactions"><code>[CEReactions]</code></dfn>
    IDL <a>extended attribute</a> is to ensure <a>custom element reactions</a> are triggered appropriately.
    It indicates that the relevant algorithm is to be supplemented with additional steps
    to appropriately track and invoke <a>custom element reactions</a>.

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -647,7 +647,7 @@
       * The <dfn scheme><code>https:</code></dfn> scheme [[!HTTP]]
       * The <dfn scheme><code>mailto:</code></dfn> scheme [[!RFC6068]]
       * The <dfn scheme><code>sms:</code></dfn> scheme [[!RFC5724]]
-      * The <dfn scheme><code>urn:</code></dfn> scheme [[!URN]]
+      * The <dfn scheme><code>urn:</code></dfn> scheme [[!RFC8141]]
 
       <dfn export>Media fragment syntax</dfn> is defined in the <cite>Media Fragments URI</cite>
       specification. [[!MEDIA-FRAGS]]

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -214,7 +214,7 @@
   * Authors can use the <{link/rel|rel=""}> mechanism to annotate links with specific meanings by
     registering <a>extensions to the predefined set of link types</a>. This is used by microformats
   * Authors can embed raw data using the <{script|script type=""}> mechanism with a custom
-    type, for further handling by inline or server-side scripts. This is what [[JSON-LD]] does.
+    type, for further handling by inline or server-side scripts. [[JSON-LD]] does this.
   * Authors can extend APIs using the JavaScript prototyping mechanism. This is widely used by
     script libraries.
   * Authors can use [[RDFa]] or [[microdata]] to annotate content.

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -217,7 +217,7 @@
     type, for further handling by inline or server-side scripts. [[JSON-LD]] does this.
   * Authors can extend APIs using the JavaScript prototyping mechanism. This is widely used by
     script libraries.
-  * Authors can use [[RDFa]] or [[microdata]] to annotate content.
+  * Authors can use [[html-RDFa]] or [[microdata]] to annotate content.
 
   When extending HTML authors should consider whether the new functionality is
   accessible to users with disabilities, and whether it risks degrading the privacy and security

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -198,27 +198,31 @@
 
   <em>This section is non-normative.</em>
 
-  HTML has a wide array of extensibility mechanisms that can be used for adding semantics in a safe
-  manner:
+  HTML has a wide array of extensibility mechanisms that can be used for adding semantics or behaviours
+  in a way that will not conflict with future development of the Web Platform:
 
-  * Authors can use the <{global/class}> attribute to extend elements, effectively creating their
-    own elements, while using the most applicable existing "real" HTML element, so that browsers
-    and other tools that don't know of the extension can still support it somewhat well. This is
-    the tack used by microformats, for example.
-  * Authors can include data for inline client-side scripts or server-side site-wide scripts to
-    process using the <{global/data-|data-*=""}> attributes. These are guaranteed to never be
-    touched by browsers, and allow scripts to include data on HTML elements that scripts can then
-    look for and process.
+  * Authors can create <a>custom elements</a> to provide new behaviours.
+  * Authors can use the <{global/class}> attribute to annotate elements for processing.
+    This is the primary mechanism used by CSS.
+  * Authors can annotate elements using the <{global/data-|data-*=""}> attributes.
+    These are guaranteed not to be touched by browsers,
+    and allow scripts to include data on HTML elements that scripts can then look for and process.
+    This is the valid and recommended practice for <a>custom elements</a>.
   * Authors can use the <{meta|meta name="" content=""}> mechanism to
     include page-wide metadata by registering
     <a lt="register the name">extensions to the predefined set of metadata names</a>.
   * Authors can use the <{link/rel|rel=""}> mechanism to annotate links with specific meanings by
-    registering <a>extensions to the predefined set of link types</a>. This is also used by
-    microformats.
+    registering <a>extensions to the predefined set of link types</a>. This is used by microformats
   * Authors can embed raw data using the <{script|script type=""}> mechanism with a custom
-    type, for further handling by inline or server-side scripts.
+    type, for further handling by inline or server-side scripts. This is what [[JSON-LD]] does.
   * Authors can extend APIs using the JavaScript prototyping mechanism. This is widely used by
-    script libraries, for instance.
+    script libraries.
+  * Authors can use [[RDFa]] or [[microdata]] to annotate content.
+
+  When extending HTML authors should consider whether the new functionality is
+  accessible to users with disabilities, and whether it risks degrading the privacy and security
+  of users. In addition, considering internationalization is important wherever users provide data.
+  These best-practice design considerations are part of the development of the HTML specification.
 
 <h3 id="html-vs-xhtml">HTML vs XML Syntax</h3>
 

--- a/sections/introduction.include
+++ b/sections/introduction.include
@@ -217,7 +217,7 @@
     type, for further handling by inline or server-side scripts. [[JSON-LD]] does this.
   * Authors can extend APIs using the JavaScript prototyping mechanism. This is widely used by
     script libraries.
-  * Authors can use [[html-RDFa]] or [[microdata]] to annotate content.
+  * Authors can use RDFa [[html-rdfa]] or [[microdata]] to annotate content.
 
   When extending HTML authors should consider whether the new functionality is
   accessible to users with disabilities, and whether it risks degrading the privacy and security

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2330,6 +2330,7 @@
 
   In addition, <a>custom element constructors</a> should implement the following good practices:
 
+  <ul>
   <li>
     <p>Work should be deferred to <code>connectedCallback</code>.
     This especially applies to work involving fetching resources or rendering.

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2165,7 +2165,7 @@
       <li><code>missing-glyph</code></li>
     </ul>
 
-    <p class="note">These are all hyphen-containing element names from the <a>applicable specifications</a>: <cite>SVG</cite> and <cite>MathML</cite>. [[SVG]] [[MATHML]]</p>
+    <p class="note">These are all hyphen-containing element names from the <a>applicable specifications</a>: <cite>SVG</cite> and <cite>MathML</cite>. [[SVG11]] [[MATHML]]</p>
   </li>
 </ul>
 

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2039,199 +2039,253 @@
 
 
 <section>
-<h4 id="autonomous-custom-elements">Autonomous custom elements</h4>
+<h4 id="custom-elements-core-concepts">Custom Elements</h4>
 
-    <p>An <dfn id="autonomous-custom-element">autonomous custom element</dfn> is a <a>custom element</a>
+  A <dfn>custom element</dfn> is an element whose {{constructor}} and {{prototype}} are defined by the author.
+  The author-supplied constructor function is called the <dfn>custom element constructor</dfn>.
+  Custom elements have the <a>custom element state</a> "<code>custom</code>".
+
+  <p class="note">For the elements whose semantics are described in this specification, or in
+  <a>other applicable specifications</a>, {{constructor}} and {{prototype}} are defined by the user agent.</p>
+
+  There are two types of custom elements:
+  :<a>autonomous custom Elements
+  ::These are entirely author-defined, extending {{HTMLElement}}
+  :<a>customized built-in Elements
+  ::These extend elements that are already defined. <span class="note">This is typically to inherit some functionality.</span>
+
+<h5 id="autonomous-custom-elements">Autonomous custom elements</h4>
+
+    An <dfn>autonomous custom element</dfn> is a <a>custom element</a>
     completely defined by the author. It <a>extends</a> {{HTMLElement}},
-    and its local name is equal to its <a href="#concept-custom-element-definition-name">defined name</a>.</p>
+    and its <a>local name</a> is equal to its <a for="customElements">name</a>.</p>
 
-@@@
-<p><a href="#autonomous-custom-element">Autonomous custom elements</a> have the following element definition:</p>
+  <a>Autonomous custom elements</a> have the following element definition:
 
 <dl class="element">
   <dt>
     <a>Categories</a>:
   </dt>
 
-  <dd>
-    <a>Flow content</a>.
-  </dd>
-
-  <dd>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>.
-  </dd>
-
-  <dd>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a>.
-  </dd>
+  <dd><a>Flow content</a>.</dd>
+  <dd><a>Phrasing content</a>.</dd>
+  <dd><a>Palpable content</a>.</dd>
 
   <dt>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:
+    <a>Contexts in which this element can be used</a>:
   </dt>
 
   <dd>
-    Where <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">phrasing content</a> is expected.
+    Where <a>phrasing content</a> is expected.
   </dd>
 
   <dt>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:
+    <a>Content model</a>:
   </dt>
 
   <dd>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#transparent">Transparent</a>.
+    <a>Transparent</a>.
   </dd>
 
   <dt>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">Content attributes</a>:
+    <a>Content attributes</a>:
   </dt>
 
   <dd>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global attributes</a>, except the <code><a href="#attr-is">is</a></code> attribute
+    <a>Global attributes</a>, except the <{global/is}> attribute
   </dd>
 
-  <dd>Any other attribute that has no namespace (see prose).</dd>
-
   <dt>
-    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+    <a>Allowed ARIA role attribute values</a>:
   </dt>
 
-  <dd>Supplied by the element's author (inherits from <code><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code>)</dd>
+  <dd>
+    Any
+  </dd>
+
+  <dt>
+    <a>Allowed ARIA state and property attributes</a>:
+  </dt>
+
+  <dd>
+    Any
+  </dd>
+
+  <dt>
+    <a>DOM interface</a>:
+  </dt>
+
+  <dd>Supplied by the element's author (inherits from {{HTMLElement}})</dd>
 </dl>
 
-<p>An <a href="#autonomous-custom-element">autonomous custom element</a> does not have any special meaning: it <a href="https://html.spec.whatwg.org/multipage/dom.html#represents">represents</a> its children. A <a href="#customized-built-in-element">customized built-in element</a> inherits the semantics of the element that it extends.</p>
+  An <a>autonomous custom element</a>'s' meaning is defined by its author. It <a>represents</a> its children.
 
-<p>Any namespace-less attribute that is relevant to the element's functioning, as determined by the element's author, may be specified on an <a href="#autonomous-custom-element">autonomous custom element</a>, so long as the attribute name is <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible">XML-compatible</a> and contains no <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#uppercase-ascii-letters">uppercase ASCII letters</a>. The exception is the <code><a href="#attr-is">is</a></code> attribute, which must not be specified on an <a href="#autonomous-custom-element">autonomous custom element</a> (and which will have no effect if it is).</p>
+ <h5 id="customized-built-in-elements">Customized built-in elements</h5>
 
-<p><a href="#customized-built-in-element">Customized built-in elements</a> follow the normal requirements for attributes, based on the elements they extend. To add custom attribute-based behavior, use <code><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-data-*">data-*</a></code> attributes.</p>
-<hr>
+  A <dfn>customized built-in element</dfn> is a <a>custom element</a> that <a>extends</a> an existing element.
+  A customized built-in element's <a>local name</a> is the name of the element it extends.
+  Its <a for="customElements">name</a> is used as the <a>is value</a>, provided in the <{global/is}>
+  attribute when it is used in markup.
 
-<p>A <dfn id="valid-custom-element-name">valid custom element name</dfn> is a sequence of characters <var>name</var> that meets all of the following requirements:</p>
+  <div class="example">For example a <{button}> has pre-defined interaction behaviour,
+      a <{tr}> already participates in the <a>table model</a>,
+      and a <{input/checkbox}> has defined behaviour and participates in form submission.
 
-<ul>
-  <li>
-    <p><var>name</var> must match the <code><a href="#prod-potentialcustomelementname">PotentialCustomElementName</a></code> production:</p>
+      Since only existing table elements takes part in the <a>table model</a>,
+      with other elements moved outside the <{table}>, creating a custom element that is part of a <{table}>
+      can only be done by customizing a built-in table element.
+  </div>
 
-    <dl>
-      <dt><code><dfn id="prod-potentialcustomelementname">PotentialCustomElementName</dfn> ::=</code></dt>
+  A <a href="#customized-built-in-element">customized built-in element</a> inherits the semantics of the element that it extends.</p>
 
-      <dd><code>[a-z] (<a href="#prod-pcenchar">PCENChar</a>)* '-' (<a href="#prod-pcenchar">PCENChar</a>)*</code></dd>
+  A <a>customized built-in element</a> has the same requirements for attributes as the element it extends.
+  To add custom attribute-based behavior, use [=custom data attributes|data-*=] attributes.</p>
 
-      <dt><code><dfn id="prod-pcenchar">PCENChar</dfn> ::=</code></dt>
+  A <a>customized built-in element</a>'s <a>is value</a> is saved on the element when it is
+   <a>created</a>. So changing the value of the <{{global/is}}> attribute does not change the element's behaviour.
 
-      <dd><code>"-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></dd>
-    </dl>
+</section>
+<section>
+<h4 id="requirement-for-all-custom-elements">Requirements for all custom elements</h4>
 
-    <p>This uses the <a href="https://www.w3.org/TR/xml/#sec-notation">EBNF notation</a> from the <cite>XML</cite> specification. [[!XML]]</p>
-  </li>
-
-  <li>
-    <p><var>name</var> must not be any of the following:</p>
+  A <dfn id="valid-custom-element-name">valid custom element name</dfn> is a sequence of characters
+  <var>name</var> that matches the <code><a>PotentialCustomElementName</a></code> production,
+  and is not one of the following:</p>
 
     <ul class="brief">
       <li><code>annotation-xml</code></li>
-
       <li><code>color-profile</code></li>
-
       <li><code>font-face</code></li>
-
       <li><code>font-face-src</code></li>
-
       <li><code>font-face-uri</code></li>
-
       <li><code>font-face-format</code></li>
-
       <li><code>font-face-name</code></li>
-
       <li><code>missing-glyph</code></li>
     </ul>
 
-    <p class="note">The list of names above is the summary of all hyphen-containing element names from the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#other-applicable-specifications">applicable specifications</a>, namely <cite>SVG</cite> and <cite>MathML</cite>. [[SVG]] [[MATHML]]</p>
+    <p class="note">These are all hyphen-containing element names from the <a>applicable specifications</a>: <cite>SVG</cite> and <cite>MathML</cite>. [[SVG]] [[MATHML]]</p>
   </li>
 </ul>
 
+  The <dfn><code>PotentialCustomElementName</code> production</dfn> is as follows:
+<dl>
+  <dt><a>PotentialCustomElementName</a> ::=</code></dt>
+
+  <dd><code>[a-z] (<a href="#prod-pcenchar">PCENChar</a>)* '-' (<a href="#prod-pcenchar">PCENChar</a>)*</code></dd>
+
+  <dt><code><dfn id="prod-pcenchar">PCENChar</dfn> ::=</code></dt>
+
+  <dd><code>"-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></dd>
+</dl>
+
+<p>This uses the <a>EBNF notation</a> from the <cite>XML</cite> specification. [[!XML]]</p>
+
 <div class="note">
-  <p>These requirements ensure a number of goals for <a href="#valid-custom-element-name">valid custom element names</a>:</p>
+  <p>These requirements ensure a number of goals for <a>valid custom element names</a>:</p>
 
   <ul>
     <li>
-      <p>They start with a <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#lowercase-ascii-letters">lowercase ASCII letter</a>, ensuring that the HTML parser will treat them as tags instead of as text.</p>
+      <p>They start with a <a>lowercase ASCII letter</a>, ensuring that the HTML parser will treat them as tags instead of as text.</p>
     </li>
 
     <li>
-      <p>They do not contain any <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#uppercase-ascii-letters">uppercase ASCII letters</a>, ensuring that the user agent can always treat HTML elements ASCII-case-insensitively.</p>
+      <p>They do not contain any <a>uppercase ASCII letters</a>, so user agent can always treat HTML elements ASCII-case-insensitively.</p>
     </li>
 
     <li>
-      <p>They contain a hyphen, used for namespacing and to ensure forward compatibility (since no elements will be added to HTML, SVG, or MathML with hyphen-containing local names in the future).</p>
+      <p>They contain a hyphen, used for namespacing and to ensure forward compatibility.
+      No new elements will be added to HTML, SVG, or MathML with names containing a hypen.</p>
     </li>
 
     <li>
-      <p>They can always be created with <code><a href="https://dom.spec.whatwg.org/#dom-document-createelement">createElement()</a></code> and <code><a href="https://dom.spec.whatwg.org/#dom-document-createelementns">createElementNS()</a></code>, which have restrictions that go beyond the parser's.</p>
+      <p>They can always be created with {{createElement()}} and {{createElementNS()}},
+      which have more restrictions than the parser.</p>
+    </li>
+
+    <li>
+    <p>They allow a wide range of names to give maximum flexibility:
+    e.g. <code>&lt;x-小山&gt;</code> <code>&lt;math-α&gt;</code> or <code>&lt;emotion-😍&gt;</code>.</p>
     </li>
   </ul>
 
-  <p>Apart from these restrictions, a large variety of names is allowed, to give maximum flexibility for use cases like <code>&lt;math-α&gt;</code> or <code>&lt;emotion-😍&gt;</code>.</p>
 </div>
 
-<p>A <dfn id="custom-element-definition">custom element definition</dfn> describes a <a href="#custom-element">custom element</a> and consists of:</p>
+  A <dfn>custom element definition</dfn> describes a <a>custom element</a> and consists of:</p>
 
 <dl>
-  <dt>A <dfn id="concept-custom-element-definition-name">name</dfn></dt>
+  <dt>A <dfn for="customElements">name</dfn></dt>
 
   <dd>
-    A <a href="#valid-custom-element-name">valid custom element name</a>
+    A <a>valid custom element name</a>.
   </dd>
 
-  <dt>A <dfn id="concept-custom-element-definition-local-name">local name</dfn></dt>
+  <dt>A <dfn for="customElements">local name</dfn></dt>
 
-  <dd>A local name</dd>
+  <dd>
+    For <a>autonomous custom elements</a> this is the same as its <a for="customElements">name</a>.
+  </dd>
+  <dd>
+    For <a>customized built-in elements</a> this is the name of the element it extends.
+  </dd>
 
   <dt>A <dfn id="concept-custom-element-definition-constructor">constructor</dfn></dt>
 
   <dd>
-    A <a href="#custom-element-constructor">custom element constructor</a>
+    A <a>custom element constructor</a> function.
   </dd>
 
-  <dt>A <dfn id="concept-custom-element-definition-prototype">prototype</dfn></dt>
+  <dt>A <dfn>prototype</dfn></dt>
 
   <dd>A JavaScript object</dd>
 
-  <dt>A list of <dfn id="concept-custom-element-definition-observed-attributes">observed attributes</dfn></dt>
+  <dt>A list of <dfn>observed attributes</dfn></dt>
 
-  <dd>A <code>sequence&lt;DOMString&gt;</code></dd>
+  <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names. When any of the named attributes changes value, the <a>attributeChangedCallback</a> <a>custom reaction</a> is
+  [=enqueue a custom element callback reaction|enqueued=].</dd>
 
-  <dt>A collection of <dfn id="concept-custom-element-definition-lifecycle-callbacks">lifecycle callbacks</dfn></dt>
+  <dt>A collection of <dfn>lifecycle callbacks</dfn></dt>
 
-  <dd>A map, whose four keys are the strings "<code>connectedCallback</code>", "<code>disconnectedCallback</code>", "<code>adoptedCallback</code>", and "<code>attributeChangedCallback</code>". The corresponding values are either a Web IDL <code><a href="https://heycam.github.io/webidl/#common-Function">Function</a></code> callback function type value, or null. By default the value of each entry is null.</dd>
+  <dd>A map, whose four keys are the strings "<code>connectedCallback</code>",
+   "<code>disconnectedCallback</code>", "<code>adoptedCallback</code>", and
+   "<code>attributeChangedCallback</code>". The corresponding values are either a Web IDL {{Function}}
+  callback function type value, or null. By default the value of each entry is null.</dd>
 
-  <dt>A <dfn id="concept-custom-element-definition-construction-stack">construction stack</dfn></dt>
+  <dt>A <dfn>construction stack</dfn></dt>
 
   <dd>
-    A list, initially empty, that is manipulated by the <a href="#concept-upgrade-an-element">upgrade an element</a> algorithm and the <a href="#html-element-constructors">HTML element constructors</a>. Each entry in the list will be either an element or an <dfn id="concept-already-constructed-marker"><i>already constructed</i> marker</dfn>.
+    A list, initially empty, that is manipulated by the <a>upgrade an element</a> algorithm and the
+    <a>HTML element constructors</a>. Each entry in the list is either an element or an
+    <dfn><i>already constructed</i> marker</dfn>.
   </dd>
 </dl>
 
-<p>To <dfn id="look-up-a-custom-element-definition">look up a custom element definition</dfn>, given a <var>document</var>, <var>namespace</var>, <var>localName</var>, and <var>is</var>, perform the following steps. They will return either a <a href="#custom-element-definition">custom element definition</a> or null:</p>
+  To <dfn>look up a custom element definition</dfn>, given a <var>document</var>,
+  <var>namespace</var>, <var>localName</var>, and <var>is</var>, perform the following steps.
+  They will return either a <a>custom element definition</a> or null:</p>
 
 <ol>
   <li>
-    <p>If <var>namespace</var> is not the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-namespace-2">HTML namespace</a>, return null.</p>
+    <p>If <var>namespace</var> is not the <a>HTML namespace</a>, return null.</p>
   </li>
 
   <li>
-    <p>If <var>document</var> does not have a <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>, return null.</p>
+    <p>If <var>document</var> does not have a <a>browsing context</a>, return null.</p>
   </li>
 
   <li>
-    <p>Let <var>registry</var> be <var>document</var>'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>'s <code><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code>'s <code><a href="#customelementregistry">CustomElementRegistry</a></code> object.</p>
+    <p>Let <var>registry</var> be <var>document</var>'s <a>browsing context</a>'s {{Window}}'s
+    {{CustomElementRegistry}} object.</p>
   </li>
 
   <li>
-    <p>If there is <a href="#custom-element-definition">custom element definition</a> in <var>registry</var> with <a href="#concept-custom-element-definition-name">name</a> and <a href="#concept-custom-element-definition-local-name">local name</a> both equal to <var>localName</var>, return that <a href="#custom-element-definition">custom element definition</a>.</p>
+    <p>If there is <a>custom element definition</a> in <var>registry</var> with <a>name</a> and
+    <a>local name</a> both equal to <var>localName</var>, return that <a>custom element definition</a>.</p>
   </li>
 
   <li>
-    <p>If there is a <a href="#custom-element-definition">custom element definition</a> in <var>registry</var> with <a href="#concept-custom-element-definition-name">name</a> equal to <var>is</var> and <a href="#concept-custom-element-definition-local-name">local name</a> equal to <var>localName</var>, return that <a href="#custom-element-definition">custom element definition</a>.</p>
+    <p>If there is a <a>custom element definition</a> in <var>registry</var> with
+    <a>name</a> equal to <var>is</var> and <a>local name</a> equal to <var>localName</var>,
+    return that <a>custom element definition</a>.</p>
   </li>
 
   <li>
@@ -2240,49 +2294,53 @@
 </ol>
 </section>
 <section>
-<h4 id="custom-elements-core-concepts">Core concepts</h4>
-
-<p>A <dfn id="custom-element">custom element</dfn> is an element that is <a href="#concept-element-custom">custom</a>. Informally, this means that its constructor and prototype are defined by the author, instead of by the user agent. This author-supplied constructor function is called the <dfn id="custom-element-constructor">custom element constructor</dfn>.</p>
-
-
-
-<p>After a <a href="#custom-element">custom element</a> is <a href="#concept-create-element">created</a>, changing the value of the <code><a href="#attr-is">is</a></code> attribute does not change the element's behaviour, as it is saved on the element as its <a href="#concept-element-is-value"><code>is</code> value</a>.</p>
-@@@@
-
-<section>
 <h4 id="custom-element-conformance">Requirements for custom element constructors</h4>
 
-<p>When authoring <a href="#custom-element-constructor">custom element constructors</a>, authors are bound by the following conformance requirements:</p>
+<p>A <a>custom element constructor</a> must meet the following requirements:</p>
 
 <ul>
   <li>
-    <p>A parameter-less call to <code>super()</code> must be the first statement in the constructor body, to establish the correct prototype chain and <b>this</b> value before any further code is run.</p>
+    <p>A parameter-less call to <code>super()</code> must be the first statement in the constructor body.
+    This establishes the correct prototype chain and <code><b>this</b></code> value before any further code is run.</p>
   </li>
 
   <li>
-    <p>A <code>return</code> statement must not appear anywhere inside the constructor body, unless it is a simple early-return (<code>return</code> or <code>return this</code>).</p>
+    <p>A <code>return</code> statement must not appear anywhere inside the constructor body,
+    unless it is a simple early-return (<code>return</code> or <code>return this</code>).</p>
   </li>
 
   <li>
-    <p>The constructor must not use the <code><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-write">document.write()</a></code> or <code><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open">document.open()</a></code> methods.</p>
+    <p>The constructor must not use the {{document.write()}} or {{document.open()}} methods.</p>
   </li>
 
   <li>
-    <p>The element's attributes and children must not be inspected, as in the non-<a href="#upgrades">upgrade</a> case none will be present, and relying on upgrades makes the element less usable.</p>
+    <p>The element's attributes and children must not be inspected.
+    In the non-<a>upgrade</a> case none will be present,
+    and relying on upgrades makes the element less usable.</p>
   </li>
 
   <li>
-    <p>The element must not gain any attributes or children, as this violates the expectations of consumers who use the <code><a href="https://dom.spec.whatwg.org/#dom-document-createelement">createElement</a></code> or <code><a href="https://dom.spec.whatwg.org/#dom-document-createelementns">createElementNS</a></code> methods.</p>
+    <p>The element must not gain any attributes or children.
+    Doing so violates the expectations of consumers who use the {{createElement()}} or
+    {{(reateElementNS()}}</a></code> methods.</p>
+  </li>
+  </ul>
+
+  In addition, <a>custom element constructors</a> should implement the following good practices:
+
+  <li>
+    <p>Work should be deferred to <code>connectedCallback</code>.
+    This especially applies to work involving fetching resources or rendering.
+    However, note that <code>connectedCallback</code> can be called more than once,
+    so initialization work may need a guard to prevent it from running twice.</p>
   </li>
 
   <li>
-    <p>In general, work should be deferred to <code>connectedCallback</code> as much as possible—especially work involving fetching resources or rendering. However, note that <code>connectedCallback</code> can be called more than once, so any initialization work that is truly one-time will need a guard to prevent it from running twice.</p>
-  </li>
-
-  <li>
-    <p>In general, the constructor should be used to set up initial state and default values, and to set up event listeners and possibly a <a href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</a>.</p>
+    <p>The constructor should set up initial state and default values, event listeners,
+    and possibly a <a>shadow root</a>.</p>
   </li>
 </ul>
 
-<p>Several of these requirements are checked during <a href="#concept-create-element">element creation</a>, either directly or indirectly, and failing to follow them will result in a custom element that cannot be instantiated by the parser or DOM APIs.</p>
+  Some of these requirements are checked during [=create an element|element creation=],
+  and failing to follow them will result in a custom element that cannot be instantiated by the parser or DOM APIs.</p>
 </section>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -502,9 +502,9 @@
       Otherwise, let <var>integrity metadata</var> be the empty string.
   17. Let <var>parser metadata</var> be "<code>parser-inserted</code>" if the <{script}> element has been flagged
        as "[=parser-inserted=]", and "`not parser-inserted`" otherwise.
-  18. Let options be a set of <a>script fetch options</a> whose <a>cryptographic nonce metadata</a> is 
-       cryptographic nonce, <a>integrity metadata</a> is integrity metadata, 
-       <a>parser metadata</a> is <var>parser metadata</var>, <a>credentials mode</a> is module 
+  18. Let options be a set of <a>script fetch options</a> whose <a>cryptographic nonce metadata</a> is
+       cryptographic nonce, <a>integrity metadata</a> is integrity metadata,
+       <a>parser metadata</a> is <var>parser metadata</var>, <a>credentials mode</a> is module
        script credentials mode, and <a>referrer policy</a> is the empty string.
   19. Let <var>settings</var> be the element's <a>node document</a>'s {{Window}} object's
        <a>environment settings object</a>.
@@ -2034,4 +2034,255 @@
   <code>CanvasRenderingContext2D</code> is bound to a new <{canvas}>, the bitmap is cleared
   and its flag reset.
 
+</section>
+<!-- start CEinsert @@ -->
+
+
+<section>
+<h4 id="autonomous-custom-elements">Autonomous custom elements</h4>
+
+    <p>An <dfn id="autonomous-custom-element">autonomous custom element</dfn> is a <a>custom element</a>
+    completely defined by the author. It <a>extends</a> {{HTMLElement}},
+    and its local name is equal to its <a href="#concept-custom-element-definition-name">defined name</a>.</p>
+
+@@@
+<p><a href="#autonomous-custom-element">Autonomous custom elements</a> have the following element definition:</p>
+
+<dl class="element">
+  <dt>
+    <a>Categories</a>:
+  </dt>
+
+  <dd>
+    <a>Flow content</a>.
+  </dd>
+
+  <dd>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>.
+  </dd>
+
+  <dd>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a>.
+  </dd>
+
+  <dt>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:
+  </dt>
+
+  <dd>
+    Where <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">phrasing content</a> is expected.
+  </dd>
+
+  <dt>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:
+  </dt>
+
+  <dd>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#transparent">Transparent</a>.
+  </dd>
+
+  <dt>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">Content attributes</a>:
+  </dt>
+
+  <dd>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global attributes</a>, except the <code><a href="#attr-is">is</a></code> attribute
+  </dd>
+
+  <dd>Any other attribute that has no namespace (see prose).</dd>
+
+  <dt>
+    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+  </dt>
+
+  <dd>Supplied by the element's author (inherits from <code><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code>)</dd>
+</dl>
+
+<p>An <a href="#autonomous-custom-element">autonomous custom element</a> does not have any special meaning: it <a href="https://html.spec.whatwg.org/multipage/dom.html#represents">represents</a> its children. A <a href="#customized-built-in-element">customized built-in element</a> inherits the semantics of the element that it extends.</p>
+
+<p>Any namespace-less attribute that is relevant to the element's functioning, as determined by the element's author, may be specified on an <a href="#autonomous-custom-element">autonomous custom element</a>, so long as the attribute name is <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible">XML-compatible</a> and contains no <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#uppercase-ascii-letters">uppercase ASCII letters</a>. The exception is the <code><a href="#attr-is">is</a></code> attribute, which must not be specified on an <a href="#autonomous-custom-element">autonomous custom element</a> (and which will have no effect if it is).</p>
+
+<p><a href="#customized-built-in-element">Customized built-in elements</a> follow the normal requirements for attributes, based on the elements they extend. To add custom attribute-based behavior, use <code><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-data-*">data-*</a></code> attributes.</p>
+<hr>
+
+<p>A <dfn id="valid-custom-element-name">valid custom element name</dfn> is a sequence of characters <var>name</var> that meets all of the following requirements:</p>
+
+<ul>
+  <li>
+    <p><var>name</var> must match the <code><a href="#prod-potentialcustomelementname">PotentialCustomElementName</a></code> production:</p>
+
+    <dl>
+      <dt><code><dfn id="prod-potentialcustomelementname">PotentialCustomElementName</dfn> ::=</code></dt>
+
+      <dd><code>[a-z] (<a href="#prod-pcenchar">PCENChar</a>)* '-' (<a href="#prod-pcenchar">PCENChar</a>)*</code></dd>
+
+      <dt><code><dfn id="prod-pcenchar">PCENChar</dfn> ::=</code></dt>
+
+      <dd><code>"-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></dd>
+    </dl>
+
+    <p>This uses the <a href="https://www.w3.org/TR/xml/#sec-notation">EBNF notation</a> from the <cite>XML</cite> specification. [[!XML]]</p>
+  </li>
+
+  <li>
+    <p><var>name</var> must not be any of the following:</p>
+
+    <ul class="brief">
+      <li><code>annotation-xml</code></li>
+
+      <li><code>color-profile</code></li>
+
+      <li><code>font-face</code></li>
+
+      <li><code>font-face-src</code></li>
+
+      <li><code>font-face-uri</code></li>
+
+      <li><code>font-face-format</code></li>
+
+      <li><code>font-face-name</code></li>
+
+      <li><code>missing-glyph</code></li>
+    </ul>
+
+    <p class="note">The list of names above is the summary of all hyphen-containing element names from the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#other-applicable-specifications">applicable specifications</a>, namely <cite>SVG</cite> and <cite>MathML</cite>. [[SVG]] [[MATHML]]</p>
+  </li>
+</ul>
+
+<div class="note">
+  <p>These requirements ensure a number of goals for <a href="#valid-custom-element-name">valid custom element names</a>:</p>
+
+  <ul>
+    <li>
+      <p>They start with a <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#lowercase-ascii-letters">lowercase ASCII letter</a>, ensuring that the HTML parser will treat them as tags instead of as text.</p>
+    </li>
+
+    <li>
+      <p>They do not contain any <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#uppercase-ascii-letters">uppercase ASCII letters</a>, ensuring that the user agent can always treat HTML elements ASCII-case-insensitively.</p>
+    </li>
+
+    <li>
+      <p>They contain a hyphen, used for namespacing and to ensure forward compatibility (since no elements will be added to HTML, SVG, or MathML with hyphen-containing local names in the future).</p>
+    </li>
+
+    <li>
+      <p>They can always be created with <code><a href="https://dom.spec.whatwg.org/#dom-document-createelement">createElement()</a></code> and <code><a href="https://dom.spec.whatwg.org/#dom-document-createelementns">createElementNS()</a></code>, which have restrictions that go beyond the parser's.</p>
+    </li>
+  </ul>
+
+  <p>Apart from these restrictions, a large variety of names is allowed, to give maximum flexibility for use cases like <code>&lt;math-α&gt;</code> or <code>&lt;emotion-😍&gt;</code>.</p>
+</div>
+
+<p>A <dfn id="custom-element-definition">custom element definition</dfn> describes a <a href="#custom-element">custom element</a> and consists of:</p>
+
+<dl>
+  <dt>A <dfn id="concept-custom-element-definition-name">name</dfn></dt>
+
+  <dd>
+    A <a href="#valid-custom-element-name">valid custom element name</a>
+  </dd>
+
+  <dt>A <dfn id="concept-custom-element-definition-local-name">local name</dfn></dt>
+
+  <dd>A local name</dd>
+
+  <dt>A <dfn id="concept-custom-element-definition-constructor">constructor</dfn></dt>
+
+  <dd>
+    A <a href="#custom-element-constructor">custom element constructor</a>
+  </dd>
+
+  <dt>A <dfn id="concept-custom-element-definition-prototype">prototype</dfn></dt>
+
+  <dd>A JavaScript object</dd>
+
+  <dt>A list of <dfn id="concept-custom-element-definition-observed-attributes">observed attributes</dfn></dt>
+
+  <dd>A <code>sequence&lt;DOMString&gt;</code></dd>
+
+  <dt>A collection of <dfn id="concept-custom-element-definition-lifecycle-callbacks">lifecycle callbacks</dfn></dt>
+
+  <dd>A map, whose four keys are the strings "<code>connectedCallback</code>", "<code>disconnectedCallback</code>", "<code>adoptedCallback</code>", and "<code>attributeChangedCallback</code>". The corresponding values are either a Web IDL <code><a href="https://heycam.github.io/webidl/#common-Function">Function</a></code> callback function type value, or null. By default the value of each entry is null.</dd>
+
+  <dt>A <dfn id="concept-custom-element-definition-construction-stack">construction stack</dfn></dt>
+
+  <dd>
+    A list, initially empty, that is manipulated by the <a href="#concept-upgrade-an-element">upgrade an element</a> algorithm and the <a href="#html-element-constructors">HTML element constructors</a>. Each entry in the list will be either an element or an <dfn id="concept-already-constructed-marker"><i>already constructed</i> marker</dfn>.
+  </dd>
+</dl>
+
+<p>To <dfn id="look-up-a-custom-element-definition">look up a custom element definition</dfn>, given a <var>document</var>, <var>namespace</var>, <var>localName</var>, and <var>is</var>, perform the following steps. They will return either a <a href="#custom-element-definition">custom element definition</a> or null:</p>
+
+<ol>
+  <li>
+    <p>If <var>namespace</var> is not the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-namespace-2">HTML namespace</a>, return null.</p>
+  </li>
+
+  <li>
+    <p>If <var>document</var> does not have a <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>, return null.</p>
+  </li>
+
+  <li>
+    <p>Let <var>registry</var> be <var>document</var>'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>'s <code><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code>'s <code><a href="#customelementregistry">CustomElementRegistry</a></code> object.</p>
+  </li>
+
+  <li>
+    <p>If there is <a href="#custom-element-definition">custom element definition</a> in <var>registry</var> with <a href="#concept-custom-element-definition-name">name</a> and <a href="#concept-custom-element-definition-local-name">local name</a> both equal to <var>localName</var>, return that <a href="#custom-element-definition">custom element definition</a>.</p>
+  </li>
+
+  <li>
+    <p>If there is a <a href="#custom-element-definition">custom element definition</a> in <var>registry</var> with <a href="#concept-custom-element-definition-name">name</a> equal to <var>is</var> and <a href="#concept-custom-element-definition-local-name">local name</a> equal to <var>localName</var>, return that <a href="#custom-element-definition">custom element definition</a>.</p>
+  </li>
+
+  <li>
+    <p>Return null.</p>
+  </li>
+</ol>
+</section>
+<section>
+<h4 id="custom-elements-core-concepts">Core concepts</h4>
+
+<p>A <dfn id="custom-element">custom element</dfn> is an element that is <a href="#concept-element-custom">custom</a>. Informally, this means that its constructor and prototype are defined by the author, instead of by the user agent. This author-supplied constructor function is called the <dfn id="custom-element-constructor">custom element constructor</dfn>.</p>
+
+
+
+<p>After a <a href="#custom-element">custom element</a> is <a href="#concept-create-element">created</a>, changing the value of the <code><a href="#attr-is">is</a></code> attribute does not change the element's behaviour, as it is saved on the element as its <a href="#concept-element-is-value"><code>is</code> value</a>.</p>
+@@@@
+
+<section>
+<h4 id="custom-element-conformance">Requirements for custom element constructors</h4>
+
+<p>When authoring <a href="#custom-element-constructor">custom element constructors</a>, authors are bound by the following conformance requirements:</p>
+
+<ul>
+  <li>
+    <p>A parameter-less call to <code>super()</code> must be the first statement in the constructor body, to establish the correct prototype chain and <b>this</b> value before any further code is run.</p>
+  </li>
+
+  <li>
+    <p>A <code>return</code> statement must not appear anywhere inside the constructor body, unless it is a simple early-return (<code>return</code> or <code>return this</code>).</p>
+  </li>
+
+  <li>
+    <p>The constructor must not use the <code><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-write">document.write()</a></code> or <code><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open">document.open()</a></code> methods.</p>
+  </li>
+
+  <li>
+    <p>The element's attributes and children must not be inspected, as in the non-<a href="#upgrades">upgrade</a> case none will be present, and relying on upgrades makes the element less usable.</p>
+  </li>
+
+  <li>
+    <p>The element must not gain any attributes or children, as this violates the expectations of consumers who use the <code><a href="https://dom.spec.whatwg.org/#dom-document-createelement">createElement</a></code> or <code><a href="https://dom.spec.whatwg.org/#dom-document-createelementns">createElementNS</a></code> methods.</p>
+  </li>
+
+  <li>
+    <p>In general, work should be deferred to <code>connectedCallback</code> as much as possible—especially work involving fetching resources or rendering. However, note that <code>connectedCallback</code> can be called more than once, so any initialization work that is truly one-time will need a guard to prevent it from running twice.</p>
+  </li>
+
+  <li>
+    <p>In general, the constructor should be used to set up initial state and default values, and to set up event listeners and possibly a <a href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</a>.</p>
+  </li>
+</ul>
+
+<p>Several of these requirements are checked during <a href="#concept-create-element">element creation</a>, either directly or indirectly, and failing to follow them will result in a custom element that cannot be instantiated by the parser or DOM APIs.</p>
 </section>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2118,7 +2118,7 @@
   <dd>Supplied by the element's author (inherits from {{HTMLElement}})</dd>
 </dl>
 
-  An <a>autonomous custom element</a>'s' meaning is defined by its author. It <a>represents</a> its children.
+  An <a>autonomous custom element</a>'s meaning is defined by its author. It <a>represents</a> its children.
 
  <h5 id="customized-built-in-elements">Customized built-in elements</h5>
 
@@ -2131,7 +2131,7 @@
       a <{tr}> already participates in the <a>table model</a>,
       and a <{input/checkbox}> has defined behaviour and participates in form submission.
 
-      Since only existing table elements takes part in the <a>table model</a>,
+      Since only existing table elements take part in the <a>table model</a>,
       with other elements moved outside the <{table}>, creating a custom element that is part of a <{table}>
       can only be done by customizing a built-in table element.
   </div>
@@ -2191,7 +2191,7 @@
     </li>
 
     <li>
-      <p>They do not contain any <a>uppercase ASCII letters</a>, so user agent can always treat HTML elements ASCII-case-insensitively.</p>
+      <p>They do not contain any <a>uppercase ASCII letters</a>, so user agents can always treat HTML elements ASCII-case-insensitively.</p>
     </li>
 
     <li>
@@ -2242,15 +2242,17 @@
 
   <dt>A list of <dfn>observed attributes</dfn></dt>
 
-  <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names. When any of the named attributes changes value, the <code>attributeChangedCallback</code> <a>custom element reaction</a> is
-  [=enqueue a custom element callback reaction|enqueued=].</dd>
+  <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names.
+   When any attribute in that list changes value, the <code>attributeChangedCallback</code>
+   <a>custom element reaction</a> is [=enqueue a custom element callback reaction|enqueued=].</dd>
 
   <dt>A collection of <dfn>lifecycle callbacks</dfn></dt>
 
-  <dd>A map, whose four keys are the strings "<code>connectedCallback</code>",
+  <dd>These callbacks are used to <a>invoke custom element reactions</a></dd>
+  <dd>The value must be a map, whose four keys are the strings "<code>connectedCallback</code>",
    "<code>disconnectedCallback</code>", "<code>adoptedCallback</code>", and
-   "<code>attributeChangedCallback</code>". The corresponding values are either a Web IDL {{Function}}
-  callback function type value, or null. By default the value of each entry is null.</dd>
+   "<code>attributeChangedCallback</code>". The values of each key are either a Web IDL
+    {{Function!!callback}}, or null. The default value of each entry is null.</dd>
 
   <dt>A <dfn>construction stack</dfn></dt>
 

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -13,6 +13,7 @@
   - noscript
   - template
   - canvas
+  - custom elements
 
 -->
 
@@ -2034,15 +2035,14 @@
   <code>CanvasRenderingContext2D</code> is bound to a new <{canvas}>, the bitmap is cleared
   and its flag reset.
 
-</section>
 <!-- start CEinsert @@ -->
 
 
 <section>
 <h4 id="custom-elements-core-concepts">Custom Elements</h4>
 
-  A <dfn>custom element</dfn> is an element whose {{constructor}} and <code>prototype</code> are defined by the author.
-  The author-supplied constructor function is called the <dfn>custom element constructor</dfn>.
+  A <dfn export>custom element</dfn> is an element whose {{constructor}} and <code>prototype</code> are defined by the author.
+  The author-supplied constructor function is called the <dfn export>custom element constructor</dfn>.
   Custom elements have the <a>custom element state</a> "<code>custom</code>".
 
   <p class="note">For the elements whose semantics are described in this specification, or in
@@ -2056,7 +2056,7 @@
 
 <h5 id="sec-autonomous-custom-elements">Autonomous custom elements</h4>
 
-    An <dfn>autonomous custom element</dfn> is a <a>custom element</a>
+    An <dfn export>autonomous custom element</dfn> is a <a>custom element</a>
     completely defined by the author. It extends {{HTMLElement}},
     and its <a>local name</a> is equal to its <a for="customElements">name</a>.</p>
 
@@ -2122,7 +2122,7 @@
 
  <h5 id="customized-built-in-elements">Customized built-in elements</h5>
 
-  A <dfn>customized built-in element</dfn> is a <a>custom element</a> that extends an existing element.
+  A <dfn export>customized built-in element</dfn> is a <a>custom element</a> that extends an existing element.
   A customized built-in element's <a>local name</a> is the name of the element it extends.
   Its <a for="customElements">name</a> is used as the <a>is value</a>, provided in the <{global/is}>
   attribute when it is used in markup.
@@ -2150,7 +2150,7 @@
 <section>
 <h4 id="requirement-for-all-custom-elements">Requirements for all custom elements</h4>
 
-  A <dfn id="valid-custom-element-name">valid custom element name</dfn> is a sequence of characters
+  A <dfn export>valid custom element name</dfn> is a sequence of characters
   <var>name</var> that matches the <a>PotentialCustomElementName</a> production,
   and is not one of the following:</p>
 
@@ -2169,13 +2169,13 @@
   </li>
 </ul>
 
-  The <dfn><code>PotentialCustomElementName</code></dfn> production is as follows:
+  The <dfn export><code>PotentialCustomElementName</code></dfn> production is as follows:
 <dl>
   <dt><a>PotentialCustomElementName</a> ::=</code></dt>
 
-  <dd><code>[a-z] (<a href="#prod-pcenchar">PCENChar</a>)* '-' (<a href="#prod-pcenchar">PCENChar</a>)*</code></dd>
+  <dd><code>[a-z] (<a>PCENChar</a>)* '-' (<a>PCENChar</a>)*</code></dd>
 
-  <dt><code><dfn id="prod-pcenchar">PCENChar</dfn> ::=</code></dt>
+  <dt><code><dfn>PCENChar</dfn> ::=</code></dt>
 
   <dd><code>"-" | "." | [0-9] | "_" | [a-z] | #xB7 | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x203F-#x2040] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]</code></dd>
 </dl>
@@ -2212,16 +2212,16 @@
 
 </div>
 
-  A <dfn>custom element definition</dfn> describes a <a>custom element</a> and consists of:</p>
+  A <dfn export>custom element definition</dfn> describes a <a>custom element</a> and consists of:</p>
 
 <dl>
-  <dt>A <dfn for="customElements">name</dfn></dt>
+  <dt>A <dfn export for="customElements">name</dfn></dt>
 
   <dd>
     A <a>valid custom element name</a>.
   </dd>
 
-  <dt>A <dfn for="customElements">local name</dfn></dt>
+  <dt>A <dfn export for="customElements">local name</dfn></dt>
 
   <dd>
     For <a>autonomous custom elements</a> this is the same as its <a for="customElements">name</a>.
@@ -2230,7 +2230,7 @@
     For <a>customized built-in elements</a> this is the name of the element it extends.
   </dd>
 
-  <dt>A <dfn id="concept-custom-element-definition-constructor">constructor</dfn></dt>
+  <dt>A <dfn export for="customElements">constructor</dfn></dt>
 
   <dd>
     A <a>custom element constructor</a> function.
@@ -2240,13 +2240,13 @@
 
   <dd>A JavaScript object</dd>
 
-  <dt>A list of <dfn>observed attributes</dfn></dt>
+  <dt>A list of <dfn export>observed attributes</dfn></dt>
 
   <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names.
    When any attribute in that list changes value, the <code>attributeChangedCallback</code>
    <a>custom element reaction</a> is [=enqueue a custom element callback reaction|enqueued=].</dd>
 
-  <dt>A collection of <dfn>lifecycle callbacks</dfn></dt>
+  <dt>A collection of <dfn export>lifecycle callbacks</dfn></dt>
 
   <dd>These callbacks are used to <a>invoke custom element reactions</a></dd>
   <dd>The value must be a map, whose four keys are the strings "<code>connectedCallback</code>",
@@ -2254,16 +2254,16 @@
    "<code>attributeChangedCallback</code>". The values of each key are either a Web IDL
     {{Function!!callback}}, or null. The default value of each entry is null.</dd>
 
-  <dt>A <dfn>construction stack</dfn></dt>
+  <dt>A <dfn export for="customElements">construction stack</dfn></dt>
 
   <dd>
     A list, initially empty, that is manipulated by the <a>upgrade an element</a> algorithm and the
     HTML element constructors. Each entry in the list is either an element or an
-    <dfn><i>already constructed</i> marker</dfn>.
+    <dfn export><i>already constructed</i> marker</dfn>.
   </dd>
 </dl>
 
-  To <dfn lt="looking up a custom element definition">look up a custom element definition</dfn>,
+  To <dfn export lt="looking up a custom element definition">look up a custom element definition</dfn>,
   given a <var>document</var>, <var>namespace</var>, <var>localName</var>, and <var>is</var>,
   perform the following steps.
   They will return either a <a>custom element definition</a> or null:</p>
@@ -2349,4 +2349,5 @@
 
   Some of these requirements are checked during [=create an element|element creation=],
   and failing to follow them will result in a custom element that cannot be instantiated by the parser or DOM APIs.</p>
+</section>
 </section>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2046,7 +2046,7 @@
   Custom elements have the <a>custom element state</a> "<code>custom</code>".
 
   <p class="note">For the elements whose semantics are described in this specification, or in
-  <a>other applicable specifications</a>, {{constructor}} and {{prototype}} are defined by the user agent.</p>
+  <a>other applicable specifications</a>, {{constructor}} and <a>prototype</a> are defined by the user agent.</p>
 
   There are two types of custom elements:
   :<a>autonomous custom Elements</a>
@@ -2261,8 +2261,9 @@
   </dd>
 </dl>
 
-  To <dfn>look up a custom element definition</dfn>, given a <var>document</var>,
-  <var>namespace</var>, <var>localName</var>, and <var>is</var>, perform the following steps.
+  To <dfn lt="looking up a custom element definition">look up a custom element definition</dfn>,
+  given a <var>document</var>, <var>namespace</var>, <var>localName</var>, and <var>is</var>,
+  perform the following steps.
   They will return either a <a>custom element definition</a> or null:</p>
 
 <ol>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2041,7 +2041,7 @@
 <section>
 <h4 id="custom-elements-core-concepts">Custom Elements</h4>
 
-  A <dfn>custom element</dfn> is an element whose {{constructor}} and {{prototype}} are defined by the author.
+  A <dfn>custom element</dfn> is an element whose {{constructor}} and <code>prototype</code> are defined by the author.
   The author-supplied constructor function is called the <dfn>custom element constructor</dfn>.
   Custom elements have the <a>custom element state</a> "<code>custom</code>".
 
@@ -2049,15 +2049,15 @@
   <a>other applicable specifications</a>, {{constructor}} and {{prototype}} are defined by the user agent.</p>
 
   There are two types of custom elements:
-  :<a>autonomous custom Elements
+  :<a>autonomous custom Elements</a>
   ::These are entirely author-defined, extending {{HTMLElement}}
-  :<a>customized built-in Elements
+  :<a>customized built-in Elements</a>
   ::These extend elements that are already defined. <span class="note">This is typically to inherit some functionality.</span>
 
-<h5 id="autonomous-custom-elements">Autonomous custom elements</h4>
+<h5 id="sec-autonomous-custom-elements">Autonomous custom elements</h4>
 
     An <dfn>autonomous custom element</dfn> is a <a>custom element</a>
-    completely defined by the author. It <a>extends</a> {{HTMLElement}},
+    completely defined by the author. It extends {{HTMLElement}},
     and its <a>local name</a> is equal to its <a for="customElements">name</a>.</p>
 
   <a>Autonomous custom elements</a> have the following element definition:
@@ -2122,7 +2122,7 @@
 
  <h5 id="customized-built-in-elements">Customized built-in elements</h5>
 
-  A <dfn>customized built-in element</dfn> is a <a>custom element</a> that <a>extends</a> an existing element.
+  A <dfn>customized built-in element</dfn> is a <a>custom element</a> that extends an existing element.
   A customized built-in element's <a>local name</a> is the name of the element it extends.
   Its <a for="customElements">name</a> is used as the <a>is value</a>, provided in the <{global/is}>
   attribute when it is used in markup.
@@ -2151,7 +2151,7 @@
 <h4 id="requirement-for-all-custom-elements">Requirements for all custom elements</h4>
 
   A <dfn id="valid-custom-element-name">valid custom element name</dfn> is a sequence of characters
-  <var>name</var> that matches the <code><a>PotentialCustomElementName</a></code> production,
+  <var>name</var> that matches the <a>PotentialCustomElementName</a> production,
   and is not one of the following:</p>
 
     <ul class="brief">
@@ -2169,7 +2169,7 @@
   </li>
 </ul>
 
-  The <dfn><code>PotentialCustomElementName</code> production</dfn> is as follows:
+  The <dfn><code>PotentialCustomElementName</code></dfn> production is as follows:
 <dl>
   <dt><a>PotentialCustomElementName</a> ::=</code></dt>
 
@@ -2242,7 +2242,7 @@
 
   <dt>A list of <dfn>observed attributes</dfn></dt>
 
-  <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names. When any of the named attributes changes value, the <a>attributeChangedCallback</a> <a>custom reaction</a> is
+  <dd>A <code>sequence&lt;DOMString&gt;</code> that is a list of attribute names. When any of the named attributes changes value, the <code>attributeChangedCallback</code> <a>custom element reaction</a> is
   [=enqueue a custom element callback reaction|enqueued=].</dd>
 
   <dt>A collection of <dfn>lifecycle callbacks</dfn></dt>
@@ -2256,7 +2256,7 @@
 
   <dd>
     A list, initially empty, that is manipulated by the <a>upgrade an element</a> algorithm and the
-    <a>HTML element constructors</a>. Each entry in the list is either an element or an
+    HTML element constructors. Each entry in the list is either an element or an
     <dfn><i>already constructed</i> marker</dfn>.
   </dd>
 </dl>
@@ -2312,7 +2312,7 @@
   </li>
 
   <li>
-    <p>The constructor must not use the {{document.write()}} or {{document.open()}} methods.</p>
+    <p>The constructor must not use the {{document.write()}} or {{Document/open()|document.open()}} methods.</p>
   </li>
 
   <li>
@@ -2324,7 +2324,7 @@
   <li>
     <p>The element must not gain any attributes or children.
     Doing so violates the expectations of consumers who use the {{createElement()}} or
-    {{(reateElementNS()}}</a></code> methods.</p>
+    {{createElementNS()}}</a></code> methods.</p>
   </li>
   </ul>
 

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2141,8 +2141,10 @@
   A <a>customized built-in element</a> has the same requirements for attributes as the element it extends.
   To add custom attribute-based behavior, use [=custom data attributes|data-*=] attributes.</p>
 
-  A <a>customized built-in element</a>'s <a>is value</a> is saved on the element when it is
-   <a>created</a>. So changing the value of the <{{global/is}}> attribute does not change the element's behaviour.
+  <p class="note">A <a>customized built-in element</a>'s <a>is value</a>
+   is saved on the element when it is [=create an element|created=].
+  This means changing the value of the <{global/is}> attribute after the element is
+  [=create an element|created=] does not change the element's behaviour.</p>
 
 </section>
 <section>

--- a/sections/semantics-scriptings.include
+++ b/sections/semantics-scriptings.include
@@ -2035,10 +2035,6 @@
   <code>CanvasRenderingContext2D</code> is bound to a new <{canvas}>, the bitmap is cleared
   and its flag reset.
 
-<!-- start CEinsert @@ -->
-
-
-<section>
 <h4 id="custom-elements-core-concepts">Custom Elements</h4>
 
   A <dfn export>custom element</dfn> is an element whose {{constructor}} and <code>prototype</code> are defined by the author.
@@ -2049,10 +2045,10 @@
   <a>other applicable specifications</a>, {{constructor}} and <a>prototype</a> are defined by the user agent.</p>
 
   There are two types of custom elements:
-  :<a>autonomous custom Elements</a>
-  ::These are entirely author-defined, extending {{HTMLElement}}
-  :<a>customized built-in Elements</a>
-  ::These extend elements that are already defined. <span class="note">This is typically to inherit some functionality.</span>
+  : <a>autonomous custom Elements</a>
+  :: These are entirely author-defined, extending {{HTMLElement}}
+  : <a>customized built-in Elements</a>
+  :: These extend elements that are already defined. <span class="note">This is typically to inherit some functionality.</span>
 
 <h5 id="sec-autonomous-custom-elements">Autonomous custom elements</h4>
 
@@ -2124,8 +2120,8 @@
 
   A <dfn export>customized built-in element</dfn> is a <a>custom element</a> that extends an existing element.
   A customized built-in element's <a>local name</a> is the name of the element it extends.
-  Its <a for="customElements">name</a> is used as the <a>is value</a>, provided in the <{global/is}>
-  attribute when it is used in markup.
+  Its <a for="customElements">name</a> is called the <dfn export>is value</dfn>: the value of
+  the <{global/is}> attribute when it is used in HTML.
 
   <div class="example">For example a <{button}> has pre-defined interaction behaviour,
       a <{tr}> already participates in the <a>table model</a>,
@@ -2146,8 +2142,6 @@
   This means changing the value of the <{global/is}> attribute after the element is
   [=create an element|created=] does not change the element's behaviour.</p>
 
-</section>
-<section>
 <h4 id="requirement-for-all-custom-elements">Requirements for all custom elements</h4>
 
   A <dfn export>valid custom element name</dfn> is a sequence of characters
@@ -2200,7 +2194,7 @@
     </li>
 
     <li>
-      <p>They can always be created with {{createElement()}} and {{createElementNS()}},
+      <p>They can always be created with {{Document/createElement()}} and {{Document/createElementNS()}},
       which have more restrictions than the parser.</p>
     </li>
 
@@ -2297,8 +2291,6 @@
     <p>Return null.</p>
   </li>
 </ol>
-</section>
-<section>
 <h4 id="custom-element-conformance">Requirements for custom element constructors</h4>
 
 <p>A <a>custom element constructor</a> must meet the following requirements:</p>
@@ -2315,7 +2307,7 @@
   </li>
 
   <li>
-    <p>The constructor must not use the {{document.write()}} or {{Document/open()|document.open()}} methods.</p>
+    <p>The constructor must not use the {{Document/write()|document.write()}} or {{Document/open()|document.open()}} methods.</p>
   </li>
 
   <li>
@@ -2326,8 +2318,8 @@
 
   <li>
     <p>The element must not gain any attributes or children.
-    Doing so violates the expectations of consumers who use the {{createElement()}} or
-    {{createElementNS()}}</a></code> methods.</p>
+    Doing so violates the expectations of consumers who use the {{Document/createElement()}} or
+    {{Document/createElementNS()}}</a></code> methods.</p>
   </li>
   </ul>
 
@@ -2349,5 +2341,4 @@
 
   Some of these requirements are checked during [=create an element|element creation=],
   and failing to follow them will result in a custom element that cannot be instantiated by the parser or DOM APIs.</p>
-</section>
 </section>

--- a/single-page.bs
+++ b/single-page.bs
@@ -176,8 +176,6 @@ url: https://w3c.github.io/using-aria/; type: dfn; spec: using-aria;
     text: Recommendations Table
 url: https://www.w3.org/TR/accname-aam/#dfn-accessible-name; type: dfn;
     text: accessible name
-url: https://wiki.whatwg.org/wiki/PragmaExtensions#content; type: dfn;
-    text: WHATWG Wiki PragmaExtensions page
 url: https://www.w3.org/TR/WCAG20/#text-altdef; type: dfn;
     text: Text alternatives
 url: https://www.w3.org/TR/rdfa-lite/#h-document-conformance; type: dfn;
@@ -492,6 +490,8 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
             text: shadow including descendant
     text: represented by the collection; type: dfn
     text: ShadowRoot; type: interface
+    url: node-remove; type: dfn
+        text: becomes disconnected
 
 # ************************* DOM PARSING AND SERIALIZATION ***********************************
 
@@ -526,6 +526,9 @@ urlPrefix: https://tc39.github.io/ecma262/#; type: dfn; spec: ECMA-262
     url: current-realm
         text: current Realm Record
         text: current Realm
+    urlPrefix: terms-and-definitions-
+        text: prototype
+    text: active function object
     text: constructor
     text: Directive Prologue
     text: early error; url: early-error-rule
@@ -1097,7 +1100,6 @@ spec:ecma-262;
     "href": "https://www.w3.org/TR/referrer-policy",
     "publisher": "W3C"
   }
-
 }
 </pre>
 

--- a/single-page.bs
+++ b/single-page.bs
@@ -129,6 +129,8 @@ url: https://www.w3.org/TR/xml/#sec-entity-decl; type:dfn; spec: xml;
     text: entity declarations
 url: https://www.w3.org/TR/xml/#dt-entref; type:dfn; spec: xml;
     text: entity references
+url: https://www.w3.org/TR/xml/#sec-notation; type:dfn; spec: xml;
+    text: EBNF notation
 url: https://www.w3.org/TR/websockets/#the-websocket-interface; type: interface; spec: WebSockets;
     text: WebSocket
 urlPrefix: https://www.w3.org/TR/hr-time/#dom-; type: interface; spec: hr-time-2;
@@ -443,21 +445,6 @@ urlPrefix: https://drafts.csswg.org/cssom/#; type: dfn; spec: CSSOM;
         text: preferred style sheet set
     text: Serializing a CSS value; url: serializing-css-values
 
-# ******************************** CUSTOM ELEMENTS ******************************************
-
-urlPrefix: http://www.w3.org/TR/custom-elements/#; type: dfn; spec: CUSTOM-ELEMENTS;
-    text: autonomous custom element
-    text: current element queue
-    text: custom element constructor
-    text: custom element reactions stack
-    text: customized built-in element
-    text: element queue
-    text: enqueue a custom element callback reaction
-    text: invoke custom element reactions
-    text: looking up a custom element definition; url: look-up-a-custom-element-definition
-    text: valid custom element name
-    text: upgrades
-
 # ************************************ DOM **************************************************
 
 urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
@@ -474,6 +461,7 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
         text: document url
         text: element attribute
         text: event listener
+        text: shadow root
         url: id
             text: id
             text: unique identifier
@@ -497,7 +485,13 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
         text: range start
     urlPrefix: interface-; type: interface
         text: Element
+    urlPrefix: shadow-; type: dfn
+        url: including
+            text: shadow including root
+        url: descendant
+            text: shadow including descendant
     text: represented by the collection; type: dfn
+    text: ShadowRoot; type: interface
 
 # ************************* DOM PARSING AND SERIALIZATION ***********************************
 
@@ -532,6 +526,7 @@ urlPrefix: https://tc39.github.io/ecma262/#; type: dfn; spec: ECMA-262
     url: current-realm
         text: current Realm Record
         text: current Realm
+    text: constructor
     text: Directive Prologue
     text: early error; url: early-error-rule
     urlPrefix: prod-
@@ -552,6 +547,7 @@ urlPrefix: https://tc39.github.io/ecma262/#; type: dfn; spec: ECMA-262
             text: JavaScript realm
             text: Realm
         text: Construct
+        text: Constructor
         text: CopyDataBlockBytes
         text: CreateDataProperty
         text: CreateByteDataBlock
@@ -1101,6 +1097,7 @@ spec:ecma-262;
     "href": "https://www.w3.org/TR/referrer-policy",
     "publisher": "W3C"
   }
+
 }
 </pre>
 

--- a/single-page.bs
+++ b/single-page.bs
@@ -453,13 +453,18 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
         text: collection
         url: create-element
             text: creating an element
+            text: create an element
         urlPrefix: document-
             text: document's character encoding; url: encoding
             text: content type
+        urlPrefix: element-
+            text: custom
+            text: custom element state
+            text: defined
         text: document url
         text: element attribute
+        text: element interface
         text: event listener
-        text: shadow root
         url: id
             text: id
             text: unique identifier
@@ -470,6 +475,7 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
             text: clone
             url: clone;
                 text: cloning
+            text: document
             text: insert
             text: pre-insert
             text: remove
@@ -481,17 +487,19 @@ urlPrefix: https://www.w3.org/TR/dom/#; spec: DOM
         text: range bp
         text: range end
         text: range start
+        text: shadow root
+        text: shadow including descendants
+        text: shadow including root
+        text: shadow including tree order
     urlPrefix: interface-; type: interface
         text: Element
-    urlPrefix: shadow-; type: dfn
-        url: including
-            text: shadow including root
-        url: descendant
-            text: shadow including descendant
     text: represented by the collection; type: dfn
     text: ShadowRoot; type: interface
     url: node-remove; type: dfn
         text: becomes disconnected
+    url: connected; type: dfn
+        text: becomes connected
+        text: connected
 
 # ************************* DOM PARSING AND SERIALIZATION ***********************************
 


### PR DESCRIPTION
This currently adds both autonomous custom elements, which are implemented in Webkit, Blink and Firefox, and customised built-in elements, apparently implemented in both Blink and Firefox.

See #1229, #1277 (This does currently include `is=`), #1337 (this PR restricts attributes to `data-*`)

This is pretty much ready for review, but not merge. It probably has linking errors, may have incomplete statements and other text bugs.

I will note the need for examples as a separate issue.