### PR TITLE
Add prose / example for headers attribute

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -142,7 +142,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>The use of the <code>role</code> attribute with the value <code>presentation</code></td>
+        <td>
+          The use of the <code>role</code> attribute with the value <code>presentation</code>
+        </td>
         <td>Probably a layout table</td>
       </tr>
       <tr>
@@ -150,8 +152,10 @@
         <td>Probably a layout table</td>
       </tr>
       <tr>
-        <td>The use of the non-conforming <code>cellspacing</code> and <code>cellpadding</code>
-        attributes with the value 0</td>
+        <td>
+          The use of the non-conforming <code>cellspacing</code> and <code>cellpadding</code>
+          attributes with the value 0
+        </td>
         <td>Probably a layout table</td>
       </tr>
     </tbody>
@@ -176,8 +180,10 @@
     <tbody>
       <tr>
         <td>The use of the non-conforming <code>summary</code> attribute</td>
-        <td>Not a good indicator (both layout and non-layout tables have historically been
-        given this attribute)</td>
+        <td>
+          Not a good indicator (both layout and non-layout tables have historically been
+          given this attribute)
+        </td>
       </tr>
     </tbody>
   </table>
@@ -1378,10 +1384,15 @@
   for instance, giving its position in the <a>table model</a>, or listing the cell's header cells
   (as determined by the <a>algorithm for assigning header cells</a>).
 
-  When a cell's header cells are being listed, user agents may use the value of <{th/abbr}>
-  attributes on those header cells, if any, instead of the contents of the header cells themselves.
-  A cell's header cell or cells are indicated by <{th}> elements, or by explicitly indicating a
-  cell's header cell or cells by authors using the <code>headers</code> attribute.
+  When a cell's header cells are being listed, user agents may instead use the value of <{th/abbr}>
+  attributes on those header cells, if any, to present to the user through a voice interface,
+  rather than presenting the visible contents of the header cells themselves. A cell's header cell
+  or cells are indicated by <{th}> elements, or by explicitly indicating a cell's header cell or
+  cells by authors using the <code>headers</code> attribute.
+
+  <p class="note">
+    See <a href="#forming-relationships-between-data-cells-and-header-cells">Forming relationships between data cells and header cells</a>.
+  </p>
 
   <p class="note">
     For examples of the <{td}> element and its <a>content attributes</a>, refer to the
@@ -1502,6 +1513,7 @@
     value affects which data cells a header cell applies to.
 
     Here is a markup fragment showing a table:
+
     <p class="note">
       The <{tbody}> elements in this example identify the range of the row groups.
     </p>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -2663,7 +2663,10 @@
 
   <em>This section is non-normative.</em>
 
-  The following shows how an one might mark up the bottom part of table 45 of the
+  The following examples showcase different <{table}> markup patterns, and how they could appear in
+  browsers with some styling provided by CSS.
+
+  This first example shows how an one might mark up the bottom part of table 45 of the
   <cite>Smithsonian physical tables, Volume 71</cite>:
 
   <xmp highlight="html">
@@ -2713,7 +2716,7 @@
     </table>
   </xmp>
 
-  This table could look like this:
+  This example produces the following table:
 
   <table>
     <caption>
@@ -2808,7 +2811,7 @@
     </table>
   </xmp>
 
-  This table could look like this:
+  This example produces the following table:
 
   <table class="apple-table-examples e1">
     <thead>
@@ -2905,7 +2908,7 @@
     </table>
   </xmp>
 
-  This table could look like this:
+  This example produces the following table:
 
   <table class="apple-table-examples e2">
     <colgroup>
@@ -2993,7 +2996,7 @@
     </table>
   </xmp>
 
-  This table could look like this:
+  This example produces the following table:
 
   <table style="width: 100%">
     <caption>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1378,7 +1378,7 @@
   for instance, giving its position in the <a>table model</a>, or listing the cell's header cells
   (as determined by the <a>algorithm for assigning header cells</a>).
 
