### PR TITLE
Editorial: add GET & POST descriptions

### DIFF
--- a/sections/browsers.include
+++ b/sections/browsers.include
@@ -3474,7 +3474,7 @@
   When a user requests that the <a>active document</a> of a <a>browsing context</a>
   be reloaded through a user interface element, the user agent should <a>navigate</a> the <a>browsing context</a> to the same resource as that
   {{Document}}, with <a>replacement enabled</a>. In the case of non-idempotent
-  methods (e.g., HTTP POST), the user agent should prompt the user to confirm the operation first,
+  methods (e.g., <a>HTTP POST</a>), the user agent should prompt the user to confirm the operation first,
   since otherwise transactions (e.g., purchases or database modifications) could be repeated. User
   agents may allow the user to explicitly override any caches when reloading. If <a>browsing
   context</a>'s <a>active document</a>'s <a>reload override flag</a> is set, then the
@@ -3576,7 +3576,7 @@
 
   <p class="note">
   A <i>resource</i> has a URL, but that might not be the only information necessary
-  to identify it. For example, a <a>form submission</a> that uses HTTP POST would also have the HTTP method
+  to identify it. For example, a <a>form submission</a> that uses <a>HTTP POST</a> would also have the HTTP method
   and payload. Similarly, <a>an `iframe` `srcdoc` document</a> needs to know the data it is to use.
   </p>
 

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -3578,7 +3578,7 @@
   11. This is the <i>main step</i>.
 
       If the resource is identified by an <a>absolute URL</a>, and the resource is to be obtained
-      using an idempotent action (such as an HTTP GET <a>or equivalent</a>), and it is already
+      using an idempotent action (such as an <a>HTTP GET</a> <a>or equivalent</a>), and it is already
       being downloaded for other reasons (e.g., another invocation of this algorithm), and this
       request would be identical to the previous one (e.g., same <a http-header><code>Accept</code></a> and
       <a http-header><code>Origin</code></a> headers), and the user agent is configured such that it is to reuse the

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -5522,7 +5522,8 @@
 
   <div class="bookkeeping">
 
-    The following common <{input}> element content attributes and IDL attributes <a>apply</a> to the element:
+    The following common <{input}> element content attributes and IDL attributes <a>apply</a>
+    to the element:
     <{input/formaction}>,
     <{input/formenctype}>,
     <{input/formmethod}>,
@@ -5532,8 +5533,7 @@
 
     The {{HTMLInputElement/value}} IDL attribute is in mode <a mode for="input">default</a>.
 
-    The following content attributes must not be specified and <a>do not apply</a> to the
-    element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -10386,27 +10386,36 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <hr />
 
   The <dfn element-attr for="form"><code>action</code></dfn> and
-  <dfn element-attr for="submitbuttonelements,input,button"><code>formaction</code></dfn> content attributes, if specified, must
-  have a value that is a <a>valid non-empty URL potentially surrounded by spaces</a>.
+  <dfn element-attr for="submitbuttonelements,input,button"><code>formaction</code></dfn> content
+  attributes, if specified, must have a value that is a
+  <a>valid non-empty URL potentially surrounded by spaces</a>.
 
   The <dfn>action</dfn> of an element is the value of the element's
-  <{submitbuttonelements/formaction}> attribute, if the element is a <{input/Submit|Submit Button}> and has such an attribute, or the value of its
-  <a>form owner</a>'s <{form/action}> attribute, if <em>it</em> has
-  one, or else the empty string.
+  <{submitbuttonelements/formaction}> attribute, if the element is a
+  <{input/Submit|Submit Button}> and has such an attribute, or the value of its
+  <a>form owner</a>'s <{form/action}> attribute, if <em>it</em> has one, or else the empty string.
 
   <hr />
 
   The <dfn element-attr for="form"><code>method</code></dfn> and
-  <dfn element-attr for="submitbuttonelements,input,button"><code>formmethod</code></dfn> content attributes are <a>enumerated attributes</a> with the following keywords and
-  states:
+  <dfn element-attr for="submitbuttonelements,input,button"><code>formmethod</code></dfn> content
+  attributes are <a>enumerated attributes</a> with the following keywords and states:
 
   <ul>
 
-    <li>The keyword <dfn attr-value for="form/method"><code>get</code></dfn>, mapping to the
-    state <dfn for="http">GET</dfn>, indicating the HTTP GET method.</li>
+    <li>
+      The keyword <dfn attr-value for="form/method"><code>get</code></dfn>, mapping to the
+      state <dfn for="http">GET</dfn>, indicating the HTTP GET method. The GET method should
+      only request and retrieve data and should have no other effect.
+    </li>
 
