### PR TITLE
update prose for table border attribute

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -112,10 +112,10 @@
   string, or "<code>1</code>" is set, such as a text string, user agents should interpret the
   value as the empty string.
 
-  The <dfn element-attr for="HTMLTableElement"><code>border</code></dfn> content attribute is used
-  by certain user agents as an indication that borders should be drawn around cells of the table.
-  These user agents may treat values greater than <code>1</code> as indicators to render wider
-  borders for the table. Authors should instead use CSS to provide styling for tables.
+  The <code>border</code> content attribute is used by certain user agents as an indication that
+  borders should be drawn around cells of the table. These user agents may treat values greater
+  than <code>1</code> as indicators to render wider borders for the table. Authors should instead
+  use CSS to provide styling for tables.
 
   <hr />
 

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -106,11 +106,16 @@
   </p>
 
   The <dfn element-attr for="HTMLTableElement"><code>border</code></dfn> content attribute may be
-  specified on a <{table}> element to explicitly indicate that the <{table}> element is not being
-  used for layout purposes. If specified, the attribute's value must either be the empty string
-  or the value "<code>1</code>".
-  The attribute is used by certain user agents as an indication that borders should be drawn
-  around cells of the table.
+  specified on a <{table}> element to explicitly indicate that the <{table}> element represents
+  tabular data and is not being used for layout purposes. If specified, the attribute's value
+  must either be the empty string or the value "<code>1</code>". If a value other than the empty
+  string, or "<code>1</code>" is set, such as a text string, user agents should interpret the
+  value as the empty string.
+
+  The <dfn element-attr for="HTMLTableElement"><code>border</code></dfn> content attribute is used
+  by certain user agents as an indication that borders should be drawn around cells of the table.
+  These user agents may treat values greater than <code>1</code> as indicators to render wider
+  borders for the table. Authors should instead use CSS to provide styling for tables.
 
   <hr />
 


### PR DESCRIPTION
fixes #1345

editorial update to the border prose to indicate what happens when a value of `border=“foo”` is added to a table, and provide some additional explination on what the attribute should indicate to user agents.

add prose that authors should not use this attribute for styling purposes, and should use CSS instead.