### PR TITLE
Deprecate object from forms

### DIFF
--- a/sections/changes.include
+++ b/sections/changes.include
@@ -12,6 +12,12 @@
 
 <h3 id="changes-wd4">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
 <dl>
+  <dt>
+    <a href="https://github.com/w3c/html/pull/1576">Deprecate <code>object</code> from forms</a>
+  </dt>
+  <dd>
+    Fixed <a href="https://github.com/w3c/html/issues/1543">object element doesn't do anything in forms</a>
+  </dd>
   <dt><a href="https://github.com/w3c/html/pull/1479"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
   <dt><a href="https://github.com/w3c/html/pull/1489">Define <code>HTMLOrSVGElement</code> mixin interface</a>.</dt>
   <dd>Fixed <a href="https://github.com/w3c/html/issues/1299">issue 1299</a>

--- a/sections/elements.include
+++ b/sections/elements.include
@@ -906,7 +906,6 @@
            <{object/type}>;
            <{object/typemustmatch}>;
            <{object/name}>;
-           <{object/form}>;
            <{media/width}>;
            <{media/height}></td>
        <td>{{HTMLObjectElement}}</td>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5415,11 +5415,12 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   removed, if the <{object}> element has a <a>browsing context</a>, the
   <a>browsing context name</a> must be set to the empty string.
 
-  The <{object/form}> attribute is used to explicitly associate the
-  <{object}> element with its <a>form owner</a>.
+  The <{object/form}> attribute is used to explicitly associate the <{object}> element with
+  a <{form}> element in the same {{Document}}. The value of the attribute must be an <a>ID</a>
+  of the <{form}> element that will become the <a>form owner</a> to the <{object]> element.
 
-  <strong>Constraint validation</strong>: <{object}> elements are always <a>barred
-  from constraint validation</a>.
+  <strong>Constraint validation</strong>: <{object}> elements are always
+  <a>barred from constraint validation</a>.
 
   The <{object}> element supports <a>dimension attributes</a>.
 

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4843,7 +4843,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd><a>Flow content</a>.</dd>
     <dd><a>Phrasing content</a>.</dd>
     <dd><a>Embedded content</a>.</dd>
-    <dd><a lt="listed element">listed</a>, <a>submittable</a>, and <a>reassociateable</a> <a>form-associated element</a>.</dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>embedded content</a> is expected.</dd>
@@ -4860,7 +4859,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
       attribute and the <a>Content-Type</a> value need to match for the resource to be used
     </dd>
     <dd><{object/name}> - Name of <a>nested browsing context</a></dd>
-    <dd><{object/form}> - Associates the control with a <{form}> element</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
@@ -4886,7 +4884,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
           attribute DOMString type;
           attribute boolean typeMustMatch;
           attribute DOMString name;
-          readonly attribute HTMLFormElement? form;
           attribute DOMString width;
           attribute DOMString height;
           readonly attribute Document? contentDocument;
@@ -4912,8 +4909,8 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   type of the resource, will either be treated as an image, as a <a>nested browsing context</a>, or as an external resource to be processed by a <a>plugin</a>.
 
   The <dfn element-attr for="object"><code>data</code></dfn> attribute, if present, specifies the
-  address of the resource. If present, the attribute must be a <a>valid non-empty URL potentially
-  surrounded by spaces</a>.
+  address of the resource. If present, the attribute must be a
+  <a>valid non-empty URL potentially surrounded by spaces</a>.
 
   <p class="warning">Authors who reference resources from other <a for="concept">origins</a>
   that they do not trust are urged to use the <code>typemustmatch</code> attribute defined below. Without that
@@ -5415,13 +5412,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   removed, if the <{object}> element has a <a>browsing context</a>, the
   <a>browsing context name</a> must be set to the empty string.
 
