### PR TITLE
Editorial: update fieldset attribute descriptions

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -9700,7 +9700,9 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dt><a>Categories</a>:</dt>
     <dd><a>Flow content</a>.</dd>
     <dd><a>Sectioning root</a>.</dd>
-    <dd><a lt="listed element">listed</a> and <a>reassociateable</a> <a>form-associated element</a>.</dd>
+    <dd>
+      <a lt="listed element">listed</a> and <a>reassociateable</a> <a>form-associated element</a>.
+    </dd>
     <dd><a>Palpable content</a>.</dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
@@ -9710,9 +9712,13 @@ You cannot submit this form when the field is incorrect.</samp></pre>
     <dd>Neither tag is omissible</dd>
     <dt><a>Content attributes</a>:</dt>
     <dd><a>Global attributes</a></dd>
-    <dd><{fieldset/disabled}> - Whether the form control is disabled</dd>
-    <dd><{fieldset/form}> - Associates the control with a <{form}> element</dd>
-    <dd><{fieldset/name}> - Name of form control to use for [[#forms-form-submission]] and in the {{HTMLFormElement/elements|form.elements}} API  </dd>
+    <dd>
+      <{fieldset/disabled}> - Whether the element's descendant form controls, except those inside the <{legend}>, are disabled
+    </dd>
+    <dd><{fieldset/form}> - Associates the element with a <{form}> element</dd>
+    <dd>
+      <{fieldset/name}> - Name of the element to use for [[#forms-form-submission]] and in the {{HTMLFormElement/elements|form.elements}} API
+    </dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
       <a attr-value for="aria/role"><code>group</code></a> (default - <a><em>do not set</em></a>),
@@ -9760,7 +9766,8 @@ You cannot submit this form when the field is incorrect.</samp></pre>
   are descendants of the <{fieldset}> element's first <{legend}> element child, if
   any, to be disabled.
 
-  A <{fieldset}> element is a <dfn>disabled fieldset</dfn> if it matches any of the following conditions:
+  A <{fieldset}> element is a <dfn>disabled fieldset</dfn> if it matches any of the
+  following conditions:
 
   <ul>
 


### PR DESCRIPTION
Fixes #1605 

Updates descriptions for:
* `disabled`
* `form`
* `name`
when used on a `fieldset`