### PR TITLE
make longdesc on <img> not obsolete anymore

### DIFF
--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -235,9 +235,7 @@
   :: Use <{img}> instead of <{input}> for image maps.
 
   : <dfn element-attr for="iframe"><code>longdesc</code></dfn> on <{iframe}> elements
-  : <dfn element-attr for="img"><code>longdesc</code></dfn> on <{img}> elements
-  :: Use a regular a element to link to the description, or (in the case of images) use an image map
-      to provide a link from the image to the image's description.
+  :: Use a regular a element to link to the description.
 
   : <dfn element-attr for="img"><code>lowsrc</code></dfn> on <{img}> elements
   :: Use a progressive JPEG image (given in the <{img/src}> attribute), instead of using two


### PR DESCRIPTION
fixes https://github.com/w3c/html/issues/1395