### PR TITLE
Editorial: Port updates from ARIA in HTML spec

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -10713,49 +10713,47 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <li>Let <var>target</var> be the element's <a>node document</a>.</li>
 
-    <li>If <var>target</var> has no <a>browsing context</a>, abort these
-    steps.</li>
+    <li>If <var>target</var> has no <a>browsing context</a>, abort these steps.</li>
 
-    <li>If <var>target</var>'s <a>browsing context</a> has no <a>top-level
-    browsing context</a> (e.g., it is a <a>nested browsing context</a> with no <a>parent
-    browsing context</a>), abort these steps.</li>
+    <li>If <var>target</var>'s <a>browsing context</a> has no
+    <a>top-level browsing context</a> (e.g., it is a <a>nested browsing context</a>
+    with no <a>parent browsing context</a>), abort these steps.</li>
 
     <li>If <var>target</var>'s <a>active sandboxing flag set</a> has the
     <a>sandboxed automatic features browsing context flag</a>, abort these steps.</li>
 
-    <li>If <var>target</var>'s [=concept/origin=] is not the same as the
-    [=concept/origin=] of the <a>node document</a> of the currently
-    focused element in <var>target</var>'s <a>top-level browsing context</a>, abort
-    these steps.</li>
+    <li>If <var>target</var>'s [=concept/origin=] is not the same as the [=concept/origin=] of the
+    <a>node document</a> of the currently focused element in <var>target</var>'s
+    <a>top-level browsing context</a>, abort these steps.</li>
 
     <li>If <var>target</var>'s [=concept/origin=] is not the same as the
     [=concept/origin=] of the <a>active document</a> of <var>target</var>'s
     <a>top-level browsing context</a>, abort these steps.</li>
 
     <li>If the user agent has already reached the last step of this list of steps in response to
-    an element being <a>inserted</a> into a
-    <code>Document</code> whose <a>top-level browsing context</a>'s <a>active
-    document</a> is the same as <var>target</var>'s <a>top-level browsing
-    context</a>'s <a>active document</a>, abort these steps.</li>
+    an element being <a>inserted</a> into a <code>Document</code> whose
+    <a>top-level browsing context</a>'s <a>active document</a> is the same as <var>target</var>'s
+    <a>top-level browsing context</a>'s <a>active document</a>, abort these steps.</li>
 
-    <li>If the user has indicated (for example, by starting to type in a form control) that he
-    does not wish focus to be changed, then optionally abort these steps.</li>
+    <li>If the user has indicated (for example, by starting to type in a form control) that they
+    do not wish focus to be changed, then optionally abort these steps.</li>
 
-    <li><a>Queue a task</a> that runs the <a>focusing steps</a> for the element. User
-    agents may also change the scrolling position of the document, or perform some other action that
+    <li><a>Queue a task</a> that runs the <a>focusing steps</a> for the element. User agents may
+    also change the scrolling position of the document, or perform some other action that
     brings the element to the user's attention. The <a>task source</a> for this task is the
     <a>user interaction task source</a>.</li>
 
   </ol>
 
   <p class="note">
-    This handles the automatic focusing during document load. The <code>show()</code> and <code>showModal()</code>
-  methods of <{dialog}> elements also processes the <{formelements/autofocus}> attribute.
+    This handles the automatic focusing during document load. The <code>show()</code> and
+    <code>showModal()</code> methods of <{dialog}> elements also processes the
+    <{formelements/autofocus}> attribute.
   </p>
 
   <p class="note">
     Focusing the control does not imply that the user agent must focus the browser
-  window if it has lost focus.
+    window if it has lost focus.
   </p>
 
   The <dfn attribute for="HTMLInputElement,HTMLButtonElement,HTMLSelectElement,HTMLTextAreaElement"><code>autofocus</code></dfn> IDL attribute must
@@ -10798,13 +10796,11 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <li>
 
-    Optionally, a token whose first eight characters are an <a>ASCII case-insensitive</a>
-    match for the string "<code>section-</code>",
-    meaning that the field belongs to the named group.
+    Optionally, a token whose first eight characters are an <a>ASCII case-insensitive</a> match
+    for the string "<code>section-</code>", meaning that the field belongs to the named group.
 
     <div class="example">
