### PR TITLE
add markup example to tfoot

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1039,11 +1039,11 @@
     <dt><a>Categories</a>:</dt>
     <dd>None.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>As a child of a <{table}> element, after any
-    <{caption}>, <{colgroup}>, <{thead}>,
-    <{tbody}>, and <{tr}> elements, but only if there
-    are no other <{tfoot}> elements that are children of the
-    <{table}> element.</dd>
+    <dd>
+      As a child of a <{table}> element, after any <{caption}>, <{colgroup}>, <{thead}>,
+      <{tbody}>, and <{tr}> elements, but only if there are no other <{tfoot}> elements that
+      are children of the <{table}> element.
+    </dd>
     <dt><a>Content model</a>:</dt>
     <dd>Zero or more <code>tr</code> and <a>script-supporting elements</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
@@ -1074,6 +1074,52 @@
   a parent and it is a <{table}>.
 
   The <{tfoot}> element takes part in the <a>table model</a>.
+
+  <div class="example">
+    The following example uses a <{tfoot}> to indicate a summary of the total monthly spending,
+    earnings, and holdings.
+
+    <xmp highlight="html">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Month</th>
+            <th scope="col">Spending</th>
+            <th scope="col">Earnings</th>
+            <th scope="col">Holdings</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">January</th>
+            <td>$800</td>
+            <td>$700</td>
+            <td>-$100</td>
+          </tr>
+          <tr>
+            <th scope="row">February</th>
+            <td>$900</td>
+            <td>$935</td>
+            <td>+$35</td>
+          </tr>
+          <tr>
+            <th scope="row">March</th>
+            <td>$900</td>
+            <td>$950</td>
+            <td>+$50</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th scope="row">Totals</th>
+            <td>$2,600</td>
+            <td>$2,585</td>
+            <td>-$15</td>
+          </tr>
+        </tfoot>
+      </table>
+    </xmp>
+  </div>
 
 <h4 id="the-tr-element">The <dfn element><code>tr</code></dfn> element</h4>
 
@@ -2504,7 +2550,8 @@
 
       <dt>If <var>current cell</var> is a data cell and <var>in header block</var> is true</dt>
 
-      <dd>Set <var>in header block</var> to false. Add all the cells in <var>headers from current header block</var> to the <var>opaque headers</var>
+      <dd>Set <var>in header block</var> to false. Add all the cells in
+      <var>headers from current header block</var> to the <var>opaque headers</var>
       list, and empty the <var>headers from current header block</var> list.
 
     </dd></dl>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1079,46 +1079,40 @@
     The following example uses a <{tfoot}> to indicate a summary of the total monthly spending,
     earnings, and holdings.
 
-    <xmp highlight="html">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Month</th>
-            <th scope="col">Spending</th>
-            <th scope="col">Earnings</th>
-            <th scope="col">Holdings</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">January</th>
-            <td>$800</td>
-            <td>$700</td>
-            <td>-$100</td>
-          </tr>
-          <tr>
-            <th scope="row">February</th>
-            <td>$900</td>
-            <td>$935</td>
-            <td>+$35</td>
-          </tr>
-          <tr>
-            <th scope="row">March</th>
-            <td>$900</td>
-            <td>$950</td>
-            <td>+$50</td>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <th scope="row">Totals</th>
-            <td>$2,600</td>
-            <td>$2,585</td>
-            <td>-$15</td>
-          </tr>
-        </tfoot>
-      </table>
-    </xmp>
+    <pre highlight="html">
+      &lt;table&gt;
+        &lt;thead&gt;
+          &lt;tr&gt;
+            &lt;th scope="col"&gt;Month&lt;/th&gt;
+            &lt;th scope="col"&gt;Spending&lt;/th&gt;
+            &lt;th scope="col"&gt;Earnings&lt;/th&gt;
+            &lt;th scope="col"&gt;Holdings&lt;/th&gt;
+          &lt;/tr&gt;
+        &lt;/thead&gt;
+        &lt;tbody&gt;
+          &lt;tr&gt;
+            &lt;th scope="row"&gt;January&lt;/th&gt;
+            &lt;td&gt;$800&lt;/td&gt;
+            &lt;td&gt;$700&lt;/td&gt;
+            &lt;td&gt;-$100&lt;/td&gt;
+          &lt;/tr&gt;
+          &lt;tr&gt;
+            &lt;th scope="row"&gt;February&lt;/th&gt;
+            &lt;td&gt;$900&lt;/td&gt;
+            &lt;td&gt;$935&lt;/td&gt;
+            &lt;td&gt;+$35&lt;/td&gt;
+          &lt;/tr&gt;
+        &lt;/tbody&gt;
+        <mark>&lt;tfoot&gt;
+          &lt;tr&gt;
+            &lt;th scope="row"&gt;Totals&lt;/th&gt;
+            &lt;td&gt;$1,700&lt;/td&gt;
+            &lt;td&gt;$1,635&lt;/td&gt;
+            &lt;td&gt;-$65&lt;/td&gt;
+          &lt;/tr&gt;
+        &lt;/tfoot&gt;</mark>
+      &lt;/table&gt;
+    </pre>
   </div>
 
 <h4 id="the-tr-element">The <dfn element><code>tr</code></dfn> element</h4>


### PR DESCRIPTION
Fixes #1356 

Adds a `table` with `tfoot` as an example for its section.