### PR TITLE
update prose for omissible tfoot tags

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1048,8 +1048,8 @@
     <dd>Zero or more <code>tr</code> and <a>script-supporting elements</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
-      A <{tfoot}> element's <a>end tag</a> may be omitted if the <{tfoot}> element is immediately
-      followed by a <{tbody}> element, or if there is no more content in the parent element.
+      A <{tfoot}> element's <a>end tag</a> may be omitted if there is no more content in
+      the parent <{table}> element.
     </dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>


### PR DESCRIPTION
fixes #1375 

A `tfoot` can't have a `tbody` follow it, let alone have its end tag omitted if followed by other elements.  Prose updated to match.