### PR TITLE
loosen the rule of the rb element

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -15,7 +15,8 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
  <li>the <{media/disableRemotePlayback}> attribute;</li>
  <li>{{registerContentHandler()}}, {{unregisterContentHandler()}} and {{isContentHandlerRegistered()}} methods;</li>
  <li><a>customized built-in elements</a> and the <{global/is}> attribute</li>
- <li>The algorithm for <a>creating an outline</a></li>
- <li><a href="https://github.com/w3c/html/pull/1329">The <code>:defined</code> pseudo-class</a></li>
- <li>Allowing multiple <{meta}> elements with <code>name="description"</code></li>
+ <li>The algorithm for <a>creating an outline</a>;</li>
+ <li><a href="https://github.com/w3c/html/pull/1329">The <code>:defined</code> pseudo-class</a>;</li>
+ <li>Allowing multiple <{meta}> elements with <code>name="description"</code>;</li>
+ <li>the <{rtc}> element;</li>
 </ul>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,6 +13,8 @@
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
+  <dt><a href="https://github.com/w3c/html/pull/1407">loosen the rule of the <code>rb</code> element</a></dt>
+   <dd>the <code>rb</code> element can be parsed propertly if the current node is a child of the <code>ruby</code> element</dd>
   <dt><a href="https://github.com/w3c/html/pull/1403">Add the <code>slot</code> element</a></dt>
    <dd>Substantive change for custom elements.</dd>
   <dt><a href="https://github.com/w3c/html/pull/1329">Add the <code>:defined</code> psuedo-class selector definition</a></dt>

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -5061,8 +5061,8 @@
 
     : A start tag whose tag name is one of: "rb", "rtc"
     :: If the [=stack of open elements=] <a lt="in scope">has a `ruby` element in scope</a>, then
-        [=generate implied end tags=]. If the [=current node=] is not now a <{ruby}> element, this
-        is a [=parse error=].
+        [=generate implied end tags=]. If the [=current node=] is not now a <{ruby}> element nor 
+        a child of a <{ruby}> element, this is a [=parse error=].
 
         [=Insert an HTML element=] for the token.
 


### PR DESCRIPTION
To fix issue #291 --
the `<rb>` element can be parsed properly as long as it's a child of the `<ruby>` element;

`<rtc>` should be marked 'at-risk', only implemented in FF.

Also see [tests](https://rawgit.com/siusin/web-platform-tests/ruby-implied-end/html/semantics/text-level-semantics/the-ruby-element/ruby-implied-end.html) (passed in FF, SF and Ch).