-  The <{object/form}> attribute is used to explicitly associate the <{object}> element with
-  a <{form}> element in the same {{Document}}. The value of the attribute must be an <a>ID</a>
-  of the <{form}> element that will become the <a>form owner</a> to the <{object]> element.
-
-  <strong>Constraint validation</strong>: <{object}> elements are always
-  <a>barred from constraint validation</a>.
-
   The <{object}> element supports <a>dimension attributes</a>.
 
   The IDL attributes <dfn attribute for="HTMLObjectElement"><code>data</code></dfn>,
@@ -5440,13 +5430,6 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   The <dfn attribute for="HTMLObjectElement"><code>contentWindow</code></dfn> IDL attribute must
   return the {{WindowProxy}} object of the <{object}> element's <a>nested browsing context</a>, if
   it has one; otherwise, it must return null.
-
-  The {{HTMLObjectElement/willValidate}}, {{HTMLObjectElement/validity}}, and
-  {{HTMLObjectElement/validationMessage}} attributes, and the
-  {{HTMLObjectElement/checkValidity()}}, {{HTMLObjectElement/reportValidity()}}, and
-  {{HTMLObjectElement/setCustomValidity()}} methods, are part of the
-  <a>constraint validation API</a>. The {{HTMLObjectElement/form}} IDL attribute is part
-  of the element's forms API.
 
   All <{object}> elements have a <dfn for="object">legacy caller operation</dfn>. If the
   <{object}> element has an instantiated <a>plugin</a> that supports a scriptable interface that

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4853,12 +4853,14 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
     <dd>Neither tag is omissible.</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><code>data</code> - Address of the resource</dd>
-    <dd><code>type</code> - Type of embedded resource</dd>
-    <dd><code>typemustmatch</code> - Whether the <code>type</code>
-    attribute and the <a>Content-Type</a> value need to match for the resource to be used</dd>
+    <dd><{object/data}> - Address of the resource</dd>
+    <dd><{object/type}> - Type of embedded resource</dd>
+    <dd>
+      <{object/typemustmatch}> - Whether the <{object/type}>
+      attribute and the <a>Content-Type</a> value need to match for the resource to be used
+    </dd>
     <dd><{object/name}> - Name of <a>nested browsing context</a></dd>
-    <dd><code>form</code> - Associates the control with a <{form}> element</dd>
+    <dd><{object/form}> - Associates the control with a <{form}> element</dd>
     <dd><code>width</code> - Horizontal dimension</dd>
     <dd><code>height</code> - Vertical dimension</dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -1038,8 +1038,8 @@
 
     <dd>
 
-    Returns an {{HTMLFormControlsCollection}} of the form controls in the form (excluding image
-    buttons for historical reasons).
+    Returns an {{HTMLFormControlsCollection}} of the form controls in the form
+    (excluding image buttons, but including <{object}> elements, for historical reasons).
 
     </dd>
 
@@ -1047,8 +1047,8 @@
 
     <dd>
 
-    Returns the number of form controls in the form (excluding image buttons for historical
-    reasons).
+    Returns the number of form controls in the form (excluding image buttons, but including
+    <{object}> elements, for historical reasons).
 
     </dd>
 
@@ -1056,8 +1056,8 @@
 
     <dd>
 
-    Returns the <var>index</var>th element in the form (excluding image buttons for
-    historical reasons).
+    Returns the <var>index</var>th element in the form (excluding image buttons, but
+    including <{object}> elements, for historical reasons).
 
     </dd>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -720,7 +720,6 @@
     <li><{fieldset}></li>
     <li><{input}></li>
     <li><{label}></li>
-    <li><{object}></li>
     <li><{output}></li>
     <li><{select}></li>
     <li><{textarea}></li>
@@ -742,7 +741,6 @@
       <li><{button}></li>
       <li><{fieldset}></li>
       <li><{input}></li>
-      <li><{object}></li>
       <li><{output}></li>
       <li><{select}></li>
       <li><{textarea}></li>
@@ -760,7 +758,6 @@
     <ul class="brief category-list">
       <li><{button}></li>
       <li><{input}></li>
-      <li><{object}></li>
       <li><{select}></li>
       <li><{textarea}></li>
     </ul>
