### PR TITLE
Editorial: autocomplete attribute clarification

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -12,10 +12,15 @@
 
 <h3 id="changes-wd4">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
 <dl>
-  <dt><a href="https://github.com/w3c/html/pull/1479"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
-  <dt><a href="https://github.com/w3c/html/pull/1489">Define <code>HTMLOrSVGElement</code> mixin interface</a>.</dt>
-  <dd>Fixed <a href="https://github.com/w3c/html/issues/1299">issue 1299</a>
-  </dd>
+  <dt><a href="https://github.com/w3c/html/pull/1517">Removes the concept of autofill mantles</a></dt>
+  <dd>Fixed <a href="https://github.com/w3c/html/issues/1389">clarify usage of <code>autocomplete</code> attribute on <code>input type=hidden</code></a></dd>
+  <dt>
+    <a href="https://github.com/w3c/html/pull/1479"><code>http-equiv="set-cookie"</code> has no effect</a>.
+  </dt>
+  <dt>
+    <a href="https://github.com/w3c/html/pull/1489">Define <code>HTMLOrSVGElement</code> mixin interface</a>.
+  </dt>
+  <dd>Fixed <a href="https://github.com/w3c/html/issues/1299">issue 1299</a></dd>
 </dl>
 
 <h3 id="changes-wd3">Changes between the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Public Working Draft</a>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -10685,8 +10685,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   <p class="warning">
     When fields with the <{autocompleteelements/autocomplete}> attribute are hidden off-screen or
-    visually disguised, personal data may still be entered when using the autofill feature of
-    browsers and password managers.
+    visually disguised, there is a risk that personal data is entered or changed using the
+    autofill feature of browsers and password managers, without the user being aware.
 
     User agents should verify that all fields with the <{autocompleteelements/autocomplete}>
     attribute are visible within the viewport before automatically entering data.

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -10684,33 +10684,13 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   to the user agent how to, or indeed whether to, provide such a feature.
 
   <p class="warning">
-  When fields with the <{autocompleteelements/autocomplete}> attribute wearing the
-  <a>autofill expectation mantle</a> are hidden off-screen or visually disguised,
-  personal data may still be entered when using the autofill feature of browsers and password managers.
-  User agents should verify that all fields with the <{autocompleteelements/autocomplete}>
-  attribute  wearing the <a>autofill expectation mantle</a>
-  are visible within the viewport before automatically entering data.
+    When fields with the <{autocompleteelements/autocomplete}> attribute are hidden off-screen or
+    visually disguised, personal data may still be entered when using the autofill feature of
+    browsers and password managers.
+
+    User agents should verify that all fields with the <{autocompleteelements/autocomplete}>
+    attribute are visible within the viewport before automatically entering data.
   </p>
-
-  There are two ways this attribute is used. When wearing the <dfn>autofill expectation
-  mantle</dfn>, the <{autocompleteelements/autocomplete}> attribute describes what
-  input is expected from users. When wearing the <dfn>autofill anchor mantle</dfn>, the <{autocompleteelements/autocomplete}> attribute describes the meaning of the given
-  value.
-
-  On an <{input}> element whose <{input/type}> attribute is
-  in the <{input/Hidden}> state, the <{input/autocomplete}> attribute wears the <a>autofill anchor
-  mantle</a>. In all other cases, it wears the <a>autofill expectation mantle</a>.
-
-  When wearing the <a>autofill expectation mantle</a>, the <{autocompleteelements/autocomplete}> attribute, if specified, must have a value that
-  is an ordered <a>set of space-separated tokens</a> consisting of either a single token that
-  is an <a>ASCII case-insensitive</a> match for the string "<code>off</code>", or a single token
-  that is an <a>ASCII case-insensitive</a> match for the string "<code>on</code>",
-  or <a>autofill detail tokens</a>.
-
-  When wearing the <a>autofill anchor
-  mantle</a>, the <{autocompleteelements/autocomplete}> attribute, if specified, must have a value that is an ordered <a>set of
-  space-separated tokens</a> consisting of just <a>autofill detail tokens</a> (i.e., the
-  "<code>on</code>" and "<code>off</code>" keywords are not allowed).
 
   <dfn>Autofill detail tokens</dfn> are the following, in the order given below:
 
