### PR TITLE
1313 update object example prose

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4925,18 +4925,28 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   <a>valid browsing context name</a>. The value is used to name the <a>nested browsing context</a> created for the object, if applicable.
 
   <div class="example">
-  This allows links to use the object's <a>browsing context</a> as a target:
+    This allows links to use the object's <a>browsing context</a> as a target:
 
-  Clicking the link "Check out the new icon" in the example below would cause the new.svg to be loaded in place of the original old.svg.
+    Clicking the link "Check out the new icon" in the example below would cause the new.svg to
+    be loaded in place of the original old.svg.
 
-  <xmp>
-<p><object data="old.svg" name="svgobject">A boring icon</object></p>
+    <xmp highlight="html">
+      <p>
+        <object data="old.svg" name="svgobject">A boring icon</object>
+      </p>
 
-<p><a href="new.svg" target="svgobject">Check out the new icon</a>!</p>
-  </xmp>
+      <p>
+        <a href="new.svg" target="svgobject">Check out the new icon</a>!
+      </p>
+    </xmp>
 
-  <p class="warning">If a <a>nested browsing context</a> is not created, e.g. for security reasons or due to incorrect implementation of the <{object/name3}> attribute,
-the <code>target</code> attribute in this example will instead <a>create a new browsing context</a> - typically a new tab - whose <a>browsing context name</a> is the attribute's value, and the resource that the link references will be loaded there.</p>
+    <p class="warning">
+      If a <a>nested browsing context</a> is not created, e.g. for security reasons or due to
+      incorrect implementation of the <{object/name3}> attribute, the <code>target</code> attribute
+      in this example will instead <a>create a new browsing context</a> - typically a new tab -
+      whose <a>browsing context name</a> is the attribute's value, and the resource that the link
+      references will be loaded there.
+    </p>
 
   </div>
 
@@ -4979,14 +4989,14 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
     <li>
 
-    If the user has indicated a preference that this <{object}> element's <a>fallback
-    content</a> be shown instead of the element's usual behavior, then jump to the step below
-    labeled <i>fallback</i>.
+    If the user has indicated a preference that this <{object}> element's
+    <a>fallback content</a> be shown instead of the element's usual behavior, then jump to
+    the step below labeled <i>fallback</i>.
 
     <p class="note">
-    For example, a user could ask for the element's <a>fallback content</a> to
-    be shown because that content uses a format that the user finds more accessible.
-  </p>
+      For example, a user could ask for the element's <a>fallback content</a> to
+      be shown because that content uses a format that the user finds more accessible.
+    </p>
 
     </li>
 
@@ -4998,8 +5008,9 @@ the <code>target</code> attribute in this example will instead <a>create a new b
     <a>browsing context</a>, or if the element's <a>node document</a> is not <a>fully
     active</a>, or if the element is still in the <a>stack of open elements</a> of an
     <a>HTML parser</a> or <a>XML parser</a>, or if the element is not <a>being rendered</a>, or if the
-    <a for="/">Should element be blocked <i lang="la">a priori</i> by Content Security Policy?</a> algorithm
-     returns "Blocked" when executed on the element, then jump to the step below labeled fallback. [[!CSP3]].
+    <a for="/">Should element be blocked <i lang="la">a priori</i> by Content Security Policy?</a>
+    algorithm returns "Blocked" when executed on the element, then jump to the step below labeled
+    <i>fallback</i>. [[!CSP3]].
 
     </li>
 
@@ -5016,8 +5027,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
     </li>
 
-    <li>If the <code>data</code> attribute is present and its value is
-    not the empty string, then:
+    <li>If the <code>data</code> attribute is present and its value is not the empty string, then:
 
     <ol>
 
@@ -5097,10 +5107,12 @@ the <code>target</code> attribute in this example will instead <a>create a new b
         <a>the resource's Content-Type metadata</a>, and jump to the step below
         labeled <i>handler</i>.
 
-        <p class="warning">This can introduce a vulnerability, wherein a site is trying to embed a
-        resource that uses a particular plugin, but the remote site overrides that and instead
-        furnishes the user agent with a resource that triggers a different plugin with different
-        security characteristics. </p>
+        <p class="warning">
+          This can introduce a vulnerability, wherein a site is trying to embed a
+          resource that uses a particular plugin, but the remote site overrides that and instead
+          furnishes the user agent with a resource that triggers a different plugin with different
+          security characteristics.
+        </p>
 
         </li>
 
