### PR TITLE
XML parsing needs to note custom elements

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -3779,7 +3779,7 @@
   ---
 
   When the steps below require the UA to
-  <dfn lt="create an element for the token">create an element for a token</dfn> in a particular
+  <dfn lt="create an element for the token|create an element for a token">create an element for a token</dfn> in a particular
   |given namespace| and with a particular |intended parent|, the UA must run the following steps:
 
   1. Let |document| be |intended parent|'s [=node document=].

--- a/sections/xhtml.include
+++ b/sections/xhtml.include
@@ -51,9 +51,9 @@
   the rules given in the XML specification to map a string of bytes or characters into a
   <code>Document</code> object.
 
-  <p class="note">
-  At the time of writing, no such rules actually exist.
-  </p>
+  To create DOM nodes representing elements an <a>XML parser</a> must use the <a>create an element for a token</a> algorithm,
+  or some equivalent that operates on appropriate XML datastructures,
+  to ensure the proper <a>element interfaces</a> are created and that <a>custom elements</a> are set up correctly.
 
   An <a>XML parser</a> is either associated with a <code>Document</code> object when it is
   created, or creates one implicitly.
@@ -70,7 +70,7 @@
   Between the time an element's start tag is parsed and the time either the element's end tag is
   parsed or the parser detects a well-formedness error, the user agent must act as if the element
   was in a <a>stack of open elements</a>.
-
+  
   <p class="note">
   This is used, e.g., by the <{object}> element to avoid instantiating plugins
   before the <{param}> element children have been parsed.


### PR DESCRIPTION
See #1229 

This is almost editorial. XHTML is a hybrid that can be parsed in various ways with a pure XML toolchain, but like SVG there is an expectation for most real use that specific knowledge of the vocabulary will also be available for most tools. This clarifies part of the hybrid nature.

cc @liamquin 