### PR TITLE
HTMLAllCollection getter should not return null

### DIFF
--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -4089,7 +4089,7 @@ interface NoncedElement {
     [LegacyUnenumerableNamedProperties]
     interface HTMLAllCollection {
       readonly attribute unsigned long length;
-      getter Element? (unsigned long index);
+      getter Element (unsigned long index);
       getter (HTMLCollection or Element)? namedItem(DOMString name);
       legacycaller (HTMLCollection or Element)? item(optional DOMString nameOrItem);
     };


### PR DESCRIPTION
Make the HTMLAllCollection IDL conformed with WHATWG LS [/whatwg/html#3562](https://github.com/whatwg/html/commit/be2f5df15c86c1847d85514602904751ec2e2b70) and the WPT [test](https://github.com/web-platform-tests/wpt/blob/fcf42b610c3eec811dc26a09b1404300aeb01ac1/interfaces/html.idl#L5).