### PR TITLE
Editorial: fix typo in HTML syntax section

### DIFF
--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -2202,7 +2202,7 @@
     :: [=Reconsume=] in the [=script data state=].
   </dl>
 
-#### <dfn id="tokenizer-script-data-escapse-start-dash-state">Script data escape start dash state</dfn> #### {#script-data-escape-start-dash-state}
+#### <dfn id="tokenizer-script-data-escape-start-dash-state">Script data escape start dash state</dfn> #### {#script-data-escape-start-dash-state}
 
   Consume the [=next input character=]:
 


### PR DESCRIPTION
* fix typo on dfn id where we have "escapse" instead of "escape"