@@ -5194,7 +5206,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
             <li>
 
             If there is a <code>type</code> attribute present on the <{object}> element, then
-            let  the <var>tentative type</var> be the type specified in that <code>type</code>
+            let the <var>tentative type</var> be the type specified in that <code>type</code>
             attribute.
 
             Otherwise, let <var>tentative type</var> be the <a>computed type of the resource</a>.
@@ -5335,17 +5347,21 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
     </li>
 
-    <li>If the <code>data</code> attribute is absent but the <code>type</code> attribute is present, and the user agent can find a
-    <a>plugin</a> suitable according to the value of the <code>type</code> attribute, and either plugins aren't being sandboxed or the <a>plugin</a> can be
-    <a>secured</a>, then that <a>plugin</a> <a>should be used</a>. If these conditions cannot be met, or if the
-    <a>plugin</a> reports an error, jump to the step below labeled <i>fallback</i>. Otherwise
-    abort these steps; once the plugin is completely loaded, <a>queue a task</a> to <a>fire
-    a simple event</a> named <code>load</code> at the element.</li>
+    <li>
+      If the <code>data</code> attribute is absent but the <code>type</code> attribute is present,
+      and the user agent can find a <a>plugin</a> suitable according to the value of the
+      <code>type</code> attribute, and either plugins aren't being sandboxed or the <a>plugin</a>
+      can be <a>secured</a>, then that <a>plugin</a> <a>should be used</a>. If these conditions
+      cannot be met, or if the <a>plugin</a> reports an error, jump to the step below labeled
+      <i>fallback</i>. Otherwise abort these steps; once the plugin is completely loaded,
+      <a>queue a task</a> to <a>fire a simple event</a> named <code>load</code> at the element.
+    </li>
 
-    <li><i>Fallback</i>: The <{object}> element <a>represents</a> the element's
-    children, ignoring any leading <{param}> element children. This is the element's
-    <a>fallback content</a>. If the element has an instantiated <a>plugin</a>, then
-    unload it.</li>
+    <li>
+      <i>Fallback</i>: The <{object}> element <a>represents</a> the element's
+      children, ignoring any leading <{param}> element children. This is the element's
+      <a>fallback content</a>. If the element has an instantiated <a>plugin</a>, then unload it.
+    </li>
 
   </ol>
 
@@ -5365,25 +5381,27 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   the <{object}> element's <a>node document</a>'s <a>active sandboxing flag
   set</a>.
 
-  Due to the algorithm above, the contents of <{object}> elements act as <a>fallback
-  content</a>, used only when referenced resources can't be shown (e.g., because it returned a 404
-  error). This allows multiple <{object}> elements to be nested inside each other,
+  Due to the algorithm above, the contents of <{object}> elements act as
+  <a>fallback content</a>, used only when referenced resources can't be shown (e.g., because it
+  returned a 404 error). This allows multiple <{object}> elements to be nested inside each other,
   targeting multiple user agents with different capabilities, with the user agent picking the first
   one it supports.
 
   When an <{object}> element represents a <a>nested browsing context</a>: if the
   <{object}> element's <a>nested browsing context</a>'s <a>active document</a>
-  is not [=ready for post-load tasks=], and when anything is <a>delaying the load event</a> of the <{object}> element's <a>browsing context</a>'s <a>active document</a>, and when the <{object}> element's
-  <a>browsing context</a> is in the <a>delaying <code>load</code>
-  events mode</a>, the <code>object</code> must <a>delay the load event</a> of its
-  document.
+  is not [=ready for post-load tasks=], and when anything is <a>delaying the load event</a> of
+  the <{object}> element's <a>browsing context</a>'s <a>active document</a>, and when the
+  <{object}> element's <a>browsing context</a> is in the <a>delaying <code>load</code>
+  events mode</a>, the <code>object</code> must <a>delay the load event</a> of its document.
 
   The <a>task source</a> for the <a>tasks</a> mentioned in this
   section is the <a>DOM manipulation task source</a>.
 
   Whenever the <code>name</code> attribute is set, if the
-  <{object}> element has a nested <a>browsing context</a>, its <a lt="browsing context name">name</a> must be changed to the new value. If the attribute is removed, if the
-  <{object}> element has a <a>browsing context</a>, the <a>browsing context name</a> must be set to the empty string.
+  <{object}> element has a nested <a>browsing context</a>, its
+  <a lt="browsing context name">name</a> must be changed to the new value. If the attribute is
+  removed, if the <{object}> element has a <a>browsing context</a>, the
+  <a>browsing context name</a> must be set to the empty string.
 
   The <{object/form}> attribute is used to explicitly associate the
   <{object}> element with its <a>form owner</a>.
