### PR TITLE
Editorial: address unclear figcaption usage - issue 1540

### DIFF
--- a/includes/status.include
+++ b/includes/status.include
@@ -4,9 +4,9 @@ reflecting the "leading edge" of what is interoperably deployed as HTML.</p>
 <p>Review is particularly requested on significant changes made to the specification,
 noted in the <a href="#changes">changelog</a> section.</p>
 
-<p>The following features are considered candidates for being marked "at risk"
-and unless testing before or during Candidate Recommendation demonstrates interoperable implementation
-will be not be included in a Proposed Recommendation,
+<p>The following features are considered candidates for being marked "at risk" in a Candidate Recommendation.
+If they are, unless testing before or during Candidate Recommendation demonstrates interoperable implementation
+they will be not be included in a Proposed Recommendation,
 per [W3C Process - 6.4 Candidate Recommendation](https://www.w3.org/2017/Process-20170301/#candidate-rec):</p>
 
 <ul>

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1462,7 +1462,7 @@
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
-    <dd><a>Flow content</a> optionally including a <{figcaption}> child element.</dd>
+    <dd><a>Flow content</a> optionally including a single <{figcaption}> child element.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
@@ -1477,49 +1477,51 @@
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
 
-  The <{figure}> element <a>represents</a> some <a>flow content</a>, optionally with a
-  caption, that is self-contained (like a complete sentence) and is typically referenced as a single
+  The <{figure}> element <a>represents</a> some <a>flow content</a>, optionally with a caption,
+  that is self-contained (like a complete sentence) and is typically referenced as a single
   unit from the main flow of the document.
 
   <p class="note">
-    "Self-contained" in this context does not necessarily mean independent. For example, each sentence
-    in a paragraph is self-contained; an image that is part of a sentence would be inappropriate for
-    <{figure}>, but an entire sentence made of images would be fitting.
+    "Self-contained" in this context does not necessarily mean independent. For example, each
+    sentence in a paragraph is self-contained; an image that is part of a sentence would be
+    inappropriate for <{figure}>, but an entire sentence made of images would be fitting.
   </p>
 
-  The element can thus be used to annotate illustrations, diagrams, photos, code listings, etc.
+  The element can thus be used to annotate illustrations, diagrams, photos, code snippets, etc.
 
   <div class="note">
-    When a <code>figure</code> is referred to from the main content of the document by identifying
-    it by its caption (e.g., by figure number), it enables such content to be easily moved away from
-    that primary content, e.g., to the side of the page, to dedicated pages, or to an appendix,
-    without affecting the flow of the document.
+    When a <{figure}> is referred to from the main content of the document by identifying
+    it by its caption (e.g., by figure number), it enables such content to be easily moved away
+    from that primary content, e.g., to the side of the page, to dedicated pages, or to an
+    appendix, without affecting the flow of the document.
 
-    If a <{figure}> element is referenced by its relative position, e.g., "in the photograph
-    above" or "as the next figure shows", then moving the figure would disrupt the page's meaning.
-    Authors are encouraged to consider using labels to refer to figures, rather than using such
-    relative references, so that the page can easily be restyled without affecting the page's
-    meaning.
+    If a <code>figure</code> element is referenced by its relative position,
+    e.g., "in the photograph above" or "as the next figure shows", then moving the figure would
+    disrupt the page's meaning. Authors are encouraged to consider using labels to refer to
+    figures, rather than using such relative references, so that the page can easily be restyled
+    without affecting the page's meaning.
   </div>
 
-  The <{figcaption}> descendant of <{figure}>, if any, represents the caption of the <{figure}>
-  element's contents. If there is no child <{figcaption}> element, then there is no caption.
+  If a <{figure}> element has a child <{figcaption}> element, the element represents the caption
+  of the <{figure}> element's contents. If there is no child <code>figcaption</code> element, then
+  the <{figure}> has no caption.
 
   A <{figure}> element's contents are part of the surrounding flow. If the purpose of the
   page is to display the figure, for example a photograph on an image sharing site, the
   <code>figure</code> and <{figcaption}> elements can be used to explicitly provide a
   caption for that figure. For content that is only tangentially related, or that serves a separate
   purpose than the surrounding flow, the <{aside}> element should be used (and can itself
-  wrap a <{figure}>). For example, a pull quote that repeats content from an
-  <{article}> would be more appropriate in an <{aside}> than in a
-  <{figure}>, because it isn't part of the content, it's a repetition of the content for
-  the purposes of enticing readers or highlighting key topics.
+  wrap a <{figure}>). For example, a pull quote that repeats content from an <{article}> would be
+  more appropriate in an <{aside}> than in a <{figure}>, because it isn't part of the content,
+  it's a repetition of the content for the purposes of enticing readers or highlighting key topics.
 
   <div class="example">
     This example shows the <{figure}> element to mark up a code listing.
@@ -1546,7 +1548,7 @@
       <!DOCTYPE html>
       <title>Bubbles at work — My Gallery™</title>
       <figure>
-        <img src="bubbles-work.jpeg" alt="Bubbles, sitting in his office chair, works on his latest project intently.">
+        <img src="bubbles-work.jpg" alt="Bubbles, sitting in his office chair, works on his latest project intently.">
         <figcaption>Bubbles at work</figcaption>
       </figure>
       <nav><a href="19414.html">Prev</a> — <a href="19416.html">Next</a></nav>
@@ -1600,7 +1602,7 @@
   <div class="example">
     In this example, which could be part of a much larger work discussing a castle, nested
     <{figure}> elements are used to provide both a group caption and individual captions for