@@ -10801,8 +10781,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
       <li>
 
       A token that is an <a>ASCII case-insensitive</a> match for one of the following
-      <a>autofill field</a> names, excluding those that are <a>inappropriate for the
-      control</a>:
+      <a>autofill field</a> names, excluding those that are <a>inappropriate for the control</a>:
 
       <ul class="brief">
         <li>"<code>name</code>"
@@ -10888,8 +10867,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
         <li>
 
         A token that is an <a>ASCII case-insensitive</a> match for one of the following
-        <a>autofill field</a> names, excluding those that are <a>inappropriate for the
-        control</a>:
+        <a>autofill field</a> names, excluding those that are <a>inappropriate for the control</a>:
 
         <ul class="brief">
           <li>"<code>tel</code>"
@@ -10918,100 +10896,29 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   </ol>
 
-  As noted earlier, the meaning of the attribute and its keywords depends on the mantle that the
-  attribute is wearing.
-
-  <dl class="switch">
-
-    <dt>When wearing the <a>autofill expectation mantle</a>...
-
-    </dt><dd>
-
-    The "<dfn attr-value for="forms/autocomplete"><code>off</code></dfn>" keyword indicates either
-    that the control's input data is particularly sensitive (for example the activation code for a
-    nuclear weapon); or that it is a value that will never be reused (for example a one-time-key for a
-    bank login) and the user will therefore have to explicitly enter the data each time, instead of
-    being able to rely on the user agent to prefill the value for him; or that the document provides its own
-    autocomplete mechanism and does not want the user agent to provide autocompletion values.
-
-    The "<dfn attr-value for="forms/autocomplete"><code>on</code></dfn>" keyword indicates that the
-    user agent is allowed to provide the user with autocompletion values, but does not provide any
-    further information about what kind of data the user might be expected to enter. User agents would
-    have to use heuristics to decide what autocompletion values to suggest.
-
-    The <a>autofill field</a> listed above indicate that the user agent is allowed to
-    provide the user with autocompletion values, and specifies what kind of value is expected. The
-    meaning of each such keyword is described in the table below.
-
-    If the <{autocompleteelements/autocomplete}> attribute is omitted, the default
-    value corresponding to the state of the element's <a>form owner</a>'s <{form/autocomplete}>
-    attribute is used instead (either "<a attr-value for="forms/autocomplete"><code>on</code></a>"
-    or "<a attr-value for="forms/autocomplete"><code>off</code></a>"). If there is no <a>form owner</a>, then the
-    value "<code>on</code>" is used.
-
-    </dd>
-
-    <dt>When wearing the <a>autofill anchor mantle</a>...
-
-    </dt><dd>
-
-    The <a>autofill field</a> listed above indicate that the value of the particular kind
-    of value specified is that value provided for this element. The meaning of each such keyword is
-    described in the table below.
-
-    <div class="example">
-      In this example the page has explicitly specified the currency and amount of the
-      transaction. The form requests a credit card and other billing details. The user agent could
-      use this information to suggest a credit card that it knows has sufficient balance and that
-      supports the relevant currency.
-
-      <xmp highlight="html">
-        <form method="post" action="step2">
-          <input type="hidden" autocomplete="transaction-currency" value="CHF">
-          <input type="hidden" autocomplete="transaction-amount" value="15.00">
-          <div>
-            <label for="cc-num">Credit card number:</label>
-            <input type="text" id="cc-num" autocomplete="cc-number">
-          </div>
-          <div>
-            <label for="exp-date">Expiry Date:</label>
-            <input type="month" id="exp-date" autocomplete="cc-exp">
-          </div>
-          <div>
-            <input type="submit" value="Continue...">
-          </div>
-        </form>
-    </xmp>
-
-    </div>
-
-    </dd>
-
-  </dl>
-
-  The <dfn>autofill field</dfn> keywords relate to each other as described in the table below. Each field name
-  listed on a row of this table corresponds to the meaning given in the cell for that row in the
-  column labeled "Meaning". Some fields correspond to subparts of other fields; for example, a
-  credit card expiry date can be expressed as one field giving both the month and year of expiry
-  ("<code>cc-exp</code>"), or as two fields, one giving the
-  month ("<code>cc-exp-month</code>") and one the year
-  ("<code>cc-exp-year</code>"). In such cases, the names of
-  the broader fields cover multiple rows, in which the narrower fields are defined.
+  The <dfn>autofill field</dfn> keywords relate to each other as described in the table below.
+  Each field name listed on a row of this table corresponds to the meaning given in the cell for
+  that row in the column labeled "Meaning". Some fields correspond to subparts of other fields;
+  for example, a credit card expiry date can be expressed as one field giving both the month and
+  year of expiry ("<code>cc-exp</code>"), or as two fields, one giving the month
+  ("<code>cc-exp-month</code>") and one the year ("<code>cc-exp-year</code>"). In such cases, the
+  names of the broader fields cover multiple rows, in which the narrower fields are defined.
 
   <p class="note">