@@ -12277,9 +12295,9 @@ red:89
 
   <p class="note">
     In user agents that do not support images, or that have images disabled,
-  <{object}> elements cannot represent images, and thus this section never applies (the
-  <a>fallback content</a> is shown instead). The following steps therefore only apply to
-  <{img}> elements.
+    <{object}> elements cannot represent images, and thus this section never applies (the
+    <a>fallback content</a> is shown instead). The following steps therefore only apply to
+    <{img}> elements.
   </p>
 
   <ol>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -273,10 +273,11 @@
         </h1>
       </xmp>
 
-      The user agent will calculate the effective pixel density of each image
-      from the specified <code>w</code> descriptors and the specified rendered size in the <code>sizes</code> attribute.
-      It can then choose any of the given resources depending on
-      the user's screen's pixel density, zoom level, and possibly other factors such as the user's network conditions.
+      The user agent will calculate the effective pixel density of each image from the specified
+      <code>w</code> descriptors and the specified rendered size in the <code>sizes</code>
+      attribute.
+      It can then choose any of the given resources depending on the user's screen's pixel
+      density, zoom level, and possibly other factors such as the user's network conditions.
 
       If the user's screen is 320 CSS pixels wide, this is equivalent to specifying
       <code>wolf-400.jpg 1.25x, wolf-800.jpg 2.5x, wolf-1600.jpg 5x</code>.
@@ -328,8 +329,8 @@
       so the image size, for the purpose of resource selection, is <code>16em</code> (half the <a>viewport</a> width).
       Notice that the slightly wider <a>viewport</a> results in a smaller image because of the different layout.
 
-      The user agent can then calculate the effective pixel density and choose an appropriate resource
-      similarly to the previous example.
+      The user agent can then calculate the effective pixel density and choose an appropriate
+      resource similarly to the previous example.
 
     </div>
 
@@ -5027,8 +5028,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
       <li><a>Parse</a> the [=url/URL=] specified by the <code>data</code> attribute, relative to the element.</li>
 
-      <li>If that failed, <a>fire a simple event</a> named <code>error</code> at the element, then jump to the step below labeled
-      <i>fallback</i>.</li>
+      <li>If that failed, <a>fire a simple event</a> named <code>error</code> at the element,
+      then jump to the step below labeled <i>fallback</i>.</li>
 
       <li>Let <var>request</var> be a new <a>request</a> whose
       [=url/URL=] is the <a>resulting URL string</a>,
@@ -5041,7 +5042,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
       <a>Fetch</a> <var>request</var>.
 
       Fetching the resource must <a>delay the load event</a> of the element's <a>node
-      document</a> until the <a>task</a> that is <a>queued</a> by the <a>networking task source</a> once the resource has been
+      document</a> until the <a>task</a> that is <a>queued</a> by the
+      <a>networking task source</a> once the resource has been
       fetched (defined next) has been run.
       </li>
 
@@ -5050,8 +5052,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
       the step below labeled <i>fallback</i>. The <a>task</a> that is
       <a>queued</a> by the <a>networking task source</a> once the
       resource is available must restart this algorithm from this step. Resources can load
-      incrementally; user agents may opt to consider a resource "available" whenever enough data has
-      been obtained to begin processing the resource.</li>
+      incrementally; user agents may opt to consider a resource "available" whenever enough data
+      has been obtained to begin processing the resource.</li>
 
       <li>If the load failed (e.g., there was an HTTP 404 error, there was a DNS error), <a>fire
       a simple event</a> named <code>error</code> at the element, then jump to
@@ -5082,8 +5084,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         <li>
 
-        If the <{object}> element has a <code>typemustmatch</code> attribute, jump to the step below
-        labeled <i>handler</i>.
+        If the <{object}> element has a <code>typemustmatch</code> attribute, jump to the step
+        below labeled <i>handler</i>.
 
         </li>
 
@@ -5091,7 +5093,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         If the user agent is configured to strictly obey Content-Type headers for this resource,
         and the resource has <a>associated Content-Type metadata</a>,
-        then let the <var>resource type</var> be the type specified in <a>the resource's Content-Type metadata</a>, and jump to the step below
+        then let the <var>resource type</var> be the type specified in
+        <a>the resource's Content-Type metadata</a>, and jump to the step below
         labeled <i>handler</i>.
 
         <p class="warning">This can introduce a vulnerability, wherein a site is trying to embed a
