### PR TITLE
Editorial updates to header

### DIFF
--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1032,8 +1032,9 @@
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
     <dd>
-      <a>Flow content</a>, but with no <{main}> element descendants, or <{header}>, <{footer}> elements
-    that are not descendants of <a>sectioning content</a> which is a descendant of the <{header}>.
+      <a>Flow content</a>, but with no <{main}> element descendants, or <{header}>,
+      <{footer}> elements that are not descendants of <a>sectioning content</a> which is
+      a descendant of the <{header}>.
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
@@ -1049,7 +1050,10 @@
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
     <dt>
@@ -1070,16 +1074,16 @@
   site-oriented content, or introductory content for the page as a whole.
 
   Assistive Technology may convey to users the semantics of the <{header}> element when it applies
-  to the whole page.
-  This information can provide a hint as to the type of content. For example, the <code>role</code>
-  of the element, which in this case is "banner", can be announced by screen reader software when a
-  user navigates to a <{header}> element that is scoped to the <{body}> element. User Agents may
-  also provide methods to navigate to a <{header}> element scoped to the <{body}> element.
+  to the whole page. This information can provide a hint as to the type of content. For example,
+  the <{aria/role}> of the element, which in this case is "<code>banner</code>", can be announced
+  by screen reader software when a user navigates to a <{header}> element that is scoped to the
+  <{body}> element. User Agents may also provide methods to navigate to a <{header}> element
+  scoped to the <{body}> element.
 
   <p class="note">
-    A <{header}> element is intended to usually contain the section's heading (an
-    <code>h1</code>–<code>h6</code> element), but this is not required. The <{header}> element
-    can also be used to wrap a section's table of contents, a search form, or any relevant logos.
+    A <{header}> element is intended to usually contain the section's heading (an <{h1}>–<{h6}>
+    element), but this is not required. The <{header}> element can also be used to wrap a
+    section's table of contents, a search form, or any relevant logos.
   </p>
 
   <div class="example">
@@ -1108,7 +1112,7 @@
   </div>
 
   <p class="note">
-    The <{header}> element is not <a>sectioning content</a>; it doesn't introduce a new section.
+    The <{header}> element is not <a>sectioning content</a>; it doesn't introduce a new section, though headings within a <code>header</code> will indicate new sections to the page.
   </p>
 
   <div class="example">

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1087,15 +1087,6 @@
   </p>
 
   <div class="example">
-    Here are some sample headers. This first one is for a game:
-
-    <xmp highlight="html">
-      <header>
-        <p>Welcome to...</p>
-        <h1>Voidwars!</h1>
-      </header>
-    </xmp>
-
     The following snippet shows how the element can be used to mark up a specification's header:
 
     <xmp highlight="html">
@@ -1109,6 +1100,34 @@
       </header>
     </xmp>
 
+    The following snippet shows how one might use headers within a blog. The first header
+    acting as introductory content for the page, as a whole, scoped to the <{body}>
+    element. The second acts as introductory content to the primary article of the page:
+
+    <xmp highlight="html">
+      <body>
+        <header>
+          <nav>
+            <a href="/">My Awesome blog</a>
+            <ul>
+              <li><a href="/new-articles">Latest</a></li>
+              <li><a href="/old-articles">Archive</a></li>
+              <li><a href="/contact">Contact</a></li>
+            </ul>
+          </nav>
+        </header>
+        <main>
+          <article>
+            <header>
+              <h1>
+                My great post!
+              </h1>
+              <p>Hello world!</p>
+            </header>
+          </article>
+        </main>
+      </body>
+    </xmp>
   </div>
 
   <p class="note">

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1081,9 +1081,9 @@
   scoped to the <{body}> element.
 
   <p class="note">
-    A <{header}> element is intended to usually contain the section's heading (an <{h1}>–<{h6}>
-    element), but this is not required. The <{header}> element can also be used to wrap a
-    section's table of contents, a search form, or any relevant logos.
+    A <{header}> element is intended to usually contain the section's heading
+    (an <code>h1</code>–<code>h6</code> element), but this is not required. The <{header}> element
+    can also be used to wrap a section's table of contents, a search form, or any relevant logos.
   </p>
 
   <div class="example">
@@ -1101,7 +1101,7 @@
     </xmp>
 
     The following snippet shows how one might use headers within a blog. The first header
-    acting as introductory content for the page, as a whole, scoped to the <{body}>
+    acting as introductory content for the page as a whole, and is scoped to the <{body}>
     element. The second acts as introductory content to the primary article of the page:
 
     <xmp highlight="html">
@@ -1128,6 +1128,48 @@
         </main>
       </body>
     </xmp>