-    Generally, authors are encouraged to use the broader fields rather than the
-  narrower fields, as the narrower fields tend to expose Western biases. For example, while it is
-  common in some Western cultures to have a given name and a family name, in that order (and thus
-  often referred to as a <i>first name</i> and a <i>surname</i>), many cultures put the family name
-  first and the given name second, and many others simply have one name (a <i>mononym</i>). Having a
-  single field is therefore more flexible.
+    Generally, authors are encouraged to use the broader fields rather than the narrower fields,
+    as the narrower fields tend to expose Western biases. For example, while it is common in some
+    Western cultures to have a given name and a family name, in that order (and thus often
+    referred to as a <i>first name</i> and a <i>surname</i>), many cultures put the family name
+    first and the given name second, and many others simply have one name (a <i>mononym</i>).
+    Having a single field is therefore more flexible.
   </p>
 
-  Some fields are only appropriate for certain form controls. An <a>autofill field</a> name
-  is <dfn lt="inappropriate for the control|inappropriate for a control">inappropriate for a control</dfn> if the control
-  does not belong to the group listed for that <a>autofill field</a> in the fifth column of
-  the first row describing that <a>autofill field</a> in the table below. What controls fall
-  into each group is described below the table.
+  Some fields are only appropriate for certain form controls.
+  An <a>autofill field</a> name is
+  <dfn lt="inappropriate for the control|inappropriate for a control">inappropriate for a control</dfn>
+  if the control does not belong to the group listed for that <a>autofill field</a> in the fifth
+  column of the first row describing that <a>autofill field</a> in the table below. What controls
+  fall into each group is described below the table.
 
   <table>
     <thead>
@@ -11480,8 +11387,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <li>Let <var>tokens</var> be the result of <a lt="split a string on spaces">splitting the attribute's value on spaces</a>.</li>
 
-    <li>If <var>tokens</var> is empty, then jump to the step labeled
-    <i>default</i>.</li>
+    <li>If <var>tokens</var> is empty, then jump to the step labeled <i>default</i>.</li>
 
     <li>Let <var>index</var> be the index of the last token in <var>tokens</var>.</li>
 
@@ -11727,20 +11633,17 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     </li>
 
-    <li>If <var>category</var> is Off or Automatic but the element's <{autocompleteelements/autocomplete}>
-    attribute is wearing the <a>autofill anchor mantle</a>, then jump to the step labeled <i>default</i>.</li>
-
     <li>If <var>category</var> is Off, let the element's <a>autofill field name</a>
     be the string "<code>off</code>", let its <a>autofill hint set</a> be empty, and
     let its <a>IDL-exposed autofill value</a> be the string "<code>off</code>". Then,
-    abort these steps.
+    abort these steps.</li>
 
-    </li><li>If <var>category</var> is Automatic, let the element's <a>autofill field
-    name</a> be the string "<code>on</code>", let its <a>autofill hint set</a> be
-    empty, and let its <a>IDL-exposed autofill value</a> be the string "<code>on</code>".
-    Then, abort these steps.
+    <li>If <var>category</var> is Automatic, let the element's <a>autofill field name</a> be the
+    string "<code>on</code>", let its <a>autofill hint set</a> be empty, and let its
+    <a>IDL-exposed autofill value</a> be the string "<code>on</code>".
+    Then, abort these steps.</li>
 
-    </li><li>Let <var>scope tokens</var> be an empty list.</li>
+    <li>Let <var>scope tokens</var> be an empty list.</li>
 
     <li>Let <var>hint tokens</var> be an empty set.</li>
 
