### PR TITLE
fix inconsistently-quoted href attribute

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -81,6 +81,7 @@
   Fabian Pijcke,
   Fantasai,
   "freshp86", <!-- https://github.com/freshp86 -->
+  <a href="https://github.com/geppy">geppy</a>,
   Hajime Morrita,
   Hayato Ito,
   Heydon Pickering, <!-- https://github.com/Heydon -->

--- a/sections/semantics-sections.include
+++ b/sections/semantics-sections.include
@@ -1536,7 +1536,7 @@
     There are currently no known native implementations of the outline algorithm in graphical
     browsers or assistive technology user agents, although the algorithm is implemented in other
     software such as conformance checkers and browser extensions. Additionally, there is an
-    <a href="https://github.com/whatwg/html/pull/3499'>alternate outline algorithm proposal</a>
+    <a href="https://github.com/whatwg/html/pull/3499">alternate outline algorithm proposal</a>
     being developed, as well as proposals to modify the existing algorithm
     (See <a href="https://github.com/w3c/html/pull/1005">W3C HTML issue #1005</a> and
     <a href="https://github.com/w3c/html/issues/830">W3C HTML issue #830</a>).


### PR DESCRIPTION
Corrects the markup typo in #1668, so the references make sense (and have working links).