@@ -5103,22 +5106,20 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         <li>
 
-        If there is a <code>type</code> attribute present on the
-        <{object}> element, and that attribute's value is not a type that the user agent
-        supports, but it <em>is</em> a type that a <a>plugin</a> supports, then let the <var>resource type</var> be the type specified in that <code>type</code> attribute, and jump to the step below labeled
-        <i>handler</i>.
+        If there is a <code>type</code> attribute present on the <{object}> element, and that
+        attribute's value is not a type that the user agent supports, but it <em>is</em> a type
+        that a <a>plugin</a> supports, then let the <var>resource type</var> be the type specified
+        in that <code>type</code> attribute, and jump to the step below labeled <i>handler</i>.
 
         </li>
 
         <li>
 
-        Run the appropriate set of steps from the following
-        list:
+        Run the appropriate set of steps from the following list:
 
         <dl class="switch">
 
-          <dt>If the resource has <a>associated Content-Type
-          metadata</a></dt>
+          <dt>If the resource has <a>associated Content-Type metadata</a></dt>
 
           <dd>
 
@@ -5132,10 +5133,10 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
             <li>
 
-            If the type specified in <a>the resource's Content-Type
-            metadata</a> is "<code>text/plain</code>", and the result of applying the <a>rules for distinguishing if a resource is
-            text or binary</a> to the resource is that the resource is not
-            <code>text/plain</code>, then set <var>binary</var> to true.
+            If the type specified in <a>the resource's Content-Type metadata</a> is
+            "<code>text/plain</code>", and the result of applying the
+            <a>rules for distinguishing if a resource is text or binary</a> to the resource is
+            that the resource is not <code>text/plain</code>, then set <var>binary</var> to true.
 
             </li>
 
@@ -5156,9 +5157,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
             <li>
 
-            If there is a <code>type</code> attribute present on the
-            <{object}> element, and its value is not <code>application/octet-stream</code>,
-            then run the following steps:
+            If there is a <code>type</code> attribute present on the <{object}> element, and its
+            value is not <code>application/octet-stream</code>, then run the following steps:
 
             <ol>
 
@@ -5193,9 +5193,9 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
             <li>
 
-            If there is a <code>type</code> attribute present on the
-            <{object}> element, then let the <var>tentative type</var> be the type
-            specified in that <code>type</code> attribute.
+            If there is a <code>type</code> attribute present on the <{object}> element, then
+            let  the <var>tentative type</var> be the type specified in that <code>type</code>
+            attribute.
 
             Otherwise, let <var>tentative type</var> be the <a>computed type of the resource</a>.
 
@@ -5224,18 +5224,20 @@ the <code>target</code> attribute in this example will instead <a>create a new b
         component matches a pattern that a <a>plugin</a> supports, then let
         <var>resource type</var> be the type that the plugin can handle.
 
-        <p class="example">For example, a plugin might say that it can handle resources with <a>path</a> components that end with the four character string
-        "<code>.swf</code>".</p>
+        <p class="example">
+          For example, a plugin might say that it can handle resources with
+          <a>path</a> components that end with the four character string "<code>.swf</code>".
+        </p>
 
         </li>
 
       </ol>
 
       <p class="note">
-    It is possible for this step to finish, or for one of the substeps above to
-      jump straight to the next step, with <var>resource type</var> still being unknown. In
-      both cases, the next step will trigger fallback.
-  </p>
+        It is possible for this step to finish, or for one of the substeps above to
+        jump straight to the next step, with <var>resource type</var> still being unknown. In
+        both cases, the next step will trigger fallback.
+      </p>
 
       </li>
 
@@ -5249,8 +5251,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         <dd>
 
-        If plugins are being sandboxed and the plugin that
-        supports <var>resource type</var> cannot be <a>secured</a>, jump to the step below labeled <i>fallback</i>.
+        If plugins are being sandboxed and the plugin that supports <var>resource type</var>
+        cannot be <a>secured</a>, jump to the step below labeled <i>fallback</i>.
 
         Otherwise, the user agent should use the plugin that supports
         <var>resource type</var> and pass the content of the resource to that
@@ -5266,16 +5268,17 @@ the <code>target</code> attribute in this example will instead <a>create a new b
         The <{object}> element must be associated with a newly created
         <a>nested browsing context</a>, if it does not already have one.
 