@@ -11754,7 +11657,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <li>
 
     If <var>category</var> is Contact and the <var>index</var>th token in <var>tokens</var> is an
-    <a>ASCII case-insensitive</a> match for one of the strings in the following list, then run the substeps that follow:
+    <a>ASCII case-insensitive</a> match for one of the strings in the following list, then run the
+    substeps that follow:
 
     <ul class="brief">
       <li>"<code>home</code>"
@@ -11770,8 +11674,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
       <li>Let <var>contact</var> be the matching string from the list above.</li>
 
-      <li>Insert <var>contact</var> at the start of <var>scope
-      tokens</var>.</li>
+      <li>Insert <var>contact</var> at the start of <var>scope tokens</var>.</li>
 
       <li>Add <var>contact</var> to <var>hint tokens</var>.</li>
 
@@ -11804,8 +11707,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
       <li>Let <var>mode</var> be the matching string from the list above.</li>
 
-      <li>Insert <var>mode</var> at the start of <var>scope
-      tokens</var>.</li>
+      <li>Insert <var>mode</var> at the start of <var>scope tokens</var>.</li>
 
       <li>Add <var>mode</var> to <var>hint tokens</var>.</li>
 
@@ -11837,8 +11739,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <li>Let <var>IDL value</var> be the concatenation of <var>section</var>, a U+0020 SPACE
     character, and the previous value of <var>IDL value</var>.</li>
 
-    <li><i>Done</i>: Let the element's <a>autofill hint set</a> be <var>hint
-    tokens</var>.
+    <li><i>Done</i>: Let the element's <a>autofill hint set</a> be <var>hint tokens</var>.
 
     </li><li>Let the element's <a>autofill scope</a> be <var>scope tokens</var>.
 
@@ -11851,19 +11752,15 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <li><i>Default</i>: Let the element's <a>IDL-exposed autofill value</a> be the empty
     string, and its <a>autofill hint set</a> and <a>autofill scope</a> be empty.</li>
 
-    <li>If the element's <{autocompleteelements/autocomplete}> attribute is
-    wearing the <a>autofill anchor mantle</a>, then let the element's <a>autofill field
-    name</a> be the empty string and abort these steps.</li>
-
-    <li>Let <var>form</var> be the element's <a>form owner</a>, if any, or null
-    otherwise.</li>
+    <li>Let <var>form</var> be the element's <a>form owner</a>, if any, or null otherwise.</li>
 
     <li>
 
     If <var>form</var> is not null and <var>form</var>'s <{autocompleteelements/autocomplete}> attribute is in the <a state for="form/autocomplete">off</a> state, then let the element's
     <a>autofill field name</a> be "<a attr-value for="forms/autocomplete"><code>off</code></a>".
 
-    Otherwise, let the element's <a>autofill field name</a> be "<a attr-value for="forms/autocomplete"><code>on</code></a>".
+    Otherwise, let the element's <a>autofill field name</a> be
+    "<a attr-value for="forms/autocomplete"><code>on</code></a>".
 
     </li>
 
@@ -11885,8 +11782,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <dd>The element's <a for="forms">value</a>.</dd>
 
-    <dt>A <{select}> element with its <code>multiple</code>
-    attribute specified</dt>
+    <dt>A <{select}> element with its <code>multiple</code> attribute specified</dt>
 
     <dd>The <{option}> elements in the <{select}> element's <a>list of options</a> that have their <a state for="option">selectedness</a> set to true.</dd>
 
@@ -11898,105 +11794,110 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
   <hr />
 
-  How to process the <a>autofill hint set</a>, <a>autofill scope</a>, and
-  <a>autofill field name</a> depends on the mantle that the <{autocompleteelements/autocomplete}> attribute is wearing.
+  How to process the <a>autofill hint set</a>, <a>autofill scope</a>,
+  and <a>autofill field name</a> depends on the value of the
+  <{autocompleteelements/autocomplete}> attribute.
 
   <dl class="switch">
 
-    <dt>When wearing the <a>autofill expectation mantle</a>...
+    <dt>When <a>autofill field name</a> is "off"...</dt>
 
-    </dt><dd>
+    <dd>
+      When an element's <a>autofill field name</a> is
+      "<a attr-value for="forms/autocomplete"><code>off</code></a>", the user agent should not
+      remember the <a>control's data</a>, and should not offer past values to the user.
 
