### PR TITLE
Added HTML only example for the video element.

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5868,6 +5868,21 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   <a>reflect</a> the <{video/poster}> content attribute.
 
   <div class="example">
+    This example shows how different video files can be offered to the browser. If the browser does not support a specific codec,
+    it can play one of the alternative files offered.
+
+    This example also shows the <code>controls</code>, and <code>preload</code> attributes.
+
+    <xmp highlight="html">
+      <video controls preload="metadata">
+        <source type="video/webm" src="example.webm">
+        <source type="video/mp4" src="example.mp4">
+        <a href="example.webm">Download the video file.</a>
+      </video>
+    </xmp>
+  </div>
+
+  <div class="example">
     This example shows how to detect when a video has failed to play correctly:
 
     <xmp highlight="html">

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5871,7 +5871,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     This example shows how different video files can be offered to the browser. If the browser does not support a specific codec,
     it can play one of the alternative files offered.
 
-    This example also shows the <code>controls</code>, and <code>preload</code> attributes.
+    This example also shows the <{video/controls}>, and <{media/preload}> attributes.
 
     <xmp highlight="html">
       <video controls preload="metadata">
@@ -6040,8 +6040,8 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     This example shows how different audio files can be offered to the browser.  If the browser does
     not support a specific codec, it can play one of the alternative files offered.
 
-    This example also shows the boolean <code>controls</code>, <code>autoplay</code>, and
-    <code>loop</code> attributes.
+    This example also shows the boolean <{audio/controls}>, <{media/autoplay}>, and
+    <{media/loop}> attributes.
 
     <xmp highlight="html">
       <audio controls autoplay loop>


### PR DESCRIPTION
Added a HTML only example for the video element (issue https://github.com/w3c/html/issues/1316)