### PR TITLE
clean up img/decoding

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -19,4 +19,5 @@ per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process
  <li><a href="https://github.com/w3c/html/pull/1329">The <code>:defined</code> pseudo-class</a>;</li>
  <li>Allowing multiple <{meta}> elements with <code>name="description"</code>;</li>
  <li>the <{rtc}> element;</li>
+ <li>the <{img/decoding}> attribute for the <{img}> element.</li>
 </ul>

--- a/sections/attributes.include
+++ b/sections/attributes.include
@@ -226,6 +226,12 @@
       </td>
     </tr>
     <tr>
+      <th><{img/decoding}></th>
+      <td><{img}></td>
+      <td>A hint to request a/synchronous loading of images</td>
+      <td>"<code>sync</code>", "<code>async</code>", "<code>auto</code>"</td>
+    </tr>
+    <tr>
       <th><code>default</code></th>
       <td><{track}></td>
       <td>Enable the track if no other <a>text track</a> is more suitable</td>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -900,7 +900,7 @@
   cross-origin access to be used with <{canvas}>.
 
   The <dfn element-attr for="img"><code>decoding</code></dfn> attribute is an enumerated attribute.
-  It is an  [=image decoding hint=], to reqeust synchronous asynchronous image loading.
+  It is an [=image decoding hint=] to request synchronous or asynchronous image loading.
   Valid values are "<code>async</code>", "<code>async</code>", and "<code>auto</code>".
   The [=missing value default=] and [=invalid value default=] are both "<code>auto</code>".
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -713,6 +713,7 @@
     (e.g., high-resolution displays, small monitors, etc) </dd>
     <dd><code>sizes</code> - Image sizes between breakpoints</dd>
     <dd><code>crossorigin</code> - How the element handles crossorigin requests</dd>
+    <dd><{img/decoding}> - Hint for requesting synchronous or asynchronous loading</dd>
     <dd><code>usemap</code> - Name of <a>image map</a> to use </dd>
     <dd><{img/ismap}> - Whether the image is a server-side image map</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
@@ -752,6 +753,7 @@
           [CEReactions] attribute DOMString srcset;
           [CEReactions] attribute DOMString sizes;
           [CEReactions] attribute DOMString? crossOrigin;
+          [CEReactions] attribute DOMString decoding;
           [CEReactions] attribute DOMString useMap;
           attribute DOMString longDesc;
           [CEReactions] attribute boolean isMap;
@@ -762,7 +764,6 @@
           readonly attribute boolean complete;
           readonly attribute DOMString currentSrc;
           [CEReactions] attribute DOMString referrerPolicy;
-          [CEReactions] attribute DOMString decoding;
         };
       </pre>
     </dd>
@@ -898,13 +899,13 @@
   settings attribute</a>. Its purpose is to allow images from third-party sites that allow
   cross-origin access to be used with <{canvas}>.
 
-  The <dfn element-attr for="img"><code>referrerpolicy</code></dfn> attribute is a <a>referrer policy attribute</a>. Its purpose is to
-  set the <a>referrer policy</a> used when <a>fetching</a> the image. [[!REFERRERPOLICY]]
+  The <dfn element-attr for="img"><code>decoding</code></dfn> attribute is an enumerated attribute.
+  It is an  [=image decoding hint=], to reqeust synchronous asynchronous image loading.
+  Valid values are "<code>async</code>", "<code>async</code>", and "<code>auto</code>".
+  The [=missing value default=] and [=invalid value default=] are both "<code>auto</code>".
 
-  The <dfn element-attr for="img"><code>decoding</code></dfn> attribute indicates
-  the preferred method to <a for="image">decode</a> this image. The attribute,
-  if present, must be an [=image decoding hint=]. This attribute's
-  [=missing value default=] and [=invalid value default=] are both the {{auto}} state.
+  The <dfn element-attr for="img"><code>referrerpolicy</code></dfn> attribute is a <a>referrer policy attribute</a>.
+  Its purpose is to set the <a>referrer policy</a> used when <a>fetching</a> the image. [[!REFERRERPOLICY]]
 
   <hr />
 


### PR DESCRIPTION
fix #1388
* Note it is at risk (but it is likely to be OK)
* Add it to `img` attributes list
* Add it to attributes index