### PR TITLE
Add colgroup / col examples

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -816,8 +816,8 @@
       </table>
     </xmp>
 
-    The next example shows how a <{colgroup}> with no child <{col}> elements, but instead use
-    the <code>span</code> attribute. The applied CSS will render the first two columns with
+    The next example shows how a <{colgroup}> with no child <{col}> elements can use
+    the <{colgroup/span}> attribute. The applied CSS will render the first two columns with
     a background color, and set their width to 25%, leaving the last column with no background
     color, and taking up the remaining width of the <{table}>.
 

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -819,19 +819,17 @@
     </dd>
   </dl>
 
-  If a <{col}> element has a parent and that is a <{colgroup}> element that
-  itself has a parent that is a <{table}> element, then the <{col}> element
-  <a>represents</a> one or more <a>columns</a> in the <a>column group</a> represented by that <{colgroup}>.
+  If a <{col}> element has a parent and that is a <{colgroup}> element that itself has a parent
+  that is a <{table}> element, then the <{col}> element <a>represents</a> one or more
+  <a>columns</a> in the <a>column group</a> represented by that <{colgroup}>.
 
   The element may have a <dfn element-attr for="col"><code>span</code></dfn> content attribute
   specified, whose value must be a <a>valid non-negative integer</a> greater than zero.
 
-  The <{col}> element and its <code>span</code> attribute take
-  part in the <a>table model</a>.
+  The <{col}> element and its <code>span</code> attribute take part in the <a>table model</a>.
 
-  The {{HTMLTableColElement/span}} IDL attribute must <a>reflect</a>
-  the content attribute of the same name. The value must be <a>limited to only non-negative
-  numbers greater than zero</a>.
+  The {{HTMLTableColElement/span}} IDL attribute must <a>reflect</a> the content attribute of the
+  same name. The value must be <a>limited to only non-negative numbers greater than zero</a>.
 
 <h4 id="the-tbody-element">The <dfn element><code>tbody</code></dfn> element</h4>
 
@@ -1002,7 +1000,7 @@
 
   <div class="example">
     This example shows a <{thead}> element being used. Notice the use of the
-    <code>th</code> element to provide headers in the <{thead}> element:
+    <{th}> element to provide headers in the <code>thead</code> element:
 
     <xmp highlight="html">
       <table border="1">
@@ -1657,8 +1655,8 @@
   columns are implied.
 
   A <dfn lt="row group|row groups">row group</dfn> is a set of <a>rows</a> anchored at a slot (0, <var>group<sub>y</sub></var>) with a particular <var>height</var> such that the row group
-  covers all the slots with coordinates (<var>x</var>, <var>y</var>) where 0&nbsp;≤&nbsp;<var>x</var>&nbsp;&lt;&nbsp;<var>x<sub>width</sub></var> and <var>group<sub>y</sub></var>&nbsp;≤&nbsp;<var>y</var>&nbsp;&lt;&nbsp;<var>group<sub>y</sub></var>+<var>height</var>. Row groups correspond to
-  <{tbody}>, <{thead}>, and <{tfoot}> elements. Not every row is necessarily in a row group.
+  covers all the slots with coordinates (<var>x</var>, <var>y</var>) where 0&nbsp;≤&nbsp;<var>x</var>&nbsp;&lt;&nbsp;<var>x<sub>width</sub></var> and <var>group<sub>y</sub></var>&nbsp;≤&nbsp;<var>y</var>&nbsp;&lt;&nbsp;<var>group<sub>y</sub></var>+<var>height</var>. Row groups correspond
+  to <{tbody}>, <{thead}>, and <{tfoot}> elements. Not every row is necessarily in a row group.
 
   A <dfn lt="column group|column groups|group">column group</dfn> is a set of <a>columns</a>
   anchored at a slot (<var>group<sub>x</sub></var>, 0) with a particular <var>width</var> such
@@ -1667,7 +1665,8 @@
   Column groups correspond to <{colgroup}> elements. Not every column is necessarily in a column
   group.
 
-  <a>Row groups</a> cannot overlap each other. Similarly, <a>column groups</a> cannot overlap each other.
+  <a>Row groups</a> cannot overlap each other. Similarly, <a>column groups</a> cannot overlap
+  each other.
 
   A <a>cell</a> cannot cover slots that are from two or more <a>row groups</a>.
   However, it is possible for a cell to be in multiple <a>column groups</a>. All the slots that