-      For example, if there are two shipping addresses in the form, then they could be marked up
-      as:
+      For example, if there are two shipping addresses in a form, then they could be marked up as:
 
       <xmp highlight="html">
         <fieldset>
@@ -10857,18 +10853,18 @@ You cannot submit this form when the field is incorrect.</samp></pre>
 
     <li>
 
-    Optionally, a token that is an <a>ASCII case-insensitive</a> match for one of the
-    following strings:
+      Optionally, a token that is an <a>ASCII case-insensitive</a> match for one of the
+      following strings:
 
-    <ul class="brief">
+      <ul class="brief">
 
-      <li>"<dfn><code>shipping</code></dfn>", meaning the field
-      is part of the shipping address or contact information
+        <li>"<dfn><code>shipping</code></dfn>", meaning the field
+        is part of the shipping address or contact information</li>
 
-      </li><li>"<dfn><code>billing</code></dfn>", meaning the field
-      is part of the billing address or contact information
+        <li>"<dfn><code>billing</code></dfn>", meaning the field
+        is part of the billing address or contact information</li>
 
-    </li></ul>
+      </ul>
 
     </li>
 

--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -3066,7 +3066,8 @@
         <dt>[=Allowed ARIA role attribute values=]:</dt>
         <dd>
           <a attr-value for="aria/role"><code>textbox</code></a>,
-          <a attr-value for="aria/role"><code>searchbox</code></a> with no <{input/list}> attribute
+          <a attr-value for="aria/role"><code>searchbox</code></a>,
+          <a attr-value for="aria/role"><code>spinbutton</code></a> with no <{input/list}> attribute
           (default - <a><em>do not set</em></a>) or with a <{input/list}> attribute:
           <a attr-value for="aria/role"><code>combobox</code></a> (default - <a><em>do not set</em></a>).
         </dd>

--- a/sections/semantics-grouping-content.include
+++ b/sections/semantics-grouping-content.include
@@ -1186,7 +1186,10 @@
   <dl class="element">
     <dt><a>Categories</a>:</dt>
     <dd><a>Flow content</a>.</dd>
-    <dd>If the element's children include at least one name-value group: <a>Palpable content</a>.</dd>
+    <dd>
+      If the element's children include at least one name-value group:
+      <a>Palpable content</a>.
+    </dd>
     <dt><a>Contexts in which this element can be used</a>:</dt>
     <dd>Where <a>flow content</a> is expected.</dd>
     <dt><a>Content model</a>:</dt>
@@ -1195,7 +1198,7 @@
       more <{dd}> elements, optionally intermixed with <a>script-supporting elements</a>.
     </dd>
     <dd>
-     Or: One or more <{div}> elements, optionally intermixed with script-supporting elements.
+      Or: One or more <{div}> elements, optionally intermixed with script-supporting elements.
     </dd>
     <dt><a>Tag omission in text/html</a>:</dt>
     <dd>Neither tag is omissible</dd>
@@ -1203,14 +1206,17 @@
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>list</code></a> role (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>list</code></a>,
       <a attr-value for="aria/role"><code>group</code></a>,
       <a attr-value for="aria/role"><code>none</code></a>
       or
       <a attr-value for="aria/role"><code>presentation</code></a>.</dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>
-    <dd>Any <code>aria-*</code> attributes <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.</dd>
+    <dd>
+      Any <code>aria-*</code> attributes
+      <a href="#allowed-aria-roles-states-and-properties">applicable to the default or allowed roles</a>.
+    </dd>
     <dt><a>DOM interface</a>:</dt>
     <dd>
       <pre class="idl" data-highlight="webidl">
@@ -1368,7 +1374,8 @@
     <dd><a>Global attributes</a></dd>
     <dt>[=Allowed ARIA role attribute values=]:</dt>
     <dd>
-      <a attr-value for="aria/role"><code>listitem</code></a> role (default - <a><em>do not set</em></a>)
+      <a attr-value for="aria/role"><code>term</code></a> role (default - <a><em>do not set</em></a>),
+      <a attr-value for="aria/role"><code>listitem</code></a>
     </dd>
     <dt>[=Allowed ARIA state and property attributes=]:</dt>
     <dd><a>Global aria-* attributes</a></dd>


### PR DESCRIPTION
Closes #1501

Updates allowed roles for `dl`, `dt`, and `input` with `type=text`