-    When an element's <a>autofill field name</a> is "<a attr-value for="forms/autocomplete"><code>off</code></a>", the user agent should not remember the <a>control's
-    data</a>, and should not offer past values to the user.
+      <p class="note">
+        In addition, when an element's <a>autofill field name</a> is
+        "<a attr-value for="forms/autocomplete"><code>off</code></a>", <a>values are reset</a>
+        when <a>traversing the history</a>.
+      </p>
 
-    <p class="note">
-    In addition, when an element's <a>autofill field name</a> is "<a attr-value for="forms/autocomplete"><code>off</code></a>", <a>values are reset</a>
-    when <a>traversing the history</a>.
-  </p>
+      <div class="example">
+        Banks frequently do not want user agents to prefill login information:
 
-    <div class="example">
-      Banks frequently do not want user agents to prefill login information:
-
-      <xmp highlight="html">
-        <div>
-          <label>
-            Account:
-            <input type="text" name="ac" autocomplete="off">
-          </label>
-        </div>
-        <div>
-          <label>
-            PIN:
-            <input type="password" name="pin" autocomplete="off">
-          </label>
-        </div>
-      </xmp>
-
-    </div>
-
-    When an element's <a>autofill field name</a> is <em>not</em> "<a attr-value for="forms/autocomplete"><code>off</code></a>", the user agent may store the <a>control's
-    data</a>, and may offer previously stored values to the user.
-
-    <div class="example">
-      For example, suppose a user visits a page with this control:
-
-      <xmp highlight="html">
-        <select name="country">
-          <option>Afghanistan</option>
-          <option>Albania</option>
-          <option>Algeria</option>
-          <option>Andorra</option>
-          <option>Angola</option>
-          <option>Antigua and Barbuda</option>
-          <option>Argentina</option>
-          <option>Armenia</option>
-          <!-- ... -->
-          <option>Yemen</option>
-          <option>Zambia</option>
-          <option>Zimbabwe</option>
-        </select>
-      </xmp>
-
-      This might render as follows:
-
-      <img src="images/select-country-1.png" alt="A drop-down control with a long alphabetical list of countries." />
-
-      Suppose that on the first visit to this page, the user selects "Zambia". On the second visit,
-      the user agent could duplicate the entry for Zambia at the top of the list, so that the interface
-      instead looks like this:
-
-      <img src="images/select-country-2.png" alt="The same drop-down control with the alphabetical list of countries, but with Zambia as an entry at the top." />
-
-    </div>
-
-    When the <a>autofill field name</a> is "<code>on</code>", the user agent should attempt to use heuristics to
-    determine the most appropriate values to offer the user, e.g., based on the element's <{formelements/name}> value, the position of the element in the document's DOM, what
-    other fields exist in the form, and so forth.
-
-    When the <a>autofill field name</a> is one of the names of the <a>autofill fields</a> described above, the user agent should provide suggestions that
-    match the meaning of the field name as given in the table earlier in this section. The
-    <a>autofill hint set</a> should be used to select amongst multiple possible suggestions.
-
-    <p class="example">For example, if a user once entered one address into fields that used the
-    "<code>shipping</code>" keyword, and another address into
-    fields that used the "<code>billing</code>" keyword, then in
-    subsequent forms only the first address would be suggested for form controls whose <a>autofill
-    hint set</a> contains the keyword "<code>shipping</code>". Both addresses might be suggested,
-    however, for address-related form controls whose <a>autofill hint set</a> does not contain
-    either keyword.</p>
-
+        <xmp highlight="html">
+          <div>
+            <label>
+              Account:
+              <input type="text" name="ac" autocomplete="off">
+            </label>
+          </div>
+          <div>
+            <label>
+              PIN:
+              <input type="password" name="pin" autocomplete="off">
+            </label>
+          </div>
+        </xmp>
+      </div>
     </dd>
 
-    <dt>When wearing the <a>autofill anchor mantle</a>...
+    <dt>
+      When <a>autofill field name</a> is <em>not</em> "off"...
+    </dt>
+    <dd>
+      When an element's <a>autofill field name</a> is <em>not</em>
+      "<a attr-value for="forms/autocomplete"><code>off</code></a>", the user agent may store
+      the <a>control's data</a>, and may offer previously stored values to the user.
 