@@ -1809,14 +1808,14 @@
 
           <li>
 
-          <i>Columns</i>: If the <var>current column</var> <{col}> element has
-          a <code>span</code> attribute, then parse its value using the
-          <a>rules for parsing non-negative integers</a>.
+          <i>Columns</i>: If the <var>current column</var> <{col}> element has a <code>span</code>
+          attribute, then parse its value using the <a>rules for parsing non-negative integers</a>.
 
-          If the result of parsing the value is not an error or zero, then let <var>span</var> be that value.
+          If the result of parsing the value is not an error or zero, then let <var>span</var>
+          be that value.
 
-          Otherwise, if the <{col}> element has no <code>span</code> attribute, or if trying to parse the attribute's value
-          resulted in an error or zero, then let <var>span</var> be 1.
+          Otherwise, if the <{col}> element has no <code>span</code> attribute, or if trying to
+          parse the attribute's value resulted in an error or zero, then let <var>span</var> be 1.
 
           </li>
 
@@ -1828,18 +1827,16 @@
 
           <li>
 
-          Let the last <var>span</var> <a>columns</a> in
-          <var>the table</var> correspond to the <var>current column</var>
-          <{col}> element.
+          Let the last <var>span</var> <a>columns</a> in <var>the table</var> correspond to the
+          <var>current column</var> <{col}> element.
 
           </li>
 
           <li>
 
-          If <var>current column</var> is not the last <{col}> element child of
-          the <{colgroup}> element, then let the <var>current column</var> be the
-          next <{col}> element child of the <{colgroup}> element, and return to
-          the step labeled <i>columns</i>.
+          If <var>current column</var> is not the last <{col}> element child of the <{colgroup}>
+          element, then let the <var>current column</var> be the next <{col}> element child of the
+          <{colgroup}> element, and return to the step labeled <i>columns</i>.
 
           </li>
 
@@ -1863,13 +1860,14 @@
 
           <li>
 
-          If the <{colgroup}> element has a <code>span</code> attribute, then parse its value using the <a>rules for parsing non-negative
-          integers</a>.
+          If the <{colgroup}> element has a <code>span</code> attribute, then parse its value
+          using the <a>rules for parsing non-negative integers</a>.
 
           If the result of parsing the value is not an error or zero, then let <var>span</var> be that value.
 
-          Otherwise, if the <{colgroup}> element has no <code>span</code> attribute, or if trying to parse the attribute's
-          value resulted in an error or zero, then let <var>span</var> be 1.
+          Otherwise, if the <{colgroup}> element has no <code>span</code> attribute, or if trying
+          to parse the attribute's value resulted in an error or zero, then let <var>span</var>
+          be 1.
 
           </li>
 
@@ -1881,9 +1879,10 @@
 
           <li>
 
-          Let the last <var>span</var> <a>columns</a> in
-          <var>the table</var> form a new <a>column
-          group</a>, anchored at the slot (<var>x<sub>width</sub></var>-<var>span</var>, 0), with width <var>span</var>, corresponding to the <{colgroup}> element.
+          Let the last <var>span</var> <a>columns</a> in <var>the table</var> form a new
+          <a>column group</a>, anchored at the slot
+          (<var>x<sub>width</sub></var>-<var>span</var>, 0), with width <var>span</var>,
+          corresponding to the <{colgroup}> element.
 
           </li>
 
@@ -1897,15 +1896,14 @@
 
       <li>
 
-      <a>Advance</a> the <var>current element</var>
-      to the next child of the <{table}>.
+      <a>Advance</a> the <var>current element</var> to the next child of the <{table}>.
 
       </li>
 
       <li>
 
-      While the <var>current element</var> is not one of the following elements, <a>advance</a> the <var>current element</var> to the
-      next child of the <code>table</code>:
+      While the <var>current element</var> is not one of the following elements, <a>advance</a>
+      the <var>current element</var> to the next child of the <code>table</code>:
 
       <ul class="brief">
         <li><{colgroup}></li>
@@ -1919,8 +1917,8 @@
 
       <li>
 
-      If the <var>current element</var> is a <{colgroup}> element, jump to the
-      step labeled <i>column groups</i> above.
+      If the <var>current element</var> is a <{colgroup}> element, jump to the step labeled
+      <i>column groups</i> above.
 
       </li>
 
@@ -1943,8 +1941,7 @@
     <li>
 
     <i>Rows</i>: While the <var>current element</var> is not one of the following
