### PR TITLE
aria-dialog to aria-modal

### DIFF
--- a/sections/acknowledgements.include
+++ b/sections/acknowledgements.include
@@ -156,6 +156,7 @@
   Stephen Checkoway, <!-- https://github.com/stevecheckoway -->
   Stephen Cunnliffe,
   Steven Faulkner, <!-- https://github.com/stevefaulkner -->
+  Steve Benoit, <!-- https://github.com/srbenoit -->
   Steve Orvell,
   Steven Skelton,
   Tab Atkins,

--- a/sections/dom.include
+++ b/sections/dom.include
@@ -3774,7 +3774,7 @@ class DontDoThis extends HTMLElement {
         <td>
           <ul class="brief">
             * <{aria/aria-expanded}> (state)
-            * <{aria/aria-dialog}>
+            * <{aria/aria-modal}>
           </ul>
         </td>
       </tr>
@@ -3938,7 +3938,7 @@ class DontDoThis extends HTMLElement {
         <td>
           <ul class="brief">
             * <{aria/aria-expanded}> (state)
-            * <{aria/aria-dialog}>
+            * <{aria/aria-modal}>
           </ul>
          </td>
       </tr>

--- a/sections/infrastructure.include
+++ b/sections/infrastructure.include
@@ -1362,7 +1362,7 @@
         <li><{aria/aria-current}>
         <li><{aria/aria-describedby}>
         <li><{aria/aria-details}>
-        <li><{aria/aria-dialog}>
+        <li><{aria/aria-modal}>
         <li><{aria/aria-disabled}>
         <li><{aria/aria-dropeffect}>
         <li><{aria/aria-errormessage}>


### PR DESCRIPTION
`aria-dialog` references changed to `aria-modal`
closes #1673