### PR TITLE
Correction to define missing 'parsed action' value

### DIFF
--- a/sections/semantics-forms.include
+++ b/sections/semantics-forms.include
@@ -13141,7 +13141,7 @@ fur
     <li><a>Parse</a> the [=url/URL=] <var>action</var>, relative to the <var>submitter</var> element's <a>node document</a>. If this fails,
     abort these steps.</li>
 
-    <li>Let <var>action</var> be the <a>resulting URL string</a>.</li>
+    <li>Let <var>parsed action</var> be the <a>resulting URL string</a>.</li>
 
     <li>Let <var>action components</var> be the <a>resulting URL record</a>.</li>
 


### PR DESCRIPTION
Without this patch:
* 'parsed action' is referenced below, but not defined
* 'action' has already been defined above, differently.

Looks like a copy-paste error/typo.