+
+    The next example shows a misuse of a <{header}>, as its content does not <a>represent</a> an
+    introduction to its parent <a>sectioning content</a>:
+
+    <xmp highlight="html">
+      <article>
+        <h2>Spinning Straw into Gold</h2>
+        <p>A primer on getting rich quick, while avoiding making horrible promises.</p>
+
+        ...
+
+        <header>
+          <h3>Make a point to learn obscure names</h3>
+        </header>
+        ...
+      </article>
+    </xmp>
+
+    Modifying the previous example, the following markup better aligns to the appropriate usage
+    for a <{header}>:
+
+    <pre highlight="html">
+      &lt;article>
+        <mark>&lt;header></mark>
+          &lt;h2>Spinning Straw into Gold&lt;/h2>
+          &lt;p>A primer on getting rich quick, while avoiding making horrible promises.&lt;/p>
+        <mark>&lt;/header></mark>
+        ...
+
+        <mark>&lt;section></mark>
+          &lt;header>
+            &lt;h3>Make a point to learn obscure names&lt;/h3>
+          &lt;/header>
+          ...
+        <mark>&lt;/section></mark>
+      &lt;/article>
+    </pre>
+
+    ...now that content that appropriately introduced the <{article}> is contained within a
+    <{header}>, and the content that was previously in a <code>header</code> is now appropriately
+    scoped to a subsection of the <code>article</code>.
+
   </div>
 
   <p class="note">

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1065,7 +1065,7 @@
   </dl>
 
   The <{header}> element <a>represents</a> introductory content for its nearest ancestor <{main}>
-  element or <a>sectioning content</a> or <a>sectioning root</a> element. A <{header}> typically
+  element, <a>sectioning content</a>, or <a>sectioning root</a> element. A <{header}> typically
   contains a group of introductory or navigational aids.
 
   When a <{header}> element's nearest ancestor <a>sectioning root</a> element is the <{body}>
@@ -1135,10 +1135,10 @@
   </p>
 
   <div class="example">
-    In this example, the page has a page heading given by the <{h1}> element, and two
-    subsections whose headings are given by <{h2}> elements. The content after the
-    <{header}> element is still part of the last subsection started in the <{header}> element,
-    because the <{header}> element doesn't take part in the <a>outline</a> algorithm.
+    In this example, the page has a page heading given by the <{h1}> element, and two subsections
+    whose headings are given by <{h2}> elements. The content after the <{header}> element is still
+    part of the last subsection started in the <{header}> element, because the <{header}> element
+    doesn't take part in the <a>outline</a> algorithm.
 
     <xmp highlight="html">
       <body>

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1101,8 +1101,8 @@
     </xmp>
 
     The following snippet shows how one might use headers within a blog. The first header
-    acting as introductory content for the page as a whole, and is scoped to the <{body}>
-    element. The second acts as introductory content to the primary article of the page:
+    provides introductory content for the page as a whole, and is scoped to the <{body}>
+    element. The second provides introductory content to the primary article of the page:
 
     <xmp highlight="html">
       <body>
@@ -1147,7 +1147,9 @@
     </xmp>
 
     Modifying the previous example, the following markup better aligns to the appropriate usage
-    for a <{header}>:
+    for a <{header}>. Now the content that appropriately introduces the <{article}> is wrapped
+    within a <{header}>, and the content that was previously in a <code>header</code> is now
+    appropriately scoped to a subsection of the <code>article</code>:
 
     <pre highlight="html">
       &lt;article>
@@ -1155,25 +1157,22 @@
           &lt;h2>Spinning Straw into Gold&lt;/h2>
           &lt;p>A primer on getting rich quick, while avoiding making horrible promises.&lt;/p>
         <mark>&lt;/header></mark>
-        ...
+        <p>This text will guide you through the necessary steps to complete this impossible task...
 
         <mark>&lt;section></mark>
           &lt;header>
             &lt;h3>Make a point to learn obscure names&lt;/h3>
           &lt;/header>
-          ...
+          <p>If you are tasked with guessing someone's name, then it should be safe to assume that common names won't get you far...
         <mark>&lt;/section></mark>
       &lt;/article>
     </pre>
 
-    ...now that content that appropriately introduced the <{article}> is contained within a
-    <{header}>, and the content that was previously in a <code>header</code> is now appropriately
-    scoped to a subsection of the <code>article</code>.
-
   </div>
 
   <p class="note">
-    The <{header}> element is not <a>sectioning content</a>; it doesn't introduce a new section, though headings within a <code>header</code> will indicate new sections to the page.
+    The <{header}> element is not <a>sectioning content</a>; it doesn't introduce a new section,
+    though headings within a <code>header</code> will indicate new sections to the page.
   </p>
 
   <div class="example">


### PR DESCRIPTION
Updates to some of the prose and modify examples related to the conversation in #1405.

Includes new example where a heading is not a child of a `header`, as well as examples to clarify how to correctly use a `header` as a means to wrap introductory content, including an example that showcases a misuse for comparison.  