-        If the [=url/URL=] of the given resource is not <code>about:blank</code>, the
-        element's <a>nested browsing context</a> must then be <a>navigated</a> to that resource, with
+        If the [=url/URL=] of the given resource is not <code>about:blank</code>, the element's
+        <a>nested browsing context</a> must then be <a>navigated</a> to that resource, with
         <a>replacement enabled</a>, and with the <{object}> element's <a>node document</a>'s
-        <a>browsing context</a> as the <a>source browsing context</a>. (The <code>data</code> attribute of the <{object}> element doesn't
-        get updated if the browsing context gets further navigated to other locations.)
+        <a>browsing context</a> as the <a>source browsing context</a>. (The <code>data</code>
+        attribute of the <{object}> element doesn't get updated if the browsing context gets
+        further navigated to other locations.)
 
         If the [=url/URL=] of the given resource <em>is</em> <code>about:blank</code>, then,
         instead, the user agent must <a>queue a task</a> to <a>fire a simple event</a>
-        named <code>load</code> at the <{object}> element. <span class="note">No <code>load</code> event is fired at the
-        <code>about:blank</code> document itself.</span>
+        named <code>load</code> at the <{object}> element.
+        <span class="note">No <code>load</code> event is fired at the <code>about:blank</code> document itself.</span>
 
         The <{object}> element <a>represents</a> the <a>nested browsing context</a>.
 
@@ -5289,8 +5292,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         <dd>
 
-        Apply the <a>image sniffing</a> rules to
-        determine the type of the image.
+        Apply the <a>image sniffing</a> rules to determine the type of the image.
 
         The <{object}> element <a>represents</a> the specified image. The image is
         not a <a>nested browsing context</a>.
@@ -5304,13 +5306,13 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
         <dd>
 
-        The given <var>resource type</var> is not supported. Jump to the step below
-        labeled <i>fallback</i>.
+          The given <var>resource type</var> is not supported. Jump to the step below
+          labeled <i>fallback</i>.
 
-        <p class="note">
-    If the previous step ended with the <var>resource type</var> being
-        unknown, this is the case that is triggered.
-  </p>
+          <p class="note">
+            If the previous step ended with the <var>resource type</var> being
+            unknown, this is the case that is triggered.
+          </p>
 
         </dd>
 
@@ -5318,14 +5320,14 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
       </li>
 
-      <li>The element's contents are not part of what the <{object}> element
-      represents.
+      <li>The element's contents are not part of what the <{object}> element represents.
 
-      </li><li>
+      </li>
+
+      <li>
 
       Abort these steps. Once the resource is completely loaded, <a>queue a task</a> to
-      <a>fire a simple event</a> named <code>load</code> at the
-      element.
+      <a>fire a simple event</a> named <code>load</code> at the element.
 
       </li>
 
@@ -5409,16 +5411,17 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   it has one; otherwise, it must return null.
 
   The {{HTMLObjectElement/willValidate}}, {{HTMLObjectElement/validity}}, and
-  {{HTMLObjectElement/validationMessage}} attributes, and the {{HTMLObjectElement/checkValidity()}},
-  {{HTMLObjectElement/reportValidity()}}, and {{HTMLObjectElement/setCustomValidity()}} methods, are
-  part of the <a>constraint validation API</a>. The {{HTMLObjectElement/form}} IDL attribute is part
+  {{HTMLObjectElement/validationMessage}} attributes, and the
+  {{HTMLObjectElement/checkValidity()}}, {{HTMLObjectElement/reportValidity()}}, and
+  {{HTMLObjectElement/setCustomValidity()}} methods, are part of the
+  <a>constraint validation API</a>. The {{HTMLObjectElement/form}} IDL attribute is part
   of the element's forms API.
 
-  All <{object}> elements have a <dfn for="object">legacy caller
-  operation</dfn>. If the <{object}> element has an instantiated <a>plugin</a> that
-  supports a scriptable interface that defines a legacy caller operation, then that must be the
-  behavior of the object's legacy caller operation. Otherwise, the object's legacy caller operation
-  must be to throw a {{NotSupportedError}} exception.
+  All <{object}> elements have a <dfn for="object">legacy caller operation</dfn>. If the
+  <{object}> element has an instantiated <a>plugin</a> that supports a scriptable interface that
+  defines a legacy caller operation, then that must be the behavior of the object's legacy caller
+  operation. Otherwise, the object's legacy caller operation must be to throw a
+  {{NotSupportedError}} exception.
 
   <div class="example">
     In the following example, a Java applet is embedded in a page using the <code>object</code>
