### PR TITLE
Editorial: note attributes are idl attributes

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -12075,7 +12075,10 @@ red:89
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><code>name</code> - Name of <a>image map</a> to reference from the <code>usemap</code> attribute</dd>
+    <dd>
+      <code>name</code> - Name of <a>image map</a> to reference from the
+      <code>usemap</code> attribute
+    </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>None</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
@@ -12092,9 +12095,8 @@ red:89
     </dd>
   </dl>
 
-  The <{map}> element, in conjunction with an <{img}> element and any
-  <{area}> element descendants, defines an <a>image map</a>. The element
-  <a>represents</a> its children.
+  The <{map}> element, in conjunction with an <{img}> element and any <{area}> element
+  descendants, defines an <a>image map</a>. The element <a>represents</a> its children.
 
   The <dfn element-attr for="map"><code>name</code></dfn> attribute gives the map a name so that
   it can be referenced. The attribute must be present and must have a non-empty value with no
@@ -12105,40 +12107,33 @@ red:89
   <dl class="domintro">
 
     <dt><var>map</var> . <code>areas</code></dt>
-
     <dd>
-
-    Returns an <code>HTMLCollection</code> of the <{area}> elements in the
-    <{map}>.
-
+      Returns an <code>HTMLCollection</code> of the <{area}> elements in the <{map}>.
     </dd>
 
     <dt><var>map</var> . <code>images</code></dt>
-
     <dd>
-
-    Returns an <code>HTMLCollection</code> of the <code>img</code> and <code>object</code>
-    elements that use the <{map}>.
-
+      Returns an <code>HTMLCollection</code> of the <code>img</code> and <code>object</code>
+      elements that use the <{map}>.
     </dd>
 
   </dl>
 
-  The <dfn attribute for="HTMLMapElement"><code>areas</code></dfn> attribute must return an
+  The <dfn attribute for="HTMLMapElement"><code>areas</code></dfn> IDL attribute must return an
   <code>HTMLCollection</code> rooted at the <{map}> element, whose filter matches only
   <{area}> elements.
 
-  The <dfn attribute for="HTMLMapElement"><code>images</code></dfn> attribute must return an
+  The <dfn attribute for="HTMLMapElement"><code>images</code></dfn> IDL attribute must return an
   <code>HTMLCollection</code> rooted at the {{Document}} node, whose filter matches only
-  <code>img</code> and <{object}> elements that are associated with this <code>map</code>
-  element according to the <a>image map</a> processing model.
+  <{img}> and <{object}> elements that are associated with this <{map}> element according
+  to the <a>image map</a> processing model.
 
   The IDL attribute <dfn attribute for="HTMLMapElement"><code>name</code></dfn> must <a>reflect</a>
   the content attribute of the same name.
 
   <div class="example">
     Image maps can be defined in conjunction with other content on the page, to ease maintenance.
-    This example is of a page with an image map at the top of the page and a corresponding set of
+    This example is of a page with an image map at the top of the page, and a corresponding set of
     text links at the bottom.
 
     <xmp highlight="html">

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -12125,7 +12125,7 @@ red:89
 
   The <dfn attribute for="HTMLMapElement"><code>images</code></dfn> IDL attribute must return an
   <code>HTMLCollection</code> rooted at the {{Document}} node, whose filter matches only
-  <{img}> and <{object}> elements that are associated with this <{map}> element according
+  <{img}> elements that are associated with this <{map}> element according
   to the <a>image map</a> processing model.
 
   The IDL attribute <dfn attribute for="HTMLMapElement"><code>name</code></dfn> must <a>reflect</a>


### PR DESCRIPTION
Fixes #1539 (repost of #1338 (no longer available))

per @chaals’s suggestion, noting that the areas and images attributes are IDL attributes.

@chaals we do have an example for `map` already.  If we do want to indicate the output of these attributes, maybe add it as an outro paragraph to the existing example?