### PR TITLE
Editorial: add prose to bdi example

### DIFF
--- a/sections/semantics-textlevel.include
+++ b/sections/semantics-textlevel.include
@@ -2900,8 +2900,10 @@
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
@@ -2921,8 +2923,9 @@
   </p>
 
   <div class="example">
-    This element is especially useful when embedding user-generated content with an unknown
-    directionality.
+    The <{bdi}> element is especially useful when embedding user-generated content with an unknown
+    directionality, or when incorporating spans of text that need to be rendered in the opposite
+    direction of the surrounding text.
 
     In this example, usernames are shown along with the number of posts that the user has
     submitted. If the <{bdi}> element were not used, the username of the Arabic user would end
@@ -2966,7 +2969,8 @@
       </ul>
     </xmp>
 
-    When there is no existing element available, the <{bdi}> element can be used to achieve the same effect.
+    When there is no existing element available, the <{bdi}> element can be used to achieve the
+    same effect.
 
     <xmp highlight="html">
       <ul>
@@ -2998,14 +3002,16 @@
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>Uses {{HTMLElement}}.</dd>
   </dl>
 
-  The <{bdo}> element <a>represents</a> explicit text directionality formatting
-  control for its children. It allows authors to override the Unicode bidirectional algorithm while
+  The <{bdo}> element <a>represents</a> explicit text directionality formatting control for its
+  children. It allows authors to override the Unicode bidirectional algorithm while
   explicitly specifying a direction override. [[!BIDI]]
 
   Authors must specify the <{global/dir}> attribute on this element, with the value
@@ -3039,9 +3045,14 @@
     <bdo dir="rtl">שלום Majima! מה שלומך היום?</bdo><br>
     <bdo dir="ltr">שלום Majima! מה שלומך היום?</bdo>
 
-    In this example, you can see the latin characters in the <{bdi}> element being rendered from left-to-right, whereas the rest of the text being rendered right-to-left. This is because the bidirectional algorithm recognizes latin characters and automatically applies a left-to-right rendering for just those characters.
+    In this example, you can see the Latin characters in the <{bdi}> element being rendered from
+    left-to-right, whereas the rest of the text being rendered right-to-left. This is because the
+    bidirectional algorithm recognizes Latin characters and automatically applies a left-to-right
+    rendering for just those characters.
 
-    In the <{bdo}> text, the bidirectional algorithm is disabled. So the text will be rendered character by character in the direction specified, in a sequential order corresponding to that of the characters in memory.
+    In the <{bdo}> text, the bidirectional algorithm is disabled. So the text will be rendered
+    character by character in the direction specified, in a sequential order corresponding to
+    that of the characters in memory.
   </div>
 
 <h4 id="the-span-element">The <dfn element><code>span</code></dfn> element</h4>
@@ -3063,8 +3074,10 @@
     <dd><a href="#allowed-aria-roles-states-and-properties">Any role value</a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes
-    <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -3073,10 +3086,9 @@
     </dd>
   </dl>
 
-  The <{span}> element doesn't mean anything on its own, but can be useful when used
-  together with the <a>Global attributes</a>, e.g., <code>class</code>,
-  <{global/lang}>, or <code>dir</code>. It
-  <a>represents</a> its children.
+  The <{span}> element doesn't mean anything on its own, but can be useful when used together with
+  the <a>Global attributes</a>, e.g., <{global/class}>, <{global/lang}>, or <{global/dir}>.
+  It <a>represents</a> its children.
 
   <div class="example">
     In this example, a code fragment is marked up using


### PR DESCRIPTION
Fixes #1493 

Provide some extra prose to the `bdi` example that better represent the example being shown.

The prose that were already in place are maintained, as while the code example doesn’t illustrate them specifiatlly, it’s still a valid statement.