-    elements, <a>advance</a> the <var>current
-    element</var> to the next child of the <{table}>:
+    elements, <a>advance</a> the <var>current element</var> to the next child of the <{table}>:
 
     <ul class="brief">
       <li><{thead}></li>
@@ -1955,7 +1952,8 @@
 
     </li>
 
-    Run the <a>algorithm for processing row groups</a> for the first <{thead}> child of the <{table}>.
+    Run the <a>algorithm for processing row groups</a> for the first <{thead}> child of
+    the <{table}>.
 
     <li>
 
@@ -1983,21 +1981,25 @@
     <ol>
       <li>
 
-       let <var>table header</var> be the current element;</li>
+       let <var>table header</var> be the current element;
+
+       </li>
       <li>
 
         <a>advance</a> the <var>current element</var> to the next child of the <{table}>, and </li>
       <li>
 
-        return to the step labeled <i>rows</i>.</li></ol>
+        return to the step labeled <i>rows</i>.
+
+      </li></ol>
 
     </li>
 
     <li>
 
-    If the <var>current element</var> is a <{tr}> then run the <a>algorithm
-    for processing rows</a>, <a>advance</a> the <var>current element</var> to the next child
-    of the <{table}>, and return to the step labeled <i>rows</i>.
+    If the <var>current element</var> is a <{tr}> then run the
+    <a>algorithm for processing rows</a>, <a>advance</a> the <var>current element</var> to the
+    next child of the <{table}>, and return to the step labeled <i>rows</i>.
 
     </li>
 
@@ -2009,8 +2011,7 @@
 
     <li>
 
-    The <var>current element</var> is either a <code>thead</code>, <{tfoot}>, or a
-    <{tbody}>.
+    The <var>current element</var> is either a <code>thead</code>, <{tfoot}>, or a <{tbody}>.
 
     Run the <a>algorithm for processing row groups</a>.
 
@@ -2018,8 +2019,7 @@
 
     <li>
 
-    <a>Advance</a> the <var>current element</var> to
-    the next child of the <{table}>.
+    <a>Advance</a> the <var>current element</var> to the next child of the <{table}>.
 
     </li>
 

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -794,6 +794,48 @@
   <a>reflect</a> the content attribute of the same name. The value must be
   <a>limited to only non-negative numbers greater than zero</a>.
 
+  <div class="example">
+    The following example shows how a <{colgroup}> consisting of three <{col}> elements can
+    utilize CSS to help visually format the columns of a <{table}>.
+
+    <xmp highlight="html">
+      <table style="width: 100%;">
+        <colgroup style="background: #ccc;">
+          <col style="background: #ddd; width: 30%;">
+          <col style="background: #eee; width: 50%;">
+          <col style="width: 20%;">
+        </colgroup>
+        <tbody>
+          <tr>
+            <td>...</td>
+            <td>...</td>
+            <td>...</td>
+          </tr>
+          <!-- ... -->
+        </tbody>
+      </table>
+    </xmp>
+
+    The next example shows how a <{colgroup}> with no child <{col}> elements, but instead use
+    the <code>span</code> attribute. The applied CSS will render the first two columns with
+    a background color, and set their width to 25%, leaving the last column with no background
+    color, and taking up the remaining width of the <{table}>.
+
+    <xmp highlight="html">
+      <table style="width: 100%;">
+        <colgroup style="background: #eee; width: 25%;" span="2"></colgroup>
+        <tbody>
+          <tr>
+            <td>...</td>
+            <td>...</td>
+            <td>...</td>
+          </tr>
+          <!-- ... -->
+        </tbody>
+      </table>
+    </xmp>
+  </div>
+
 <h4 id="the-col-element">The <dfn element><code>col</code></dfn> element</h4>
 
   <dl class="element">
@@ -830,6 +872,11 @@
 
   The {{HTMLTableColElement/span}} IDL attribute must <a>reflect</a> the content attribute of the
   same name. The value must be <a>limited to only non-negative numbers greater than zero</a>.
+
+  <p class="note">
+    For examples of the <{col}> element, refer to the examples within the <{colgroup}> section,
+    and the section for <a href="#examples">table examples</a>.
+  </p>
 
 <h4 id="the-tbody-element">The <dfn element><code>tbody</code></dfn> element</h4>
 


### PR DESCRIPTION
fixes #1347

fixes #1348

add example to the `colgroup` section.

as `col`s were used in the `colgroup` example, added a note to reference.

other source formatting that does not change prose.