### PR TITLE
Editorial: additions to enctype description

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -13657,7 +13657,7 @@ fur
 
   For details on how to interpret <code>multipart/form-data</code> payloads, see RFC 7578. [[!RFC7578]]
 
-<h5 id="plain-text-form-data"><dfn>Plain text form data</dfn></h5>
+<h5><dfn>Plain text form data</dfn></h5>
 
   The <dfn><code>text/plain</code> encoding algorithm</dfn> is as follows:
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -10499,7 +10499,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
       keyword and corresponding state.
     </dt>
     <dd>
-      Allows for entire files to be submitted along with with form data.
+      Allows for entire files to be submitted along with form data.
     </dd>
 
     <dt>
@@ -13657,7 +13657,7 @@ fur
 
   For details on how to interpret <code>multipart/form-data</code> payloads, see RFC 7578. [[!RFC7578]]
 
-<h5 id="plain-text-form-data">Plain text form data</h5>
+<h5 id="plain-text-form-data"><dfn>Plain text form data</dfn></h5>
 
   The <dfn><code>text/plain</code> encoding algorithm</dfn> is as follows:
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -4507,11 +4507,11 @@
   See [[#date-time-and-number-formats]] for a discussion of the difference between the input format
   and submission format for date, time, and number form controls, and the
   <a>implementation notes</a> regarding localization of form controls.
-  
+
   Systems that need to enforce a particular format are encouraged to use the <code>pattern</code>
   attribute or the {{HTMLInputElement/setCustomValidity()}} method to hook into the client-side
   validation mechanism.
-  
+
   See [[#the-pattern-attribute]] for examples.
   </div>
 
@@ -10489,29 +10489,53 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <hr />
 
   The <dfn element-attr for="form"><code>enctype</code></dfn> and
-  <dfn element-attr for="submitbuttonelements,input,button"><code>formenctype</code></dfn> content attributes are <a>enumerated attributes</a> with the following keywords and
-  states:
+  <dfn element-attr for="submitbuttonelements,input,button"><code>formenctype</code></dfn>
+  content attributes are <a>enumerated attributes</a> that specify how form data should be encoded
+  upon a form submission. These attributes have the following keywords and states:
 
-  <ul>
-    <li>The "<dfn attr-value for="form/enctype"><code>application/x-www-form-urlencoded</code></dfn>" keyword and corresponding state.</li>
-    <li>The "<dfn attr-value for="form/enctype"><code>multipart/form-data</code></dfn>" keyword and corresponding state.</li>
-    <li>The "<dfn attr-value for="form/enctype"><code>text/plain</code></dfn>" keyword and corresponding state.</li>
-  </ul>
+  <dl>
+    <dt>The
+      "<dfn attr-value for="form/enctype"><code>application/x-www-form-urlencoded</code></dfn>"
+      keyword and corresponding state.
+    </dt>
+    <dd>
+      The default value if the attribute is not specified.
+    </dd>
 
-  The <i>invalid value default</i> for these attributes is the <code>application/x-www-form-urlencoded</code> state. The <i>missing value default</i> for the <{form/enctype}> attribute is also the <code>application/x-www-form-urlencoded</code> state. (There is no
-  <i>missing value default</i> for the <{submitbuttonelements/formenctype}>
-  attribute.)
+    <dt>
+      The "<dfn attr-value for="form/enctype"><code>multipart/form-data</code></dfn>"
+      keyword and corresponding state.
+    </dt>
+    <dd>
+      Allows for entire files to be submitted along with with form data.
+    </dd>
+
+    <dt>
+      The "<dfn attr-value for="form/enctype"><code>text/plain</code></dfn>"
+      keyword and corresponding state.
+    </dt>
+    <dd>
+      Submits as <a>plain text form data</a>, which is meant to be human readable.
+    </dd>
+  </dl>
+
+  The <i>invalid value default</i> for these attributes is the
+  <code>application/x-www-form-urlencoded</code> state. The <i>missing value default</i> for the
+  <{form/enctype}> attribute is also the <code>application/x-www-form-urlencoded</code> state.
+  (There is no <i>missing value default</i> for the
+  <{submitbuttonelements/formenctype}> attribute.)
 
   The <dfn>enctype</dfn> of an element is one of those three states.
-  If the element is a <{input/Submit|Submit Button}> and has a <{submitbuttonelements/formenctype}> attribute, then the element's <a>enctype</a> is that attribute's state; otherwise, it is the
-  <a>form owner</a>'s <{form/enctype}> attribute's state.
+  If the element is a <{input/Submit|Submit Button}> and has a
+  <{submitbuttonelements/formenctype}> attribute, then the element's <a>enctype</a> is that
+  attribute's state; otherwise, it is the <a>form owner</a>'s <{form/enctype}> attribute's state.
 
   <hr />
 
   The <dfn element-attr for="form"><code>target</code></dfn> and
-  <dfn element-attr for="submitbuttonelements,input,button"><code>formtarget</code></dfn> content attributes, if specified, must
-  have values that are <a>valid browsing context
-  names or keywords</a>.
+  <dfn element-attr for="submitbuttonelements,input,button"><code>formtarget</code></dfn> content
+  attributes, if specified, must have values that are
+  <a>valid browsing context names or keywords</a>.
 
   The <{form/target}> of an element is the value of the element's
   <{submitbuttonelements/formtarget}> attribute, if the element is a <{input/Submit|Submit Button}> and has such an attribute; or the value of its
@@ -13058,8 +13082,8 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
     </form>
   </xmp>
 
-  If the user types in "cats" in the first field and "fur" in the second, and then hits the
-  submit button, then the user agent will load <code>/find?t=cats&amp;q=fur</code>.
+  If the user types in "cats" in the first field and "fur" in the second, and then submits
+  the form, then the user agent will load <code>/find?t=cats&amp;q=fur</code>.
 
   On the other hand, consider this form:
 
@@ -13086,8 +13110,8 @@ fur
 
 <h5 id="implicit-submission">Implicit submission</h5>
 
-  A <{form}> element's <dfn>default button</dfn> is the first <{input/Submit|Submit Button}> in <a>tree order</a> whose <a>form
-  owner</a> is that <{form}> element.
+  A <{form}> element's <dfn>default button</dfn> is the first <{input/Submit|Submit Button}> in
+  <a>tree order</a> whose <a>form owner</a> is that <{form}> element.
 
   If the user agent supports letting the user submit a form implicitly (for example, on some
   platforms hitting the "enter" key while a text field is <a>focused</a> implicitly submits the form), then


### PR DESCRIPTION
Fixes #1445 

Adding some additional context to the purpose of the enctype attribute.

Converted the list of different keywords/states to a `dl` to provide short descriptions of each.