-    </dt><dd>
+      <div class="example">
+        For example, suppose a user visits a page with this control:
 
-    When the <a>autofill field name</a> is not the empty string, then the user agent must
-    act as if the user had specified the <a>control's data</a> for the given <a>autofill
-    hint set</a>, <a>autofill scope</a>, and <a>autofill field name</a>
-    combination.
+        <xmp highlight="html">
+          <select name="country">
+            <option>Afghanistan</option>
+            <option>Albania</option>
+            <option>Algeria</option>
+            <option>Andorra</option>
+            <option>Angola</option>
+            <option>Antigua and Barbuda</option>
+            <option>Argentina</option>
+            <option>Armenia</option>
+            <!-- ... -->
+            <option>Yemen</option>
+            <option>Zambia</option>
+            <option>Zimbabwe</option>
+          </select>
+        </xmp>
 
+        This might render as follows:
+
+        <img src="images/select-country-1.png" alt="A drop-down control with a long alphabetical list of countries." />
+
+        Suppose that on the first visit to this page, the user selects "Zambia". On the second
+        visit, the user agent could duplicate the entry for Zambia at the top of the list, so
+        that the interface instead looks like this:
+
+        <img src="images/select-country-2.png" alt="The same drop-down control with the alphabetical list of countries, but with Zambia as an entry at the top." />
+
+      </div>
+
+      When the <a>autofill field name</a> is "<code>on</code>", the user agent should attempt to
+      use heuristics to determine the most appropriate values to offer the user, e.g., based on
+      the element's <{formelements/name}> value, the position of the element in the document's
+      DOM, what other fields exist in the form, and so forth.
+
+      When the <a>autofill field name</a> is one of the names of the <a>autofill fields</a>
+      described above, the user agent should provide suggestions that match the meaning of the
+      field name as given in the table earlier in this section. The <a>autofill hint set</a>
+      should be  used to select amongst multiple possible suggestions.
+
+      <p class="example">
+        For example, if a user once entered one address into fields that used the
+        "<code>shipping</code>" keyword, and another address into fields that used the
+        "<code>billing</code>" keyword, then in subsequent forms only the first address would be
+        suggested for form controls whose <a>autofill hint set</a> contains the keyword
+        "<code>shipping</code>". Both addresses might be suggested, however, for address-related
+        form controls whose <a>autofill hint set</a> does not contain either keyword.
+      </p>
+    </dd>
+
+    <dt>When not the empty string...</dt>
+    <dd>
+      When the <a>autofill field name</a> is not the empty string, then the user agent must
+      act as if the user had specified the <a>control's data</a> for the given
+      <a>autofill hint set</a>, <a>autofill scope</a>, and <a>autofill field name</a> combination.
     </dd>
 
   </dl>
@@ -12024,8 +11925,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   </p>
 
   <div class="example">
-    This requirement interacts with the <a>autofill anchor mantle</a> also. Consider the
-    following markup snippet:
+    Consider the following markup snippet:
 
     <xmp highlight="html">
       <form>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -2989,17 +2989,21 @@
     </dl>
   </div>
 
-  When an <{input}> element's <{input/type}> attribute is in
-  the <{input/Hidden}> state, the rules in this section apply.
+  When an <{input}> element's <{input/type}> attribute is in the <{input/Hidden}> state,
+  the rules in this section apply.
 
-  The <{input}> element <a>represents</a> a value that is not intended to be
-  examined or manipulated by the user.
+  The <{input}> element <a>represents</a> a value that is not intended to be examined or
+  manipulated by the user.
 
-  <strong>Constraint validation</strong>: If an <{input}> element's <{input/type}> attribute is in the <{input/Hidden}> state, it is <a>barred from constraint
-  validation</a>.
+  If an <{autocomplete}> attribute is used on an <{input}> element in the <{input/Hidden}> state,
+  it must not be used to change the value of the <{input}> element.
+
+  <strong>Constraint validation</strong>: If an <{input}> element's <{input/type}> attribute is in
+  the <{input/Hidden}> state, it is <a>barred from constraint validation</a>.
 
   If the <{input/name}> attribute is present and has a value that is a
