### PR TITLE
fix #1397

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -194,10 +194,11 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a>, but with no <a>heading
-    content</a> descendants, no <a>sectioning content</a>
-    descendants, and no <{header}>, <{footer}>, or
-    <{address}> element descendants.</dd>
+    <dd>
+      <a>Flow content</a>, but with no <a>heading content</a> descendants,
+      no <a>sectioning content</a> descendants, and no <{main}>, <{header}>, <{footer}>,
+      or <{address}> element descendants.
+    </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>


### PR DESCRIPTION
fixes #1397
mention that `main` can not be a child of the `address` element.