### PR TITLE
Editorial: audio *and container*

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -5677,8 +5677,8 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
   data, possibly with associated audio data.
 
   Because the <{video}> element is necessary to support accessibility for audio content,
-  user agents should support playback of the same set of audio formats in the <{video}> element
-  that they support for the <{audio}> element.
+  user agents should support playback of the same set of audio formats and container formats
+  in the <{video}> element that they support for the <{audio}> element.
 
   The <code>src</code>, <code>preload</code>, <code>autoplay</code>, <code>loop</code>,
   <code>muted</code>, and <{video/controls}> attributes are the attributes common to all


### PR DESCRIPTION
trivial tweak for correctness, thanks to Owen Edwards