### PR TITLE
indicate alternate method for labeling

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -53,9 +53,10 @@
 
   Any form starts with a <{form}> element, inside which are placed the controls. Most controls are
   represented by the <{input}> element, which by default provides a one-line text field. To label
-  a control, the <{label}> element is used; the label text and the control itself go inside the
-  <{label}> element. Each area within a form is typically represented using a <{div}> element.
-  Putting this together, here is how one might ask for the customer's name:
+  a control, the <{label}> element is used. One way to associate a label with a control is to nest
+  the label text, and the control itself, inside a <{label}> element. Each area within a form is
+  typically represented using a <{div}> element. Putting this all together, here is how one might
+  ask for the customer's name:
 
   <xmp highlight="html">
     <form>
@@ -66,6 +67,11 @@
       </div>
     </form>
   </xmp>
+
+  <p class="note">
+    For an alternate method to associate a <{label}> with a form control, please refer to the
+    <code>label</code>'s <{label/for}> attribute.
+  </p>
 
   To assist users with entering their names, an <{input/autocapitalize}> attribute with the value
   of "words" can be added to the <{input}> so that user agents are provided a suggestion to


### PR DESCRIPTION
fixes #1441 
revisions to intro prose to indicate placing a control within a `label` is not the only way to label a form control, and added note to refer to the `for` attribute.