@@ -5440,8 +5443,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   </div>
 
   <div class="example">
-    In this example, an HTML page is embedded in another using the <code>object</code>
-    element.
+    In this example, an HTML page is embedded in another using the <code>object</code> element.
 
     <xmp highlight="html">
       <figure>
@@ -5454,8 +5456,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
   <div class="example">
     The following example shows how a plugin can be used in HTML (in this case the Flash plugin,
-    to show a video file). Fallback is provided for users who do not have Flash enabled, in this case
-    using the <{video}> element to show the video for those using user agents that support
+    to show a video file). A fallback is provided for users who do not have Flash enabled, in this
+    case using the <{video}> element to show the video for those using user agents that support
     <{video}>, and finally providing a link to the video for those who have neither Flash
     nor a <code>video</code>-capable browser.
 
@@ -5606,8 +5608,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
     </dd>
   </dl>
 
-  A <{video}> element is used for playing videos or movies, and audio files with
-  captions.
+  A <{video}> element is used for playing videos or movies, and audio files with captions.
 
   Content may be provided inside the <{video}> element. User agents
   should not show this content to the user; it is intended for older Web browsers which do
@@ -5615,22 +5616,23 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   users of these older browsers informing them of how to access the video contents.
 
   <p class="note">
-  In particular, this content is not intended to address accessibility concerns. To
-  make video content accessible to people with disabilities, a variety of features are available.
-  Captions and sign language tracks can be embedded in the video stream, or as external files using the
-  <{track}> element. Audio descriptions can be provided, either as a separate track embedded in the video
-  stream, or by referencing a <a>WebVTT file</a> with the <{track}> element that the user agent can present
-  as synthesized speech. WebVTT can also be used to provide chapter titles. For
-  users who would rather not use a media element at all, transcripts or other textual alternatives
-  can be provided by simply linking to them in the prose near the <{video}> element. [[WEBVTT]]
+    In particular, this content is not intended to address accessibility concerns. To make video
+    content accessible to people with disabilities, a variety of features are available.
+    Captions and sign language tracks can be embedded in the video stream, or as external files
+    using the <{track}> element. Audio descriptions can be provided, either as a separate track
+    embedded in the video stream, or by referencing a <a>WebVTT file</a> with the <{track}>
+    element that the user agent can present as synthesized speech. WebVTT can also be used to
+    provide chapter titles. For users who would rather not use a media element at all, transcripts
+    or other textual alternatives can be provided by simply linking to them in the prose near the
+    <{video}> element. [[WEBVTT]]
   </p>
 
-  The <{video}> element is a <a>media element</a> whose <a>media data</a> is
-  ostensibly video data, possibly with associated audio data.
+  The <{video}> element is a <a>media element</a> whose <a>media data</a> is ostensibly video
+  data, possibly with associated audio data.
 
-  The <code>src</code>, <code>preload</code>,
-  <code>autoplay</code>, <code>loop</code>, <code>muted</code>, and <{video/controls}>
-  attributes are the attributes common to all media elements.
+  The <code>src</code>, <code>preload</code>, <code>autoplay</code>, <code>loop</code>,
+  <code>muted</code>, and <{video/controls}> attributes are the attributes common to all
+  media elements.
 
   The <dfn element-attr for="video"><code>poster</code></dfn> content attribute gives the address of an
   image file that the user agent can show while no video data is available. The attribute, if
@@ -5650,8 +5652,8 @@ the <code>target</code> attribute in this example will instead <a>create a new b
     or if the attribute is absent, then there is no <a>poster frame</a>; abort these
     steps.</li>
 
-    <li><a>Parse</a> the <code>poster</code> attribute's value relative to the element. If this fails,
-    then there is no <a>poster frame</a>; abort these steps.</li>
+    <li><a>Parse</a> the <code>poster</code> attribute's value relative to the element. If this
+    fails, then there is no <a>poster frame</a>; abort these steps.</li>
 
     <li>Let <var>request</var> be a new <a>request</a> whose
     [=url/URL=] is the <a>resulting URL string</a>,
@@ -5668,21 +5670,20 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   </ol>
 
   <p class="note">
-    The image given by the <code>poster</code> attribute,
-  the <i>poster frame</i>, is intended to be a representative frame of the
-  video (typically one of the first non-blank frames) that gives the user an idea of what the video
-  is like.
+    The image given by the <code>poster</code> attribute, the <i>poster frame</i>, is intended to
+    be a representative frame of the video (typically one of the first non-blank frames) that
+    gives the user an idea of what the video is like.
   </p>
 
   <hr />
 
