### PR TITLE
non-conforming features fixes

### DIFF
--- a/sections/obsolete.include
+++ b/sections/obsolete.include
@@ -132,14 +132,8 @@
   : <dfn element><code>plaintext</code></dfn>
   :: Use the "<code>text/plain</code>" [=MIME type=] instead.
 
-  : <{rb}>
-  : <{rtc}>
-  :: Providing the ruby base directly inside the <{ruby}> element or using nested <{ruby}> elements
-      is sufficient.
-
   : <dfn element><code>strike</code></dfn>
-  :: Use <{del}> instead if the element is marking an edit, otherwise use <{s}>
-      instead.
+  :: Use <{del}> instead if the element is marking an edit, otherwise use <{s}> instead.
 
   : <dfn element><code>xmp</code></dfn>
   :: Use <{pre}> and <{code}> instead, and escape "<code>&lt;</code>" and
@@ -181,8 +175,8 @@
   : <dfn element-attr for="link"><code>charset</code></dfn> on <{link}> elements
   :: Use an HTTP <code>Content-Type</code> header on the linked resource instead.
 
-  : <dfn element-attr for="script"><code>charset</code></dfn> on <{script}> elements 
-    (except as noted in the previous section)
+  : <dfn element-attr for="script"><code>charset</code></dfn> on <{script}> elements
+     (except as noted in the previous section)
   :: Omit the attribute. Both documents and scripts are required to use <a>UTF-8</a>. It is
      redundant to specify it on the <{script}> element since it inherits from the document.
 
@@ -208,11 +202,6 @@
   : <dfn element-attr for="form"><code>accept</code></dfn> on <{form}> elements
   :: Use the <{input/accept}> attribute directly on the <{input}> elements instead.
 
-  : <dfn element-attr for="area"><code>hreflang</code></dfn> on <{area}> elements
-  : <dfn element-attr for="area"><code>type</code></dfn> on <{area}> elements
-  :: These attributes do not do anything useful, and for historical reasons there are no
-      corresponding IDL attributes on <{area}> elements. Omit them altogether.
-
   : <dfn element-attr for="area"><code>nohref</code></dfn> on <{area}> elements
   :: Omitting the <{links/href}> attribute is sufficient; the <code>nohref</code> attribute is
       unnecessary. Omit it altogether.
@@ -220,16 +209,14 @@
   : <dfn element-attr for="head"><code>profile</code></dfn> on <{head}> elements
   :: When used for declaring which <code>meta</code> terms are used in the document, unnecessary;
       omit it altogether, and [=register the names=].
-  :: When used for triggering specific user agent behaviors: use a <{link}> element
-      instead.
+  :: When used for triggering specific user agent behaviors: use a <{link}> element instead.
 
   : <dfn element-attr for="html"><code>version</code></dfn> on <{html}> elements
   :: Unnecessary. Omit it altogether.
 
   : <dfn element-attr for="input"><code>ismap</code></dfn> on <{input}> elements
   :: Unnecessary. Omit it altogether. All <{input}> elements with a <{input/type}> attribute in
-      the <{input/Image|Image Button}> state are processed as server-side image
-      maps.
+      the <{input/Image|Image Button}> state are processed as server-side image maps.
 
   : <dfn element-attr for="input"><code>usemap</code></dfn> on <{input}> elements
   :: Use <{img}> instead of <{input}> for image maps.
@@ -369,7 +356,6 @@
   : <dfn element-attr for="pre"><code>width</code></dfn> on <{pre}> elements
   : <dfn element-attr for="table"><code>align</code></dfn> on <{table}> elements
   : <dfn element-attr for="table"><code>bgcolor</code></dfn> on <{table}> elements
-  : <dfn element-attr for="table"><code>border</code></dfn> on <{table}> elements
   : <dfn element-attr for="table"><code>bordercolor</code></dfn> on <{table}> elements
   : <dfn element-attr for="table"><code>cellpadding</code></dfn> on <{table}> elements
   : <dfn element-attr for="table"><code>cellspacing</code></dfn> on <{table}> elements
@@ -420,11 +406,11 @@
 
   When the element matches any of the following conditions, it [=represents=] its contents:
 
-  * The element is still in the [=stack of open elements=] of an [=HTML parser=] or
-      [=XML parser=].
+  * The element is still in the [=stack of open elements=] of an [=HTML parser=] or [=XML parser=].
   * The element is not <a>in a <code>document</code></a>.
   * The element's [=node document=] is not [=fully active=].
-  * The element's [=node document=]'s [=active sandboxing flag set=] has its [=sandboxed plugins browsing context flag=] set.
+  * The element's [=node document=]'s [=active sandboxing flag set=] has its
+    [=sandboxed plugins browsing context flag=] set.
   * The element has an ancestor [=media element=].
   * The element has an ancestor <{object}> element that is <em>not</em> showing its
     [=fallback content=].
@@ -440,13 +426,11 @@
   [=parameters=] given by <{param}> elements that are children of the
   <{applet}> element, in [=tree order=], to the [=plugin=] used. If the [=plugin=]
   supports a scriptable interface, the <code>HTMLAppletElement</code> object representing the
-  element should expose that interface. The <{applet}> element [=represents=] the
-  [=plugin=].
+  element should expose that interface. The <{applet}> element [=represents=] the [=plugin=].
 
   <p class="note">
-    The <{applet}> element is unaffected by the CSS 'display' property. The
-    Java Language runtime is instantiated even if the element is hidden with a 'display:none' CSS
-    style.
+    The <{applet}> element is unaffected by the CSS 'display' property. The Java Language runtime
+    is instantiated even if the element is hidden with a 'display:none' CSS style.
   </p>
 
   The <{applet}> element must implement the <code>HTMLAppletElement</code> interface.


### PR DESCRIPTION
fixes #1390

* remove `rb` and `rtc`.
* remove `area[hreflang]` and `area[type]`.
* remove `table[border]`