### PR TITLE
Editorial: update figcaption usage context

### DIFF
--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1632,9 +1632,9 @@
           <img src="obama-reid.jpeg" alt="Obama and Reid sit together smiling in the Oval Office.">
           <figcaption>Barack Obama and Harry Reid. White House press photograph.</figcaption>
         </figure>
-        <p>Negotiations in Congress to end the fiscal impasse sputtered on Tuesday, leaving both chambers
-        grasping for a way to reopen the government and raise the country's borrowing authority with a
-        Thursday deadline drawing near.</p>
+        <p>
+          Negotiations in Congress to end the fiscal impasse sputtered on Tuesday, leaving both chambers grasping for a way to reopen the government and raise the country's borrowing authority with a Thursday deadline drawing near.
+        </p>
         ...
       </article>
     </xmp>
@@ -1646,7 +1646,7 @@
     <dt><a>Categories</a>:</dt>
     <dd>None.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>As a descendant of a <{figure}> element.</dd>
+    <dd>As a child of a <{figure}> element.</dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
@@ -1661,8 +1661,10 @@
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>


### PR DESCRIPTION
figcaption must be a child of a figure.