-    each figure in the group:
+    each figure in the group.
 
     <xmp highlight="html">
       <figure>
@@ -1615,7 +1617,7 @@
         </figure>
         <figure>
           <figcaption>Film photograph. Peter Jankle, 1999.</figcaption>
-          <img src="castle1999.jpeg" alt="The castle lies in ruins, the original tower all that remains in one piece.">
+          <img src="castle1999.jpeg" alt="The castle lies in ruins, the original tower is all that remains in one piece.">
         </figure>
       </figure>
     </xmp>
@@ -1629,7 +1631,7 @@
       <article>
         <h1>Fiscal negotiations stumble in Congress as deadline nears</h1>
         <figure>
-          <img src="obama-reid.jpeg" alt="Obama and Reid sit together smiling in the Oval Office.">
+          <img src="obama-reid.jpg" alt="Obama and Reid sit together smiling in the Oval Office.">
           <figcaption>Barack Obama and Harry Reid. White House press photograph.</figcaption>
         </figure>
         <p>
@@ -1672,13 +1674,62 @@
   The <{figcaption}> element <a>represents</a> a caption or legend for the rest of the
   contents of the <{figcaption}> element's parent <{figure}> element, if any.
 
+  There should be no more than one child <{figcaption}> element to a single
+  parent <{figure}> element.
+
+  If a <{table}> element is the only content of a <{figure}> element, other than the
+  <{figcaption}>, the <{caption}> element should be omitted in favor of the
+  <code>figcaption</code>.
+
+  <div class="example">
+    The following example shows an erroneous <{figure}> with two <{figcaption}> elements.
+
+    <xmp highlight="html" class="bad">
+      <!-- bad example -->
+      <figure>
+        <figcaption>
+          <p>Using appropriate markup will lead to less confusion and more accessible code.</p>
+        </figcaption>
+        <pre><code>
+          <div onClick="doSomething()">
+            What am I?
+          </div>
+        </code></pre>
+        <figcaption>
+          <p>Instead the author should have used a <code>button</code> element to ensure proper semantics and keyboard functionality were preserved.</p>
+        </figcaption>
+      </figure>
+    </xmp>
+
+    Instead of providing two captions to the <{figure}>, the markup should have been
+    markedup as follows:
+
+    <xmp highlight="html">
+      <figure>
+        <pre><code>
+          <div onClick="doSomething()">
+            What am I?
+          </div>
+        </code></pre>
+        <figcaption>
+          <p>Using appropriate markup will lead to less confusion and more accessible code.</p>
+
+          <p>Instead the author should have used a <code>button</code> element to ensure proper semantics and keyboard functionality were preserved.</p>
+        </figcaption>
+      </figure>
+    </xmp>
+  </div>
+
 <h4 id="the-main-element">The <dfn element><code>main</code></dfn> element</h4>
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Flow content</a>.</dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
-    <dd>Where <a>flow content</a> is expected, but only if it is a <dfn>hierarchically correct main element</dfn>.</dd>
+    <dd>
+      Where <a>flow content</a> is expected, but only if it is a
+      <dfn>hierarchically correct main element</dfn>.
+    </dd>
     <dt><a>Content model</a>:</dt>
     <dd><a>Flow content</a>.</dd>
     <dt><a>Tag omission in text/html</a>:</dt>
@@ -1691,17 +1742,23 @@
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default role</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses <code>HTMLElement</code></dd>
   </dl>
 
   The <{main}> element <a>represents</a> the dominant contents of the document.
 
-  A document must not have more than one <{main}> element that does not have the [[#the-hidden-attribute]] attribute specified.
+  A document must not have more than one <{main}> element that does not have the
+  [[#the-hidden-attribute]] attribute specified.
 
-  A <a>hierarchically correct main element</a> is one whose ancestor elements are limited to <{html}>, <{body}>, <{div}>, <{form}> without an <a>accessible name</a>, and <a>autonomous custom elements</a>. Each <{main}> element must be a <a>hierarchically correct main element</a>.
+  A <a>hierarchically correct main element</a> is one whose ancestor elements are limited to
+  <{html}>, <{body}>, <{div}>, <{form}> without an <a>accessible name</a>, and
+  <a>autonomous custom elements</a>. Each <{main}> element must be a
+  <a>hierarchically correct main element</a>.
 
   <p class="note">
     The <{main}> element is not <a>sectioning content</a> and has no effect on the document

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1510,7 +1510,7 @@
     without affecting the page's meaning.
   </div>
 
-  If a <{figure}> element has a child <{figcaption}> element, the element represents the caption
+  If a <{figure}> element has a child <{figcaption}> element, that element represents the caption
   of the <{figure}> element's contents. If there is no child <code>figcaption</code> element, then
   the <{figure}> has no caption.
 
@@ -1702,7 +1702,7 @@
     </xmp>
 
     Instead of providing two captions to the <{figure}>, the markup should have been
-    markedup as follows:
+    written as follows:
 
     <xmp highlight="html">
       <figure>


### PR DESCRIPTION
Fixes #1540

Addresses point to clarif content model for `figure` element.

Mention in the prose of the `figcaption` section that there should be no more than one child `figcaption`  to a single parent `figure`.

Additionally pull over prose from `table` section, about how a `figcaption` should be used instead of a `caption` if a `table` is the primary content of a `figure`.

Further, added new example showing how 2 `figcaption` elements should be avoided and instead coded as a single `figcaption` to a `figure` showcasing a code snippet.

Includes other file cleanup.