### PR TITLE
Support audio codecs in video

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -82,7 +82,7 @@
   Hayato Ito,
   Heydon Pickering, <!-- https://github.com/Heydon -->
   <a href="https://github.com/iandevlin">Ian Devlin</a>,
-  "Isaacrojas0394", <!-- https://github.com/isaacrojas0394 --> 
+  "Isaacrojas0394", <!-- https://github.com/isaacrojas0394 -->
   J.C.Jones,
   James Craig,
   Jan Miksovsky,
@@ -121,6 +121,7 @@
   Noel Gordon,
   Oliver Byford,
   Olli Pettay,
+  Owen Edwards,
   Patrick H. Lauke, <!-- https://github.com/patrickhlauke -->
   Paul Libbrecht,
   "paulpalaszewski", <!-- https://github.com/paulpalaszewski -->

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -16,7 +16,7 @@
   <dt><a href="https://github.com/w3c/html/pull/1517">Removes the concept of autofill mantles</a></dt>
   <dd>Fixed <a href="https://github.com/w3c/html/issues/1389">Issue 1389</a> - clarify usage of <{input/autocomplete}> attribute on <code>input type=hidden</code></dd>
 <dl>
-  <dt><a href="https://github.com/w3c/html/pull/@@">Be explicit that user agents should support the same set of audio codecs in both <coode>audio</code> and <code>video</code> elements</a>.</dt>
+  <dt><a href="https://github.com/w3c/html/pull/1579">Be explicit that user agents should support the same set of audio codecs in both <coode>audio</code> and <code>video</code> elements</a>.</dt>
   <dd>Fixed <a href="https://github.com/w3c/html/issues/1430">issue 1430</a>
   </dd>
 </dl>

--- a/sections/changes.include
+++ b/sections/changes.include
@@ -10,7 +10,16 @@
   <a href="https://github.com/w3c/html/">w3c/html github repository</a>, including various
   editorial and linking fixes.
 
-<h3 id="changes-wd4">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
+<h3 id="changes-wd5">Changes since the <a href="https://www.w3.org/TR/2018/WD-html53-@@/">HTML 5.3 Fourth Working Draft</a></h3>
+<dl>
+  <dt><a href="https://github.com/w3c/html/pull/@@">Be explicit that user agents should support the same set of audio codecs in both <coode>audio</code> and <code>video</code> elements</a>.</dt>
+  <dd>Fixed <a href="https://github.com/w3c/html/issues/1430">issue 1430</a>
+  </dd>
+</dl>
+
+
+
+<h3 id="changes-wd4">Changes between the @@fourth and <a href="https://www.w3.org/TR/2018/WD-html53-20180426/">HTML 5.3 Third Working Draft</a></h3>
 <dl>
   <dt><a href="https://github.com/w3c/html/pull/1479"><code>http-equiv="set-cookie"</code> has no effect</a>.</dt>
   <dt><a href="https://github.com/w3c/html/pull/1489">Define <code>HTMLOrSVGElement</code> mixin interface</a>.</dt>

--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5676,6 +5676,10 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   The <{video}> element is a <a>media element</a> whose <a>media data</a> is ostensibly video
   data, possibly with associated audio data.
 
+  Because the <{video}> element is necessary to support accessibility for audio content,
+  user agents should support playback of the same set of audio formats in the <{video}> element
+  that they support for the <{audio}> element.
+
   The <code>src</code>, <code>preload</code>, <code>autoplay</code>, <code>loop</code>,
   <code>muted</code>, and <{video/controls}> attributes are the attributes common to all
   media elements.
@@ -6019,7 +6023,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
   <p class="note">
     In particular, this content is not intended to address accessibility concerns. To
-    make audio content accessible to the deaf or to those with other physical or cognitive
+    make audio content accessible to people with hearing, cognitive or other
     disabilities, a variety of features are available. If captions or a sign language video are
     available, the <{video}> element can be used instead of the <{audio}> element to
     play the audio, allowing users to enable the visual alternatives. Chapter titles can be


### PR DESCRIPTION
fix #1430 

Note that user agents should support playback of all supported audio codecs in video element for accessibility.