### PR TITLE
add in canonical

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -13,6 +13,9 @@
 <h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
+  <dt><a href="https://github.com/w3c/html/pull/1467">Add <code>canonical</code></a>
+  as a supported link type.</dt>
+  <dd>Defined in [[rfc6596]].</dd>
   <dt><a href="https://github.com/w3c/html/pull/1406">Only select a browsing context by name</a>
   from within the <a>unit of related browsing contexts</a>.</dt>
   <dd>Match Firefox and Blink changes, to mitigate <a href="https://github.com/w3c/html/issues/262">an XSS attack vector</a>.</dd>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -407,7 +407,8 @@
   allowed to be used with <{link}> elements, impact the processing model, and are supported by
   the user agent. The possible [=supported tokens=] are
   <{link/alternate}>,
-  <code>dns-prefetch</code>,
+  <{link/canonical}>,
+  <{link/dns-prefetch}>,
   <{link/icon}>,
   <{link/next}>,
   <code data-x="rel-pingback">pingback</code>,

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -405,22 +405,8 @@
 
   <{link/rel}>'s [=supported tokens=] are the keywords defined in [=HTML link types=] which are
   allowed to be used with <{link}> elements, impact the processing model, and are supported by
-  the user agent. The possible [=supported tokens=] are
-  <{link/alternate}>,
-  <{link/canonical}>,
-  <{link/dns-prefetch}>,
-  <{link/icon}>,
-  <{link/next}>,
-  <code data-x="rel-pingback">pingback</code>,
-  <code data-x="rel-preconnect">preconnect</code>,
-  <code data-x="rel-prefetch">prefetch</code>,
-  <code data-x="rel-preload">preload</code>,
-  <code data-x="rel-prerender">prerender</code>,
-  <{link/search}>,
-  <code data-x="rel-serviceworker">serviceworker</code>, and
-  <{link/stylesheet}>.
-  A <{link/rel}>'s [=supported tokens=] must only include the tokens (keywords) from this list
-  that the user agent implements the processing model for.
+  the user agent. A <{link/rel}> must only include the tokens (keywords) outlined in the
+  table of [=supported tokens=] that the user agent implements the processing model for.
 
   If a <{link}> element has a <{link/rel}> attribute that contains only keywords that are
   <a>body-ok</a>, then the element is said to be <dfn>allowed in the body</dfn>. This means

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -1099,6 +1099,14 @@
     </tr>
 
     <tr>
+      <td><{link/canonical}></td>
+      <td><em>not allowed</em></td>
+      <td><a>hyperlink</a></td>
+      <td class="no"> · </td>
+      <td>Gives the preferred URL for the current document.</td>
+    </tr>
+
+    <tr>
       <td><{link/dns-prefetch}></td>
       <td><em>not allowed</em></td>
       <td><a>hyperlink</a></td>
@@ -1400,6 +1408,15 @@
       </body>
     </xmp>
   </div>
+
+<h5 id="link-type-canonical">Link type "<dfn element-state for="link"><code>canonical</code></dfn>"</h5>
+
+  The <{link/canonical}> keyword may be used with the <{link}> element.
+  This keyword creates a <a>hyperlink</a>
+
+  The <{link/canonical}> keyword indicates that the URL given by the <{links/href}> attribute
+  is the preferred URL for the current document. Indicating the preferred URL helps search engines
+  reduce duplicate content, as described in more detail in The Canonical Link Relation specification. <!-- todo ref link goes here -->
 
 <h5 id="link-type-dns-prefetch">Link type "<dfn element-state for="link"><code>dns-prefetch</code></dfn>"</h5>
 

--- a/sections/semantics-links.include
+++ b/sections/semantics-links.include
@@ -1416,7 +1416,7 @@
 
   The <{link/canonical}> keyword indicates that the URL given by the <{links/href}> attribute
   is the preferred URL for the current document. Indicating the preferred URL helps search engines
-  reduce duplicate content, as described in more detail in The Canonical Link Relation specification. <!-- todo ref link goes here -->
+  reduce duplicate content, as described in more detail in The Canonical Link Relation specification [[!rfc6596]].
 
 <h5 id="link-type-dns-prefetch">Link type "<dfn element-state for="link"><code>dns-prefetch</code></dfn>"</h5>
 


### PR DESCRIPTION
Fixes #1392 

Needs reference link to https://tools.ietf.org/html/rfc6596

This PR does not address some of the sub-issues mentioned in 1392, but specifically:

- adds reference to canonical in [list of supported tokens](https://w3c.github.io/html/document-metadata.html#ref-for-supported-tokens)
- adds in reference to canonical in link type table, and add corresponding section of prose.