### PR TITLE
add notes to refer to other examples for td & tr elements

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1220,6 +1220,12 @@
   Otherwise, remove the <var>index</var>th element in the <code>cells</code> collection
   from its parent.
 
+  <p class="note">
+    For examples of the <{tr}> element, refer to the <{table}> examples within
+    [[#sec-techniques-for-describing-tables|techniques for describing tables]], and
+    the section for <a href="#examples">table examples</a>.
+  </p>
+
 <h4 id="the-td-element">The <dfn element><code>td</code></dfn> element</h4>
 
   <dl class="element">
@@ -1266,12 +1272,17 @@
   attributes take part in the <a>table model</a>.
 
   User agents, especially in non-visual environments or where displaying the table as a 2D grid
-  is impractical, may give the user context for the cell when rendering the contents of a cell; for
-  instance, giving its position in the <a>table model</a>, or listing the cell's header cells
+  is impractical, may give the user context for the cell when rendering the contents of a cell;
+  for instance, giving its position in the <a>table model</a>, or listing the cell's header cells
   (as determined by the <a>algorithm for assigning header cells</a>). When a cell's header
-  cells are being listed, user agents may use the value of <code>abbr</code>
-  attributes on those header cells, if any, instead of the contents of the header cells
-  themselves.
+  cells are being listed, user agents may use the value of <code>abbr</code> attributes on
+  those header cells, if any, instead of the contents of the header cells themselves.
+
+  <p class="note">
+    For examples of the <{td}> element, refer to the <{table}> examples within
+    [[#sec-techniques-for-describing-tables|techniques for describing tables]], and
+    the section for <a href="#examples">table examples</a>.
+  </p>
 
 <h4 id="the-th-element">The <dfn element><code>th</code></dfn> element</h4>
 
@@ -2463,8 +2474,7 @@
 
           If there are any cells in the <var>opaque headers</var> list anchored with the
           same <var>y</var>-coordinate as the <var>current cell</var>, and with
-          the same height as <var>current cell</var>, then let <var>blocked</var>
-          be true.
+          the same height as <var>current cell</var>, then let <var>blocked</var> be true.
 
           If the <var>current cell</var> is not a <a>row header</a>, then let <var>blocked</var> be true.
 


### PR DESCRIPTION
Fixes #1357 
Fixes #1358 

the `td` and `tr` elements are used within almost all the other code examples in the tabular data document. Adding notes for readers to refer to other existing examples, rather than create duplicate examples for these elements.