### PR TITLE
set-cookie meta has no effect

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -10,7 +10,13 @@
   <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various
   editorial and linking fixes.
 
-<h3 id="changes-wd3">Changes since the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
+<h3 id="changes-wd4">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
+<dl>
+  <dt><a href="https://github.com/w3c/html/pull/***"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
+</dl>
+
+<h3 id="changes-wd3">Changes between the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Public Working Draft</a>
+and the <a href="https://www.w3.org/TR/2017/WD-html53-20170206/">HTML 5.3 Second Public Working Draft</a></h3>
 
   <dl>
   <dt><a href="https://github.com/w3c/html/pull/1406">Only select a browsing context by name</a>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -12,7 +12,7 @@
 
 <h3 id="changes-wd4">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
 <dl>
-  <dt><a href="https://github.com/w3c/html/pull/***"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
+  <dt><a href="https://github.com/w3c/html/pull/1479"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
 </dl>
 
 <h3 id="changes-wd3">Changes between the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Public Working Draft</a>

--- a/sections/semantics-document-metadata.include
+++ b/sections/semantics-document-metadata.include
@@ -1178,9 +1178,14 @@
         <td></td>
       </tr>
       <tr>
-        <td><a state for="http-equiv" lt="set-cookie">Cookie setter</a></td>
+        <td><a state for="http-equiv" lt="set-cookie">Set-Cookie</a></td>
         <td><code>set-cookie</code></td>
         <td>Non-conforming</td>
+      </tr>
+      <tr>
+        <td><a state for="http-equiv" lt="content-security-policy">Content Security Policy</a></td>
+        <td><code>content-security-policy</code></td>
+        <td></td>
       </tr>
     </tbody>
   </table>
@@ -1373,18 +1378,11 @@
         <xmp highlight="html"><meta http-equiv="Refresh" content="20; URL=page4.html"></xmp>
       </div>
 
-    : <dfn state for="http-equiv" lt="set-cookie">Cookie setter</dfn> (<code>http-equiv="set-cookie"</code>)
-    :: This pragma sets an HTTP cookie. [[!COOKIES]]
+    : <dfn state for="http-equiv" lt="set-cookie">Set-Cookie state</dfn> (<code>http-equiv="set-cookie"</code>)
+    :: This pragma is non-conforming and has no effect.
+         <p>User agents are required to ignore this pragma.</p>
 
-        It is non-conforming. Real HTTP headers should be used instead.
-
-        1. If the <{meta}> element has no <code>content</code> attribute, or if that
-            attribute's value is the empty string, then abort these steps.
-        2. Act as if <a>receiving a set-cookie-string</a> for the document's [=Document/URL=] via a
-            "non-HTTP" API, consisting of the value of the element's <code>content</code> attribute
-            <a>encoded as UTF-8</a>. [[!COOKIES]] [[!ENCODING]]
-
-    : <dfn state for="http-equiv">Content security policy state</dfn> (<code>http-equiv="content-security-policy"</code>)
+    : <dfn state for="http-equiv" lt="content-security-policy">Content security policy state</dfn> (<code>http-equiv="content-security-policy"</code>)
     :: This pragma <a lt="enforced">enforces</a> a <a>Content Security Policy</a> on a {{Document}}.
         [[CSP3]]
 


### PR DESCRIPTION
Conform with whatwg/html@9c13539.
[Test](https://wpt.fyi/results/cookies/meta-blocked.html) passes in Chrome and Edge.