-  A <{video}> element represents what is given for the first matching condition in the
-  list below:
+  A <{video}> element represents what is given for the first matching condition in the list below:
 
   <dl class="switch">
 
-    <dt>When no video data is available (the element's <code>readyState</code> attribute is either <code>HAVE_NOTHING</code>, or <code>HAVE_METADATA</code> but no video data has yet been obtained at
-    all, or the element's <code>readyState</code> attribute is any
+    <dt>When no video data is available (the element's <code>readyState</code> attribute is
+    either <code>HAVE_NOTHING</code>, or <code>HAVE_METADATA</code> but no video data has yet been
+    obtained at all, or the element's <code>readyState</code> attribute is any
     subsequent value but the <a>media resource</a> does not have a video channel)</dt>
 
     <dd>The <{video}> element <a>represents</a> its <a>poster frame</a>, if any,
@@ -5721,15 +5722,16 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
   </dl>
 
-  Frames of video must be obtained from the video track that was <a>selected</a> when the <a>event loop</a> last reached
-  step 1.
+  Frames of video must be obtained from the video track that was <a>selected</a> when the
+  <a>event loop</a> last reached step 1.
 
   <p class="note">
     Which frame in a video stream corresponds to a particular playback position is
-  defined by the video stream's format.
+    defined by the video stream's format.
   </p>
 
-  The <{video}> element also <a>represents</a> any <a>text track cues</a> whose <a>text track cue active flag</a> is set and whose
+  The <{video}> element also <a>represents</a> any <a>text track cues</a> whose
+  <a>text track cue active flag</a> is set and whose
   <a>text track</a> is in the <a mode for="track">showing</a> mode, and any
   audio from the <a>media resource</a>, at the <a>current playback position</a>.
 
@@ -5738,11 +5740,11 @@ the <code>target</code> attribute in this example will instead <a>create a new b
   media volume</a>. The user agent must play the audio from audio tracks that were enabled when the <a>event loop</a> last reached step 1.
 
   In addition to the above, the user agent may provide messages to the user (such as "buffering",
-  "no video loaded", "error", or more detailed information) by overlaying text or icons on the video
-  or other areas of the element's playback area, or in another appropriate manner.
+  "no video loaded", "error", or more detailed information) by overlaying text or icons on the
+  video or other areas of the element's playback area, or in another appropriate manner.
 
-  User agents that cannot render the video may instead make the element <a>represent</a> a link to an external video playback utility or to the video
-  data itself.
+  User agents that cannot render the video may instead make the element <a>represent</a> a link
+  to an external video playback utility or to the video data itself.
 
   When a <{video}> element's <a>media resource</a> has a video channel, the
   element provides a <a>paint source</a> whose width is the <a>media resource</a>'s
@@ -5777,9 +5779,10 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
   The <dfn attribute for="HTMLVideoElement"><code>videoWidth</code></dfn> IDL attribute must return
   the <a for='video'>intrinsic width</a> of the video in CSS pixels.
-  The <dfn attribute for="HTMLVideoElement"><code>videoHeight</code></dfn> IDL attribute must return
-  the <a for='video'>intrinsic height</a> of the video in CSS
-  pixels. If the element's <code>readyState</code> attribute is <code>HAVE_NOTHING</code>, then the attributes must return 0.
+  The <dfn attribute for="HTMLVideoElement"><code>videoHeight</code></dfn> IDL attribute must
+  return the <a for='video'>intrinsic height</a> of the video in CSS
+  pixels. If the element's <code>readyState</code> attribute is <code>HAVE_NOTHING</code>,
+  then the attributes must return 0.
 
   Whenever the <a for='video'>intrinsic width</a>
   or <a for='video'>intrinsic height</a> of the video changes
@@ -5799,7 +5802,7 @@ the <code>target</code> attribute in this example will instead <a>create a new b
 
   <p class="note">
     In user agents that implement CSS, the above requirement can be implemented by
