### PR TITLE
Example typo correction

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -59,7 +59,7 @@
   <a href="https://github.com/chaals">Chaals McCathie Nevile</a>,
   Chris Harvey,
   Chris Rebert,
-  cinephile85, <!-- https://github.com/cinephile85 -->
+  "cinephile85", <!-- https://github.com/cinephile85 -->
   Collin Anderson,
   Dan Beam,
   Daniel Buchner,
@@ -107,6 +107,7 @@
   Léonie Watson, <!-- https://github.com/ljwatson -->
   Lea Verou, <!-- https://github.com/LeaVerou -->
   Maciej Stachowiak,
+  "maffe", <!-- https://github.com/maffe -->
   Mallory van Achterberg,
   Marco Zehe,
   Mark Svancarek,

--- a/sections/syntax.include
+++ b/sections/syntax.include
@@ -3484,11 +3484,11 @@
         <div class="example">
           If the markup contains (not in an attribute) the string `I'm &notit; I tell you`, the
           character reference is parsed as "not", as in, `I'm ¬it; I tell you` (and this is a parse
-          error). But if the markup was `I'm &amp;notin; I tell you`, the character reference would
+          error). But if the markup was `I'm &notin; I tell you`, the character reference would
           be parsed as "notin;", resulting in `I'm ∉ I tell you` (and no parse error).
 
           However, if the markup contains the string `I'm &amp;notit; I tell you` in an attribute,
-          no character reference is parsed and string remains intact (and there is no parse error).
+          there is no parse error and the string `I'm &notit; I tell you` is the result of parsing.
         </div>
   </dl>
 


### PR DESCRIPTION
Fix #897

Markdown does odd things with "&"