@@ -798,7 +795,6 @@
       <li><{button}></li>
       <li><{fieldset}></li>
       <li><{input}></li>
-      <li><{object}></li>
       <li><{output}></li>
       <li><{select}></li>
       <li><{textarea}></li>
@@ -901,15 +897,6 @@
         <td class="yes">yes</td>
         <td class="yes">yes</td>
         <td class="yes">yes</td>
-      </tr>
-      <tr>
-        <td><{object}></td>
-        <td class="yes">yes</td>
-        <td class="yes">yes</td>
-        <td class="yes">yes</td>
-        <td>no</td>
-        <td class="yes">yes</td>
-        <td>no</td>
       </tr>
       <tr>
         <td><{meter}></td>
@@ -4507,11 +4494,11 @@
   See [[#date-time-and-number-formats]] for a discussion of the difference between the input format
   and submission format for date, time, and number form controls, and the
   <a>implementation notes</a> regarding localization of form controls.
-  
+
   Systems that need to enforce a particular format are encouraged to use the <code>pattern</code>
   attribute or the {{HTMLInputElement/setCustomValidity()}} method to hook into the client-side
   validation mechanism.
-  
+
   See [[#the-pattern-attribute]] for examples.
   </div>
 
@@ -12608,8 +12595,11 @@ control.setSelectionRange(oldStart + prefix.length, oldEnd + prefix.length, oldD
 
 <h5 id="constraints-definitions">Definitions</h5>
 
-  A <a>submittable element</a> is a <dfn lt="candidates for constraint validation|candidate for constraint validation">candidate for constraint validation</dfn> except when a condition has <dfn lt="barred from constraint validation|barring it from constraint validation">barred the element from constraint validation</dfn>. (For example, an element is <a>barred from
-  constraint validation</a> if it is an <{object}> element.)
+  A <a>submittable element</a> is a <dfn lt="candidates for constraint validation|candidate for
+  constraint validation">candidate for constraint validation</dfn> except when a condition has
+  <dfn lt="barred from constraint validation|barring it from constraint validation">barred the element from constraint validation</dfn>.
+  (For example, an <{input}> with the <{input/readonly}> attribute is
+  <a>barred from constraint validation</a>.)
 
   An element can have a <dfn>custom validity error message</dfn> defined. Initially, an element
   must have its <a>custom validity error message</a> set to the empty string. When its value
@@ -13467,9 +13457,6 @@ fur
         specified, or its <{formelements/name}> attribute's value is the empty
         string.</li>
 
-        <li>The <var>field</var> element is an <{object}> element that is not using
-        a <a>plugin</a>.</li>
-
       </ul>
 
       Otherwise, process <var>field</var> as follows:
@@ -13548,11 +13535,6 @@ fur
       the name, the file (consisting of the name, the type, and the body) as the value, and <var>type</var> as the type. If there are no <a>selected files</a>, then append an entry to the
       <var>form data set</var> with the <var>name</var> as the name, the empty
       string as the value, and <code>application/octet-stream</code> as the type.</li>
-
-      <li>Otherwise, if the <var>field</var> element is an <{object}> element:
-      try to obtain a <a>form submission</a> value from the <a>plugin</a>, and if that is successful,
-      append an entry to the <var>form data set</var> with <var>name</var> as the
-      name, the returned <a>form submission</a> value as the value, and the string "<code>object</code>" as the type.</li>
 
       <li>Otherwise, append an entry to the <var>form data set</var> with <var>name</var> as the name, the <a for="forms">value</a> of the <var>field</var> element as the value, and <var>type</var> as the type.</li>
 


### PR DESCRIPTION
Fixes #1543 (was #1314)

~The linked 'form owner' section provides additional information on the attribute an its usage, so i'm not too concerned with adding in an actual example to for the `object` element.  Especially considering issue #1545 ...~

~The prose for this section were expanded a bit though, to explicitly indicate that an `id` is the expected value for associating an `object` with a `form` within the same document.~

Additionally linked up object attributes to their sections in the spec...