### PR TITLE
removed redundant comma in note on <cite>

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -578,7 +578,7 @@
   <p class="note">
     Creative works include a book, a paper, an essay, a poem, a score, a song, a script, a film, a
     TV show, a game, a sculpture, a painting, a theatre production, a play, an opera, a musical, an
-    exhibition, a legal case report, a computer program, , a web site, a web page, a blog post or
+    exhibition, a legal case report, a computer program, a web site, a web page, a blog post or
     comment, a forum post or comment, a tweet, a written or oral statement, etc.
   </p>
 


### PR DESCRIPTION
I removed redundant comma in note on `<cite>`.