### PR TITLE
refer to existing tbody examples

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -892,7 +892,7 @@
 
   <p class="note">
     For examples of the <{tbody}> element, refer to the <{table}> examples within
-    [[#sec-techniques-for-describing-tables|techniques for describing tables]], and
+    <a href="#sec-techniques-for-describing-tables">techniques for describing tables</a>, and
     the section for <a href="#examples">table examples</a>.
   </p>
 
@@ -912,8 +912,7 @@
     the argument, and returns the <{tr}>.
 
     The position is relative to the rows in the table section. The index -1, which is the
-    default if the argument is omitted, is equivalent to inserting at the end of the table
-    section.
+    default if the argument is omitted, is equivalent to inserting at the end of the table section.
 
     If the given position is less than -1 or greater than the number of rows, throws an
     {{IndexSizeError}} exception.

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -890,6 +890,12 @@
 
   The <{tbody}> element takes part in the <a>table model</a>.
 
+  <p class="note">
+    For examples of the <{tbody}> element, refer to the <{table}> examples within
+    [[#sec-techniques-for-describing-tables|techniques for describing tables]], and
+    the section for <a href="#examples">table examples</a>.
+  </p>
+
   <dl class="domintro">
 
     <dt><var>tbody</var> . <code>rows</code></dt>


### PR DESCRIPTION
fixes #1349

add note to refer to the many other table examples for `tbody` usage.