### PR TITLE
update example and prose for caption element

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -679,6 +679,10 @@
   When a <{table}> element is the only content in a <{figure}> element other than the
   <{figcaption}>, the <{caption}> element should be omitted in favor of the <{figcaption}>.
 
+  As noted in [[#sec-techniques-for-describing-tables|techniques for describing tables]], a
+  <code>caption</caption> is the most robust method for providing an accessible caption to
+  a <code>table</table>.
+
   A caption can introduce context for a table, making it significantly easier to understand.
 
   <div class="example">
@@ -698,13 +702,15 @@
     (for reference in the main prose) and explaining its use, it makes more sense:
 
     <xmp highlight="html">
-      <caption>
-        <p>Table 1.</p>
-        <p>This table shows the total score obtained from rolling two
-        six-sided dice. The first row represents the value of the first die,
-        the first column the value of the second die. The total is given in
-        the cell that corresponds to the values of the two dice.</p>
-      </caption>
+      <table>
+        <caption>
+          Table 1.
+          This table shows the total score obtained from rolling two six-sided dice. The first row represents the value of the first die, the first column the value of the second die. The total is given in the cell that corresponds to the values of the two dice.
+        </caption>
+        <tbody>
+          <!-- ... -->
+        </tbody>
+      </table>
     </xmp>
 
     This provides the user with more context:


### PR DESCRIPTION
fixes #1346 

reference techniques for describing tables.

update `caption` example to provide context as to its placement within a `table`.

Remove `p` elements from `caption` example so that the code will match the output example.