-  When a cell's header cells are being listed, user agents may use the value of <code>abbr</code>
+  When a cell's header cells are being listed, user agents may use the value of <{th/abbr}>
   attributes on those header cells, if any, instead of the contents of the header cells themselves.
   A cell's header cell or cells are indicated by <{th}> elements, or by explicitly indicating a
   cell's header cell or cells by authors using the <code>headers</code> attribute.

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1339,9 +1339,9 @@
     <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
-      A <{td}> element's <a>end tag</a> may be omitted if the <{td}> element is immediately
-      followed by a <code>td</code> or <{th}> element, or if there is no more content in the
-      parent element.
+      A <{td}> element's <a>end tag</a> may be omitted if the <code>td</code> element is
+      immediately followed by a <code>td</code> or <{th}> element, or if there is no more
+      content in the parent element.
     </dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
@@ -1376,12 +1376,16 @@
   User agents, especially in non-visual environments or where displaying the table as a 2D grid
   is impractical, may give the user context for the cell when rendering the contents of a cell;
   for instance, giving its position in the <a>table model</a>, or listing the cell's header cells
-  (as determined by the <a>algorithm for assigning header cells</a>). When a cell's header
-  cells are being listed, user agents may use the value of <code>abbr</code> attributes on
-  those header cells, if any, instead of the contents of the header cells themselves.
+  (as determined by the <a>algorithm for assigning header cells</a>).
+
+  When a cell's header cells are being listed, user agents may use the value of <code>abbr</code>
+  attributes on those header cells, if any, instead of the contents of the header cells themselves.
+  A cell's header cell or cells are indicated by <{th}> elements, or by explicitly indicating a
+  cell's header cell or cells by authors using the <code>headers</code> attribute.
 
   <p class="note">
