### PR TITLE
Typo fix in The object element for the name attribute

### DIFF
--- a/sections/semantics-embedded-content.include
+++ b/sections/semantics-embedded-content.include
@@ -4972,7 +4972,7 @@ attribute's value is a type that a <a>plugin</a> supports, then the value of the
 
     <p class="warning">
       If a <a>nested browsing context</a> is not created, e.g. for security reasons or due to
-      incorrect implementation of the <{object/name3}> attribute, the <code>target</code> attribute
+      incorrect implementation of the <{object/name}> attribute, the <code>target</code> attribute
       in this example will instead <a>create a new browsing context</a> - typically a new tab -
       whose <a>browsing context name</a> is the attribute's value, and the resource that the link
       references will be loaded there.


### PR DESCRIPTION
In the warning paragraph of The object element, fix a typo : "name" attribute is more appropriate than "name3"