### PR TITLE
multiple attribute not allowed on input type=range

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -4763,48 +4763,50 @@
     <img src="images/sample-range-labels.png" width="103" height="164" alt="A vertical slider control with two tick marks, one near the top labeled 'High', and one near the bottom labeled 'Low'." />
   </div>
 
-  <p class="note">In this state, the range and step constraints are enforced even during user input,
-  and there is no way to set the value to the empty string.</p>
+  <p class="note">
+    In this state, the range and step constraints are enforced even during user input,
+    and there is no way to set the value to the empty string.
+  </p>
 
   The <{input/min}> attribute, if specified, must have a value that is a
   <a>valid floating-point number</a>. The <a>default minimum</a> is 0. The <{input/max}> attribute,
-  if specified, must have a value that is a <a>valid floating-point number</a>. The
-  <a>default maximum</a> is 100.
+  if specified, must have a value that is a <a>valid floating-point number</a>.
+  The <a>default maximum</a> is 100.
 
   The <a>step scale factor</a> is 1. The <a>default step</a> is 1 (allowing only integers, unless
   the <{input/min}> attribute has a non-integer value).
 
-  <strong>The <a>algorithm to convert a string to a number</a>, given a string <var>input</var>, is
-  as follows</strong>: If applying the <a>rules for parsing floating-point number values</a> to
-  <var>input</var> results in an error, then return an error; otherwise, return the resulting
+  <strong>The <a>algorithm to convert a string to a number</a>, given a string <var>input</var>,
+  is as follows</strong>: If applying the <a>rules for parsing floating-point number values</a>
+  to <var>input</var> results in an error, then return an error; otherwise, return the resulting
   number.
 
-  <strong>The <a>algorithm to convert a number to a string</a>, given a number <var>input</var>, is
-  as follows</strong>: Return the
+  <strong>The <a>algorithm to convert a number to a string</a>, given a number <var>input</var>,
+  is as follows</strong>: Return the
   <a lt="best floating-point number">best representation, as a floating-point number</a>, of
   <var>input</var>.
 
   <div class="bookkeeping">
-    The following common <{input}> element content attributes, IDL attributes, and
-    methods <a>apply</a> to the element:
-    <{input/autocomplete}>,
-    <{input/list}>,
-    <{input/max}>,
-    <{input/min}>,
-    <{input/multiple}>, and
-    <{input/step}> content attributes;
-    {{HTMLInputElement/list}},
-    {{HTMLInputElement/value}}, and
-    {{HTMLInputElement/valueAsNumber}} IDL attributes;
-    {{HTMLInputElement/stepDown()}} and
-    {{HTMLInputElement/stepUp()}} methods.
+    <p>
+      The following common <{input}> element content attributes, IDL attributes, and
+      methods <a>apply</a> to the element:
+      <{input/autocomplete}>,
+      <{input/list}>,
+      <{input/max}>,
+      <{input/min}>, and
+      <{input/step}> content attributes;
+      {{HTMLInputElement/list}},
+      {{HTMLInputElement/value}}, and
+      {{HTMLInputElement/valueAsNumber}} IDL attributes;
+      {{HTMLInputElement/stepDown()}} and
+      {{HTMLInputElement/stepUp()}} methods.
+    </p>
 
     The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not apply</a> to the
-    element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -4819,6 +4821,7 @@
     <{input/height}>,
     <{input/maxlength}>,
     <{input/minlength}>,
+    <{input/multiple}>,
     <{input/pattern}>,
     <{input/placeholder}>,
     <{input/readonly}>,


### PR DESCRIPTION
fixes #1380

removes `multiple` from allowed attributes of `input type=range` and adds it to list of attributes not to be specified.

Additionally, explicitly wraps first paragraph in `p` elements as this was not rendering correctly in the spec.