-    For examples of the <{td}> element, refer to the <{table}> examples within
+    For examples of the <{td}> element and its <a>content attributes</a>, refer to the
+    <{table}> examples within
     [[#sec-techniques-for-describing-tables|techniques for describing tables]], and
     the section for <a href="#examples">table examples</a>.
   </p>
@@ -2948,6 +2952,79 @@
         <td> 12.6% </td>
       </tr>
     </tbody>
+  </table>
+
+  <hr>
+
+  The following shows how one might mark up a coffee order that includes the team,
+  types of coffee, how many cups, and if sugar is needed to fulfill the order:
+
+  <xmp highlight="html">
+    <table>
+      <caption>
+        Daily coffee order for team meetings
+      </caption>
+      <thead>
+        <tr>
+          <th id="t1">Team</th>
+          <th id="t3" abbr="Types" colspan="2">Types of Coffee</th>
+          <th id="t2" colspan="2">Cups</th>
+          <th id="t4">Sugar Packets?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td headers="t1">Design</td>
+          <td headers="t3" id="c1">House Blend</td>
+          <td headers="t3" id="c2">French Roast</td>
+          <td headers="t2 c1">8</td>
+          <td headers="t2 c2">3</td>
+          <td headers="t4">Yes</td>
+        </tr>
+        <tr>
+          <td headers="t1">Development</td>
+          <td headers="t3" id="c3">Cold Brew</td>
+          <td headers="t3" id="c4">Espresso</td>
+          <td headers="t2 c3">6</td>
+          <td headers="t2 c4">5</td>
+          <td headers="t4">No</td>
+        </tr>
+      <tbody>
+    </table>
+  </xmp>
+
+  This table could look like this:
+
+  <table style="width: 100%">
+    <caption>
+      Daily coffee order for team meetings
+    </caption>
+    <thead>
+      <tr>
+        <th id="t1">Team</th>
+        <th id="t3" abbr="Types" colspan="2">Types of Coffee</th>
+        <th id="t2" colspan="2">Cups</th>
+        <th id="t4">Sugar Packets?</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td headers="t1">Design</td>
+        <td headers="t3" id="c1">House Blend</td>
+        <td headers="t3" id="c2">French Roast</td>
+        <td headers="t2 c1">8</td>
+        <td headers="t2 c2">3</td>
+        <td headers="t4">Yes</td>
+      </tr>
+      <tr>
+        <td headers="t1">Development</td>
+        <td headers="t3" id="c3">Cold Brew</td>
+        <td headers="t3" id="c4">Espresso</td>
+        <td headers="t2 c3">6</td>
+        <td headers="t2 c4">5</td>
+        <td headers="t4">No</td>
+      </tr>
+    <tbody>
   </table>
 
 </section>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1379,22 +1379,18 @@
   The <{td}> element and its <code>colspan</code>, <code>rowspan</code>, and <code>headers</code>
   attributes take part in the <a>table model</a>.
 
-  User agents, especially in non-visual environments or where displaying the table as a 2D grid
-  is impractical, may give the user context for the cell when rendering the contents of a cell;
-  for instance, giving its position in the <a>table model</a>, or listing the cell's header cells
-  (as determined by the <a>algorithm for assigning header cells</a>).
+  User agents, especially in environments where displaying the table as a 2D grid is impractical,
+  (e.g. in speech output), sometimes add information about a cell when rendering its contents;
+  for instance, giving its position in the <a>table model</a>, or listing its header cells
+  as determined by the <a>algorithm for assigning header cells</a>.
 
-  When a cell's header cells are being listed, user agents may instead use the value of <{th/abbr}>
-  attributes on those header cells, if any, to present to the user through a voice interface,
-  rather than presenting the visible contents of the header cells themselves. A cell's header cell
-  or cells are indicated by <{th}> elements, or by explicitly indicating a cell's header cell or
-  cells by authors using the <code>headers</code> attribute.
+  When referring to a cell's header cells are being listed, user agents may use the value of <{th/abbr}>
+  to present to the user through a voice interface, instead of the full contents of the header cells themselves.
+  A cell's header cells are determined by the algorithm for 
+  <a href="#forming-relationships-between-data-cells-and-header-cells">Forming relationships between data cells and header cells</a>
+  or can be explicitly defined using the <{td/headers}> attribute.
 
-  <p class="note">
-    See <a href="#forming-relationships-between-data-cells-and-header-cells">Forming relationships between data cells and header cells</a>.
-  </p>
-
-  <p class="note">
+<p class="note">
     For examples of the <{td}> element and its <a>content attributes</a>, refer to the
     <{table}> examples within
     [[#sec-techniques-for-describing-tables|techniques for describing tables]], and

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -1345,9 +1345,9 @@
     <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
-      A <{td}> element's <a>end tag</a> may be omitted if the <code>td</code> element is
-      immediately followed by a <code>td</code> or <{th}> element, or if there is no more
-      content in the parent element.
+      A <{td}> element's <a>end tag</a> may be omitted if the element is immediately followed by
+      another <code>td</code> element or <{th}> element, or if there is no more content in the
+      parent element.
     </dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
@@ -1386,7 +1386,7 @@
 
   When referring to a cell's header cells are being listed, user agents may use the value of <{th/abbr}>
   to present to the user through a voice interface, instead of the full contents of the header cells themselves.
-  A cell's header cells are determined by the algorithm for 
+  A cell's header cells are determined by the algorithm for
   <a href="#forming-relationships-between-data-cells-and-header-cells">Forming relationships between data cells and header cells</a>
   or can be explicitly defined using the <{td/headers}> attribute.
 
@@ -2724,7 +2724,7 @@
     </table>
   </xmp>
 
-  This example produces the following table:
+  This example produces the following table in a browser:
 
   <table>
     <caption>
@@ -2819,7 +2819,7 @@
     </table>
   </xmp>
 
-  This example produces the following table:
+  This example produces the following table in a browser:
 
   <table class="apple-table-examples e1">
     <thead>
@@ -2916,7 +2916,7 @@
     </table>
   </xmp>
 
-  This example produces the following table:
+  This example produces the following table in a browser:
 
   <table class="apple-table-examples e2">
     <colgroup>
@@ -3004,7 +3004,7 @@
     </table>
   </xmp>
 
-  This example produces the following table:
+  This example produces the following table in a browser:
 
   <table style="width: 100%">
     <caption>


### PR DESCRIPTION
fixes #1359

Updates the `td` prose to mention of how the `headers` attribute can be used to explicitly indicate headers for a particular cell.

Revise note to refer to tables example to indicate that the `td`’s content attributes (`colspan`, `rowspan`, `headers`) will have examples in one of/both of the linked sections.

Add table with `headers` example to table examples at end of file.