-  using the style rule suggested in [[#rendering]].
+    using the style rule suggested in [[#rendering]].
   </p>
 
   The <a for="css">intrinsic width</a> of a <{video}> element's playback area is the
@@ -5884,12 +5887,16 @@ the <code>target</code> attribute in this example will instead <a>create a new b
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>embedded content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd>If the element has a <code>src</code> attribute:
-zero or more <{track}> elements, then
-<a>transparent</a>, but with no <a>media element</a> descendants.</dd>
-    <dd>If the element does not have a <code>src</code> attribute: zero or more <{source}> elements, then
-  zero or more <{track}> elements, then
-  <a>transparent</a>, but with no <a>media element</a> descendants.</dd>
+    <dd>
+      If the element has a <code>src</code> attribute:
+      zero or more <{track}> elements, then <a>transparent</a>,
+      but with no <a>media element</a> descendants.
+    </dd>
+    <dd>
+      If the element does not have a <code>src</code> attribute: zero or more <{source}> elements,
+      then zero or more <{track}> elements, then <a>transparent</a>,
+      but with no <a>media element</a> descendants.
+    </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -5941,17 +5948,16 @@ zero or more <{track}> elements, then
 
   <p class="note">
     In particular, this content is not intended to address accessibility concerns. To
-  make audio content accessible to the deaf or to those with other physical or cognitive
-  disabilities, a variety of features are available. If captions or a sign language video are
-  available, the <{video}> element can be used instead of the <{audio}> element to
-  play the audio, allowing users to enable the visual alternatives. Chapter titles can be provided
-  to aid navigation, using the <{track}> element and a <a>WebVTT file</a>. And,
-  naturally, transcripts or other textual alternatives can be provided by simply linking to them in
-  the prose near the <{audio}> element. [[WEBVTT]]
+    make audio content accessible to the deaf or to those with other physical or cognitive
+    disabilities, a variety of features are available. If captions or a sign language video are
+    available, the <{video}> element can be used instead of the <{audio}> element to
+    play the audio, allowing users to enable the visual alternatives. Chapter titles can be
+    provided to aid navigation, using the <{track}> element and a <a>WebVTT file</a>. And,
+    naturally, transcripts or other textual alternatives can be provided by simply linking to
+    them in the prose near the <{audio}> element. [[WEBVTT]]
   </p>
 
-  The <{audio}> element is a <a>media element</a> whose <a>media data</a> is
-  ostensibly audio data.
+  The <{audio}> element is a <a>media element</a> whose <a>media data</a> is ostensibly audio data.
 
   The <code>src</code>, <code>preload</code>,
   <code>autoplay</code>, <code>loop</code>, <code>muted</code>, and <{audio/controls}>
@@ -5962,8 +5968,7 @@ zero or more <{track}> elements, then
   <a>effective media volume</a>. The user agent must play the audio from audio tracks that
   were enabled when the <a>event loop</a> last reached step 1.
 
-  When an <{audio}> element is not <a>potentially playing</a>, audio must not play
-  for the element.
+  When an <{audio}> element is not <a>potentially playing</a>, audio must not play for the element.
 
   <dl class="domintro">
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5443,7 +5443,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
   <div class="example">
     In the following example, a Java applet is embedded in a page using the <code>object</code>
-    element. To account for a user not having JAVA installed, a paragraph of
+    element. To account for a user not having Java installed, a paragraph of
     <a>fallback content</a> has been added after the <{param}>. The fallback <{p}> should not be
     displayed if the Java applet loads.
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5443,10 +5443,9 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
   <div class="example">
     In the following example, a Java applet is embedded in a page using the <code>object</code>
-    element. (Generally speaking, it is better to avoid using applets like these and instead use
-    native JavaScript and HTML to provide the functionality, since that way the application will work
-    on all Web browsers without requiring a third-party plugin. Many devices, especially embedded
-    devices, do not support third-party technologies like Java.)
+    element. To account for a user not having JAVA installed, a paragraph of
+    <a>fallback content</a> has been added after the <{param}>. The fallback <{p}> should not be
+    displayed if the Java applet loads.
 
     <xmp highlight="html">
       <figure>
@@ -5457,6 +5456,13 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
         <figcaption>My Java Clock</figcaption>
       </figure>
     </xmp>
+
+    <p class="note">
+      Generally, it is better to avoid using applets like in the above example, and to instead use
+      native JavaScript and HTML to provide the functionality, since that way the application will
+      work on all Web browsers without requiring a third-party plugin. Many devices, especially
+      embedded devices, do not support third-party technologies like Java.
+    </p>
 
   </div>
 


### PR DESCRIPTION
Fixes #1313 

This PR updates the [prose of the first object example](https://github.com/w3c/html/commit/d090a5225f788bd1d0a38c6a80900a3d4a607208) to call out the use of fallback content.

The other commits of this PR are just general source cleanup for the file, and make no updates to the prose of the document.