### PR TITLE
update td, th, caption content models

### DIFF
--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -654,7 +654,10 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>As the first element child of a <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a>, but with no descendant <{table}> elements.</dd>
+    <dd>
+      <a>Flow content</a>, excluding the <{main}> element,
+      and no descendant <{table}> elements.
+    </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{caption}> element's end tag may be omitted.</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -1336,7 +1339,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>As a child of a <{tr}> element.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a>.</dd>
+    <dd><a>Flow content</a> excluding the <{main}> element.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{td}> element's <a>end tag</a> may be omitted if the <{td}> element is immediately
@@ -1395,8 +1398,8 @@
     <dd>As a child of a <{tr}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>
-      <a>Flow content</a>, but with no <{header}>, <{footer}>, <a>sectioning content</a>, or
-      <a>heading content</a> descendants.
+      <a>Flow content</a>, but with no <{header}>, <{footer}>, <{main}>,
+      <a>sectioning content</a>, or <a>heading content</a> descendants.
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
@@ -1498,6 +1501,7 @@
     value affects which data cells a header cell applies to.
 
     Here is a markup fragment showing a table:
+
     <p class="note">
       The <{tbody}> elements in this example identify the range of the row groups.
     </p>

--- a/sections/semantics-tabular-data.include
+++ b/sections/semantics-tabular-data.include
@@ -655,8 +655,8 @@
     <dd>As the first element child of a <{table}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>
-      <a>Flow content</a>, excluding the <{main}> element,
-      and no descendant <{table}> elements.
+      <a>Flow content</a>, but with no <{main}>,
+      or <{table}> element descendants.
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>A <{caption}> element's end tag may be omitted.</dd>
@@ -1339,7 +1339,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>As a child of a <{tr}> element.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a> excluding the <{main}> element.</dd>
+    <dd><a>Flow content</a> but with no <{main}> element descendant.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>
       A <{td}> element's <a>end tag</a> may be omitted if the <{td}> element is immediately


### PR DESCRIPTION
fixes #1428

updates content model for `td`, `th`, `caption` to indicate that `main` is an invalid child element.