-  <a>case-sensitive</a> match for the string "<code>_charset_</code>", then the element's <code>value</code> attribute must be omitted.
+  <a>case-sensitive</a> match for the string "<code>_charset_</code>", then the element's
+  <code>value</code> attribute must be omitted.
 
   <div class="bookkeeping">
 
@@ -3008,12 +3012,10 @@
     IDL attribute <a>applies</a> to this element and is
     in mode <a mode for="input">default</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
-    <{input/autocomplete}>,
     <{input/capture}>,
     <{input/checked}>,
     <{input/dirname}>,
@@ -3038,8 +3040,7 @@
     <{input/step}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/list}},
@@ -3142,13 +3143,11 @@
     {{HTMLInputElement/setRangeText()}}, and
     {{HTMLInputElement/setSelectionRange()}} methods.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/capture}>,
@@ -3166,8 +3165,7 @@
     <{input/step}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/valueAsDate}}, and
@@ -3241,13 +3239,11 @@
     {{HTMLInputElement/setRangeText()}}, and
     {{HTMLInputElement/setSelectionRange()}} methods.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -3267,8 +3263,7 @@
     <{input/step}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/valueAsDate}}, and
@@ -3590,13 +3585,11 @@
     {{HTMLInputElement/value}} IDL attributes;
     {{HTMLInputElement/select()}} method.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/capture}>,
@@ -3614,8 +3607,7 @@
     <{input/step}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/selectionStart}},
@@ -3680,13 +3672,11 @@
     {{HTMLInputElement/setRangeText()}}, and
     {{HTMLInputElement/setSelectionRange()}} methods.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/capture}>,
@@ -3706,8 +3696,7 @@
     <{input/step}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/list}},
@@ -3837,13 +3826,11 @@
     {{HTMLInputElement/stepDown()}}, and
     {{HTMLInputElement/stepUp()}} methods.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -3865,8 +3852,7 @@
     <{input/src}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/selectionStart}},
     {{HTMLInputElement/selectionEnd}}, and
@@ -3970,13 +3956,11 @@
     {{HTMLInputElement/stepDown()}}, and
     {{HTMLInputElement/stepUp()}} methods.
 
-    The {{HTMLInputElement/value}} IDL attribute is
-    in mode <a for="forms">value</a>.
+    The {{HTMLInputElement/value}} IDL attribute is in mode <a for="forms">value</a>.
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not
-    apply</a> to the element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -3998,8 +3982,7 @@
     <{input/src}>, and
     <{input/width}>.
 
-    The following IDL attributes and methods <a>do not apply</a> to the
-    element:
+    The following IDL attributes and methods <a>do not apply</a> to the element:
     {{HTMLInputElement/checked}},
     {{HTMLInputElement/files}},
     {{HTMLInputElement/selectionStart}},
@@ -4113,8 +4096,7 @@
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not apply</a> to the
-    element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,
@@ -4247,8 +4229,7 @@
 
     The <code>input</code> and <code>change</code> events <a>apply</a>.
 
-    The following content attributes must not be specified and <a>do not apply</a> to the
-    element:
+    The following content attributes must not be specified and <a>do not apply</a> to the element:
     <{input/accept}>,
     <{input/alt}>,
     <{input/autocapitalize}>,

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -1947,7 +1947,7 @@
 
     </td></tr><tr>
       <th> <{input/autocomplete}>
-      </th><td class="no"> ·
+      </th><td class="yes"> Yes
       </td><td class="yes"> Yes
 
       </td><td class="yes"> Yes
@@ -4488,11 +4488,11 @@
   See [[#date-time-and-number-formats]] for a discussion of the difference between the input format
   and submission format for date, time, and number form controls, and the
   <a>implementation notes</a> regarding localization of form controls.
-  
+
   Systems that need to enforce a particular format are encouraged to use the <code>pattern</code>
   attribute or the {{HTMLInputElement/setCustomValidity()}} method to hook into the client-side
   validation mechanism.
-  
+
   See [[#the-pattern-attribute]] for examples.
   </div>
 


### PR DESCRIPTION
Fixes #1389 
Removes instances of autofill mantle references to simplify the rules around `autocomplete` usage.
Notes that `autocomplete` should not be used to change the value of a hidden input
Corrects instances where `autocomplete` was said to not be valid on a hidden input element.