### PR TITLE
use latest version of bikeshed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ before_install:
 install:
 - pip install -U pip setuptools>=18.5
 - pip install pygments cssselect html5lib lxml
-- git clone --depth=500 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
+# - git clone --depth=500 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
 # Use stable copy of bikeshed
+# - git checkout fbf1456a756299b3ff6d248d0857ec87f2e68cd7
+# Use latest version of bikeshed
+- - git clone --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
 - pushd ./bikeshed
-- git checkout fbf1456a756299b3ff6d248d0857ec87f2e68cd7
 - popd
 - pip install --editable ./bikeshed
-# Use latest update for the build.
 - bikeshed update
 # Use cached copy of bikeshed data files to give consistent builds
 #- cp -R .spec-data/* ./bikeshed/bikeshed/spec-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ before_install:
 install:
 - pip install -U pip setuptools>=18.5
 - pip install pygments cssselect html5lib lxml
-# - git clone --depth=500 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
-# Use stable copy of bikeshed
-# - git checkout fbf1456a756299b3ff6d248d0857ec87f2e68cd7
-# Use latest version of bikeshed
-- - git clone --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
+- git clone --depth=500 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
 - pushd ./bikeshed
+#- git checkout fbf1456a756299b3ff6d248d0857ec87f2e68cd7
 - popd
 - pip install --editable ./bikeshed
+# Use latest update for the build.
 - bikeshed update
 # Use cached copy of bikeshed data files to give consistent builds
 #- cp -R .spec-data/* ./bikeshed/bikeshed/spec-data


### PR DESCRIPTION
Switch to the latest version of bikeshed so that the parser can support WebIDL mixins.

See Issues: #1299 #1298 