-    <li>The keyword <dfn attr-value for="form/method"><code>post</code></dfn>, mapping to the
-    state <dfn for="http">POST</dfn>, indicating the HTTP POST method.</li>
+    <li>
+      The keyword <dfn attr-value for="form/method"><code>post</code></dfn>, mapping to the
+      state <dfn for="http">POST</dfn>, indicating the HTTP POST method.
+
+      The POST method requests that the server accept the submitted <{form}>'s data to be processed, which may result in an item being added to a database, the creation of a new
+      web page resource, the updating of the existing page, or all of the mentioned outcomes.
+    </li>
 
     <li>The keyword <dfn attr-value for="form/method"><code>dialog</code></dfn>, mapping to
     the state <dfn for="state">dialog</dfn>, indicating that submitting the
@@ -10415,37 +10424,36 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   </ul>
 
-  The <i>invalid value default</i> for these attributes is the <a for="http">GET</a> state. The <i>missing value default</i> for the <{form/method}> attribute is also the <a for="http">GET</a> state. (There is no <i>missing value default</i> for the
+  The <i>invalid value default</i> for these attributes is the <a for="http">GET</a> state.
+  The <i>missing value default</i> for the <{form/method}> attribute is also the
+  <a for="http">GET</a> state. (There is no <i>missing value default</i> for the
   <{submitbuttonelements/formmethod}> attribute.)
 
   The <dfn for="forms">method</dfn> of an element is one of those states. If the element is a
-  <{input/Submit|Submit Button}> and has a <{submitbuttonelements/formmethod}>
-  attribute, then the element's <a for="forms">method</a> is that attribute's state; otherwise, it
-  is the <a>form owner</a>'s <{form/method}> attribute's state.
+  <{input/Submit|Submit Button}> and has a <{submitbuttonelements/formmethod}> attribute, then the
+  element's <a for="forms">method</a> is that attribute's state; otherwise, it is the
+  <a>form owner</a>'s <{form/method}> attribute's state.
 
   <div class="example">
-    Here the <{form/method}> attribute is used to explicitly specify
-    the default value, "<a attr-value for="form/method">get</a>", so that the search
-    query is submitted in the URL:
+    Here the <{form/method}> attribute is used to explicitly specify the default value,
+    "<a attr-value for="form/method">get</a>", so that the search query is submitted in the URL:
 
     <xmp highlight="html">
       <form method="get" action="/search">
-        <div>
-          <label>
-            Search terms:
-            <input type="search" name="q">
-          </label>
-        </div>
-        <div><input type="submit"></div>
+        <label>
+          Search terms:
+          <input type="search" name="q">
+        </label>
+        <input type="submit">
       </form>
     </xmp>
 
   </div>
 
   <div class="example">
-    On the other hand, here the <{form/method}> attribute is used to
-    specify the value "<a attr-value for="form/method">post</a>", so that the user's
-    message is submitted in the HTTP request's body:
+    On the other hand, here the <{form/method}> attribute is used to specify the value
+    "<a attr-value for="form/method">post</a>", so that the user's message is submitted in
+    the HTTP request's body:
 
     <xmp highlight="html">
       <form method="post" action="/post-message">
@@ -10453,14 +10461,17 @@ You cannot submit this form when the field is incorrect.</samp></pre>
           <label for="message">Message:</label>
           <input type="text" id="message" name="m">
         </div>
-        <div><input type="submit" value="Submit message"></div>
+        <div>
+          <input type="submit" value="Submit Message">
+        </div>
       </form>
     </xmp>
 
   </div>
 
   <div class="example">
-    In this example, a <{form}> is used within a <{dialog}>. The <{form/method}> attribute's "<a attr-value for="form/method">dialog</a>" keyword is used to have the dialog
+    In this example, a <{form}> is used within a <{dialog}>. The <{form/method}> attribute's
+    "<a attr-value for="form/method">dialog</a>" keyword is used to have the dialog
     automatically close when the form is submitted.
 
     <xmp lang="en-GB" highlight="html">
@@ -10489,8 +10500,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <hr />
 
   The <dfn element-attr for="form"><code>enctype</code></dfn> and
-  <dfn element-attr for="submitbuttonelements,input,button"><code>formenctype</code></dfn> content attributes are <a>enumerated attributes</a> with the following keywords and
-  states:
+  <dfn element-attr for="submitbuttonelements,input,button"><code>formenctype</code></dfn>
+  content attributes are <a>enumerated attributes</a> with the following keywords and states:
 
   <ul>
     <li>The "<dfn attr-value for="form/enctype"><code>application/x-www-form-urlencoded</code></dfn>" keyword and corresponding state.</li>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -4507,11 +4507,11 @@
   See [[#date-time-and-number-formats]] for a discussion of the difference between the input format
   and submission format for date, time, and number form controls, and the
   <a>implementation notes</a> regarding localization of form controls.
-  
+
   Systems that need to enforce a particular format are encouraged to use the <code>pattern</code>
   attribute or the {{HTMLInputElement/setCustomValidity()}} method to hook into the client-side
   validation mechanism.
-  
+
   See [[#the-pattern-attribute]] for examples.
   </div>
 
@@ -5735,8 +5735,8 @@
 
   <hr />
 
-  The <{input/formaction}>, <{input/formenctype}>, <{input/formmethod}>, <{input/formnovalidate}>, and <{input/formtarget}> attributes are <a>attributes for form
-  submission</a>.
+  The <{input/formaction}>, <{input/formenctype}>, <{input/formmethod}>, <{input/formnovalidate}>,
+  and <{input/formtarget}> attributes are <a>attributes for form submission</a>.
 
   <dl class="domintro">
 
@@ -5756,7 +5756,8 @@
 
   <div class="bookkeeping">
 
-    The following common <{input}> element content attributes and IDL attributes <a>apply</a> to the element:
+    The following common <{input}> element content attributes and IDL attributes
+    <a>apply</a> to the element:
     <{input/alt}>,
     <{input/formaction}>,
     <{input/formenctype}>,
@@ -5770,8 +5771,7 @@
 
     The {{HTMLInputElement/value}} IDL attribute is in mode <a mode for="input">default</a>.
 
-    The following content attributes must not be specified and <a>do not apply</a> to the
-    element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/autocapitalize}>,
     <{input/autocomplete}>,
@@ -10405,13 +10405,13 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <li>
       The keyword <dfn attr-value for="form/method"><code>get</code></dfn>, mapping to the
-      state <dfn for="http">GET</dfn>, indicating the HTTP GET method. The GET method should
+      state <dfn for="http">GET</dfn>, indicating the <a>HTTP GET</a> method. The GET method should
       only request and retrieve data and should have no other effect.
     </li>
 
     <li>
       The keyword <dfn attr-value for="form/method"><code>post</code></dfn>, mapping to the
-      state <dfn for="http">POST</dfn>, indicating the HTTP POST method.
+      state <dfn for="http">POST</dfn>, indicating the <a>HTTP POST</a> method.
 
       The POST method requests that the server accept the submitted <{form}>'s data to be processed, which may result in an item being added to a database, the creation of a new
       web page resource, the updating of the existing page, or all of the mentioned outcomes.

--- a/single-page.bs
+++ b/single-page.bs
@@ -753,6 +753,8 @@ urlPrefix: https://tools.ietf.org/html/
         text: content-language; url: section-3.1.3.2
         text: accept-language; url: section-5.3.5
         text: accept; url: section-5.3.2
+        text: HTTP GET; type: dfn; url: section-4.3.1
+        text: HTTP POST; type: dfn; url: section-4.3.3
     urlPrefix: rfc7231#; spec: rfc7231;
         text: media-type; type: dfn; url: section-3.1.1.1
         text: referer; type: http-header; url: section-5.5.2

--- a/single-page.bs
+++ b/single-page.bs
@@ -753,8 +753,8 @@ urlPrefix: https://tools.ietf.org/html/
         text: content-language; url: section-3.1.3.2
         text: accept-language; url: section-5.3.5
         text: accept; url: section-5.3.2
-        text: HTTP GET; type: dfn; url: section-4.3.1
-        text: HTTP POST; type: dfn; url: section-4.3.3
+        text: HTTP GET; url: section-4.3.1
+        text: HTTP POST; url: section-4.3.3
     urlPrefix: rfc7231#; spec: rfc7231;
         text: media-type; type: dfn; url: section-3.1.1.1
         text: referer; type: http-header; url: section-5.5.2


### PR DESCRIPTION
fixes #1447 

add short descriptions of GET and POST values.

other minor char length cleanup for source file.