### PR TITLE
Editorial: Clarify expected value of button type attribute

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -4507,11 +4507,11 @@
   See [[#date-time-and-number-formats]] for a discussion of the difference between the input format
   and submission format for date, time, and number form controls, and the
   <a>implementation notes</a> regarding localization of form controls.
-  
+
   Systems that need to enforce a particular format are encouraged to use the <code>pattern</code>
   attribute or the {{HTMLInputElement/setCustomValidity()}} method to hook into the client-side
   validation mechanism.
-  
+
   See [[#the-pattern-attribute]] for examples.
   </div>
 
@@ -7400,23 +7400,26 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     </dd>
   </dl>
 
-  The <{button}> element <a>represents</a> a control allowing a user to trigger actions, when enabled.
-  It is labeled by its content.
+  The <{button}> element <a>represents</a> a control allowing a user to trigger actions,
+  when enabled. It is labeled by its content.
 
   The element is a <a>button</a>.
 
   The <dfn element-attr for="button"><code>type</code></dfn> attribute controls the behavior of
   the button when it is activated. It is an <a>enumerated attribute</a>. The following table
-  lists the keywords and states for the attribute — the keywords in the left column map to the
-  states in the cell in the second column on the same row as the keyword.
+  lists the allowed keywords for the attribute that will determine the state of the element —
+  the keywords in the left column map to the states in the cell in the second column on the
+  same row as the keyword.
 
   <table>
     <thead>
     <tr>
-      <th> Keyword
-      </th><th> State
-      </th><th> Brief description
-    </th></tr></thead><tbody>
+      <th> Keyword </th>
+      <th> State </th>
+      <th> Brief description </th>
+    </tr>
+    </thead>
+    <tbody>
     <tr>
       <td><dfn attr-value for="button/type"><code>submit</code></dfn>
       </td><td><dfn element-state for="button/type">submit button</dfn>
@@ -7429,20 +7432,23 @@ You cannot submit this form when the field is incorrect.</samp></pre>
       <td><dfn attr-value for="button/type"><code>button</code></dfn>
       </td><td><dfn element-state for="button/type">Button</dfn>
       </td><td>Does nothing.
-    </td></tr></tbody></table>
+    </td></tr>
+    </tbody>
+  </table>
 
   The <i>missing value default</i> is the <a element-state for="button/type">submit button</a> state.
 
-  If the <{input/type}> attribute is in the <a element-state for="button/type">submit button</a> state, the element is specifically a
-  <a element-state for="button/type">submit button</a>.
+  If the <{button/type}> attribute is in the <a element-state for="button/type">submit button</a>
+  state, the element is specifically a <a element-state for="button/type">submit button</a>.
 
-  <strong>Constraint validation</strong>: If the <{input/type}>
-  attribute is in the <a element-state for="button/type">reset button</a> state, or the
-  <a element-state for="button/type">Button</a> state, the element is barred from constrain validation.
+  <strong>Constraint validation</strong>: If the <{button/type}> attribute is in the
+  <a element-state for="button/type">reset button</a> state, or the
+  <a element-state for="button/type">Button</a> state, the element is barred
+  from constrain validation.
 
-  When a <{button}> element is not disabled,
-  its <a>activation behavior</a> element is to run the steps defined in the following list for
-  the current state of the element's <{input/type}> attribute:
+  When a <{button}> element is not disabled, its <a>activation behavior</a> element
+  is to run the steps defined in the following list for the current state of the
+  element's <{button/type}> attribute:
 
   <dl>
 
@@ -7455,8 +7461,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt> <a element-state for="button/type">reset button</a> </dt>
 
     <dd>If the element has a <a>form owner</a> and the element's <a>node document</a> is
-    <a>fully active</a>, the element must <a>reset</a> the
-    <a>form owner</a>.</dd>
+    <a>fully active</a>, the element must <a>reset</a> the <a>form owner</a>.</dd>
 
     <dt> <a element-state for="button/type">Button</a>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -7446,7 +7446,7 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   <a element-state for="button/type">Button</a> state, the element is barred
   from constrain validation.
 
-  When a <{button}> element is not disabled, its <a>activation behavior</a> element
+  When a <{button}> element is not disabled, its <a>activation behavior</a>
   is to run the steps defined in the following list for the current state of the
   element's <{button/type}> attribute:
 


### PR DESCRIPTION
Fixes #1319 

Update the prose to clarify that a button’s type attribute accepts a *keyword* to determine the *state* of the button.

Additionally, change `type` attribute links that were going to `input[type]` table to instead refer to `button[type]` table, since the `type` attribute is referring to the `button` element.